### PR TITLE
release: adopt official A2A SDK and enable release-plz publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.85.0
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.85.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      PYO3_PYTHON: python
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -22,6 +25,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.85.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -34,15 +39,20 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Run release-plz
+      - name: Require crates.io publish token
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN is not configured. Set the repository secret to allow release-plz to publish crates."
+            exit 1
+          fi
+
+      - name: Run release-plz publish
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release
           manifest_path: ./Cargo.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          PYO3_PYTHON: python
 
   release-crates-pr:
     name: Release crates - PR
@@ -53,6 +63,8 @@ jobs:
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
+    env:
+      PYO3_PYTHON: python
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -62,6 +74,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.85.0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -81,5 +95,3 @@ jobs:
           manifest_path: ./Cargo.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          PYO3_PYTHON: python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,18 @@ usually a good idea to first open an issue describing the change to solicit
 feedback and guidance. This will increase the likelihood of the PR getting
 merged.
 
+## Releasing crates
+
+Rust crate releases are driven by `.github/workflows/release-rust.yml` using
+`release-plz`.
+
+- Public workspace crates are published to crates.io from the `main` branch
+   release job.
+- The release job requires the repository secret `CARGO_REGISTRY_TOKEN` and
+   fails early if the token is missing.
+- Non-publishable workspace members such as `shadi_demo_bot` are excluded from
+   release-plz so they do not generate release tags or publish attempts.
+
 ## Developer's Certificate of Origin
 
 To improve tracking of who did what, we have introduced a "sign-off" procedure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,104 @@
 version = 4
 
 [[package]]
+name = "a2a-client-lf"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5ff1acdf4bce66aa7438fdb448bccb9411c0f03fae450fd37f6c5e5a6f10d6"
+dependencies = [
+ "a2a-lf",
+ "a2a-pb",
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "futures",
+ "pin-project-lite",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "a2a-lf"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db828ec4710d8e4f3a5dc116eb373ccdf2fb7d002aae261f872518be19e1b8d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "a2a-pb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e2ca08997e49a61c00ce79d126abc6333cabc9945dae1379db710a516dc285"
+dependencies = [
+ "a2a-lf",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "pbjson-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "protoc-bin-vendored",
+ "serde",
+ "serde_json",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+]
+
+[[package]]
+name = "a2a-server-lf"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044b465c1f5c1b5fc19dc4878785f23e177eab4e169b66e72eacfd90417885d5"
+dependencies = [
+ "a2a-lf",
+ "a2a-pb",
+ "async-trait",
+ "axum 0.8.8",
+ "chrono",
+ "futures",
+ "hyper",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "a2a-slimrpc"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99713a7e2038a629fbf8431c89a0e9ee96d902c93aeb02bbdbf0c89c71a4ef6"
+dependencies = [
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-pb",
+ "a2a-server-lf",
+ "agntcy-slim-bindings",
+ "async-trait",
+ "futures",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,110 +143,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be0b586d63f3f6ca6c19f6d45c174413371bab9a68a25bf8167938791779f0e"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "agntcy-a2a-client"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6616e8c3823cc2fbfda39d06e9b096cdc946a31ab24afcab6f44032313fb2018"
-dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-pb",
- "async-trait",
- "bytes",
- "futures",
- "pin-project-lite",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "agntcy-a2a-pb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3daf98c4dbed9b204903dc4567133462e849f3469b907744d0a7780cbc8bd"
-dependencies = [
- "agntcy-a2a",
- "chrono",
- "pbjson",
- "pbjson-build",
- "pbjson-types",
- "prost 0.13.5",
- "prost-types 0.13.5",
- "protoc-bin-vendored",
- "serde",
- "serde_json",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
-]
-
-[[package]]
-name = "agntcy-a2a-server"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c72b12f7bf74f610b872d7dfbf8ab2ec922338bcb2730556428a57adc73ef78"
-dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-pb",
- "async-trait",
- "axum 0.8.8",
- "chrono",
- "futures",
- "hyper",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.3",
- "tower-http",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "agntcy-a2a-slimrpc"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279e7a8ea491be9f3ad607bf198f722aaf09b8f74f9731ef57dd9f4f28c48bd9"
-dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-pb",
- "agntcy-a2a-server",
- "agntcy-slim-bindings",
- "async-trait",
- "futures",
- "prost 0.13.5",
- "prost-types 0.13.5",
-]
-
-[[package]]
 name = "agntcy-shadi-a2a"
 version = "0.1.0"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-server",
- "agntcy-a2a-slimrpc",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-server-lf",
+ "a2a-slimrpc",
  "agntcy-shadi-agent-secrets",
  "agntcy-slim-bindings",
  "async-trait",
@@ -180,9 +181,9 @@ dependencies = [
 name = "agntcy-shadi-cli"
 version = "0.1.0"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-server-lf",
  "agntcy-shadi-a2a",
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-agent-transport-slim",
@@ -836,6 +837,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -5188,9 +5200,9 @@ dependencies = [
 name = "shadi_demo_bot"
 version = "0.1.0"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-server-lf",
  "agntcy-shadi-a2a",
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-agent-transport-slim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ resolver = "2"
 [workspace.package]
 license = "Apache-2.0"
 repository = "https://github.com/agntcy/shadi"
+rust-version = "1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ resolver = "2"
 [workspace.package]
 license = "Apache-2.0"
 repository = "https://github.com/agntcy/shadi"
-rust-version = "1.85"
+rust-version = "1.88"

--- a/crates/shadi_a2a/CHANGELOG.md
+++ b/crates/shadi_a2a/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- migrate the SHADI A2A wrapper to the official `a2aproject/a2a-rs` SDK
+
 ## [0.1.0] - 2026-04-07
 
 ### Added

--- a/crates/shadi_a2a/Cargo.toml
+++ b/crates/shadi_a2a/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-shadi-a2a"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.85"
 description = "A2A channel support for SHADI over SLIMRPC."
 license.workspace = true
 repository.workspace = true
@@ -11,10 +12,10 @@ name = "shadi_a2a"
 
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.0", path = "../agent_secrets" }
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-client = { package = "agntcy-a2a-client", version = "0.1" }
-a2a-server = { package = "agntcy-a2a-server", version = "0.2" }
-a2a-slimrpc = { package = "agntcy-a2a-slimrpc", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2.4" }
+a2a-client = { package = "a2a-client-lf", version = "0.1.13" }
+a2a-server = { package = "a2a-server-lf", version = "0.2.6" }
+a2a-slimrpc = { package = "a2a-slimrpc", version = "0.1.8" }
 async-trait = "0.1"
 futures = "0.3"
 slim_bindings = { package = "agntcy-slim-bindings", version = "1.3.0" }

--- a/crates/shadi_a2a/Cargo.toml
+++ b/crates/shadi_a2a/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-shadi-a2a"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "A2A channel support for SHADI over SLIMRPC."
 license.workspace = true
 repository.workspace = true

--- a/crates/shadictl/CHANGELOG.md
+++ b/crates/shadictl/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- switch `shadictl` A2A commands to the official `a2aproject/a2a-rs` SDK through `shadi_a2a`
+
 ## [0.1.0](https://github.com/agntcy/shadi/releases/tag/agntcy-shadi-cli-v0.1.0) - 2026-04-07
 
 ### Added

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-shadi-cli"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.85"
 description = "Command-line interface for SHADI policy, secrets, memory, and SLIM operations."
 license.workspace = true
 repository.workspace = true
@@ -12,9 +13,9 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
-a2a = { package = "agntcy-a2a", version = "0.2.4" }
-a2a-client = { package = "agntcy-a2a-client", version = "0.1.13" }
-a2a-server = { package = "agntcy-a2a-server", version = "0.2.6" }
+a2a = { package = "a2a-lf", version = "0.2.4" }
+a2a-client = { package = "a2a-client-lf", version = "0.1.13" }
+a2a-server = { package = "a2a-server-lf", version = "0.2.6" }
 async-trait = "0.1"
 futures = "0.3"
 shadi_sandbox = { package = "agntcy-shadi-sandbox", version = "0.1.0", path = "../shadi_sandbox" }

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agntcy-shadi-cli"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Command-line interface for SHADI policy, secrets, memory, and SLIM operations."
 license.workspace = true
 repository.workspace = true

--- a/crates/shadictl/tests/shell_integration.rs
+++ b/crates/shadictl/tests/shell_integration.rs
@@ -103,6 +103,9 @@ fn mock_accept_loop(listener: &UnixListener, state: &Arc<Mutex<MockState>>, sock
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .expect("set blocking mock stream");
                 // Spawn a thread per connection so the listener is never
                 // blocked while handling a client; this prevents the race
                 // where a short-lived probe connect holds the accept loop

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -530,6 +530,10 @@ cargo run -p agntcy-shadi-cli -- memory delete \
 
 `shadictl slim` exposes native SLIM helpers and an A2A-over-SLIMRPC demo surface.
 
+The A2A commands are backed by `shadi_a2a`, which wraps the official
+`a2aproject/a2a-rs` SDK and keeps SHADI's outbound verifier gate in front of
+the transport.
+
 The A2A commands reuse the same SLIM mTLS assets as the rest of the native SLIM path:
 
 - Client certs from `SLIM_TLS_CERT` and `SLIM_TLS_KEY`, or the default `.tmp/shadi-slim-mtls/client[-$SHADI_AGENT_ID].crt|key` lookup.

--- a/docs/slim_a2a.md
+++ b/docs/slim_a2a.md
@@ -3,6 +3,10 @@
 This crate is designed to hook into the slima2a distribution and SLIM's MLS
 stack without re-implementing MLS.
 
+SHADI's current A2A wrapper is built on the official Rust SDK from
+`a2aproject/a2a-rs`, using its core protocol, client, server, and SLIMRPC
+bindings while preserving SHADI's verifier-gated secret and identity checks.
+
 ## Intended flow
 1. SLIM session setup verifies agent identity (DID/VC).
 2. Secrets are accessed only after verification succeeds.

--- a/examples/shadi_demo_bot/Cargo.toml
+++ b/examples/shadi_demo_bot/Cargo.toml
@@ -2,12 +2,13 @@
 name = "shadi_demo_bot"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.85"
 publish = false
 
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-client = { package = "agntcy-a2a-client", version = "0.1" }
-a2a-server = { package = "agntcy-a2a-server", version = "0.2" }
+a2a = { package = "a2a-lf", version = "0.2.4" }
+a2a-client = { package = "a2a-client-lf", version = "0.1.13" }
+a2a-server = { package = "a2a-server-lf", version = "0.2.6" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", path = "../../crates/agent_secrets" }
 agent_transport_slim = { package = "agntcy-shadi-agent-transport-slim", path = "../../crates/agent_transport_slim" }
 async-trait = "0.1"

--- a/examples/shadi_demo_bot/Cargo.toml
+++ b/examples/shadi_demo_bot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shadi_demo_bot"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 publish = false
 
 [dependencies]

--- a/examples/shadi_demo_bot/README.md
+++ b/examples/shadi_demo_bot/README.md
@@ -9,7 +9,7 @@ It has three roles behind one binary:
 - `shell-ticker`: tiny long-running ticker for the shell walkthrough
 - `slim-echo-peer`: helper used by the feature bot for the local SLIM echo flow
 - `a2a-echo-peer`: helper that exposes a task-backed A2A handler over SLIMRPC
-- `a2a-send`: client that uses `shadi_a2a::A2AChannel` to send unary or streaming A2A requests
+- `a2a-send`: client that uses `shadi_a2a::A2AChannel` and the official `a2aproject/a2a-rs` SDK to send unary or streaming A2A requests
 
 ## Build
 
@@ -76,7 +76,8 @@ The peer exposes a `SlimRpcHandler` backed by the A2A server task model, so the
 unary path returns a completed task and the streaming path emits a working
 status followed by a completed task. The client side uses
 `shadi_a2a::A2AChannelBuilder`, which gates the outbound A2A call through
-SHADI's `AgentVerifier` before it sends protocol traffic.
+SHADI's `AgentVerifier` before it sends protocol traffic through the official
+Rust A2A transport bindings.
 
 ## Use The Rust Shell Ticker
 

--- a/examples/shadi_demo_bot/src/lib.rs
+++ b/examples/shadi_demo_bot/src/lib.rs
@@ -1271,14 +1271,7 @@ fn run_shell_ticker(args: ShellTickerArgs) -> Result<(), String> {
     let shutdown = Arc::new(AtomicBool::new(false));
     install_shutdown_handlers(&shutdown)?;
 
-    if let Some(path) = &args.ready_file {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|err| format!("failed to create ready file parent: {}", err))?;
-        }
-        fs::write(path, b"ready")
-            .map_err(|err| format!("failed to write ready file: {}", err))?;
-    }
+    maybe_write_ready_file(args.ready_file.as_deref())?;
 
     println!("[demo-agent] starting - press Ctrl-C to stop");
     println!("[demo-agent] pid={}", std::process::id());
@@ -1814,6 +1807,19 @@ where
     Ok(output)
 }
 
+fn maybe_write_ready_file(path: Option<&Path>) -> Result<(), String> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create ready file parent: {}", err))?;
+    }
+
+    fs::write(path, b"ready").map_err(|err| format!("failed to write ready file: {}", err))
+}
+
 #[cfg(unix)]
 fn install_shutdown_handlers(shutdown: &Arc<AtomicBool>) -> Result<(), String> {
     use signal_hook::consts::signal::{SIGINT, SIGTERM};
@@ -2140,6 +2146,27 @@ mod tests {
             fs::write(tls_dir.join(relative), b"fixture").expect("write tls fixture");
         }
         tls_dir
+    }
+
+    #[test]
+    fn maybe_write_ready_file_accepts_none() {
+        assert!(maybe_write_ready_file(None).is_ok());
+    }
+
+    #[test]
+    fn maybe_write_ready_file_writes_nested_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ready_file = dir.path().join("nested").join("shell-ticker.ready");
+
+        maybe_write_ready_file(Some(ready_file.as_path())).expect("write ready file");
+
+        assert_eq!(fs::read(&ready_file).expect("read ready file"), b"ready");
+    }
+
+    #[test]
+    fn maybe_write_ready_file_reports_write_error_without_parent() {
+        let err = maybe_write_ready_file(Some(Path::new(""))).expect_err("empty path should fail");
+        assert!(err.contains("failed to write ready file"), "{err}");
     }
 
     #[test]

--- a/examples/shadi_demo_bot/src/lib.rs
+++ b/examples/shadi_demo_bot/src/lib.rs
@@ -113,6 +113,9 @@ impl Default for FeatureBotArgs {
 struct ShellTickerArgs {
     #[arg(long, env = "DEMO_TICK", default_value_t = DEFAULT_TICK_SECONDS)]
     tick_seconds: u64,
+
+    #[arg(long, hide = true)]
+    ready_file: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -1267,6 +1270,15 @@ fn run_a2a_exchange(
 fn run_shell_ticker(args: ShellTickerArgs) -> Result<(), String> {
     let shutdown = Arc::new(AtomicBool::new(false));
     install_shutdown_handlers(&shutdown)?;
+
+    if let Some(path) = &args.ready_file {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|err| format!("failed to create ready file parent: {}", err))?;
+        }
+        fs::write(path, b"ready")
+            .map_err(|err| format!("failed to write ready file: {}", err))?;
+    }
 
     println!("[demo-agent] starting - press Ctrl-C to stop");
     println!("[demo-agent] pid={}", std::process::id());

--- a/examples/shadi_demo_bot/tests/cli_integration.rs
+++ b/examples/shadi_demo_bot/tests/cli_integration.rs
@@ -43,6 +43,17 @@ fn wait_for_file(path: &std::path::Path, timeout: Duration) {
     panic!("timed out waiting for {}", path.display());
 }
 
+#[cfg(unix)]
+#[test]
+fn wait_for_file_panics_on_timeout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("missing.ready");
+
+    let result = std::panic::catch_unwind(|| wait_for_file(&missing, Duration::from_millis(0)));
+
+    assert!(result.is_err(), "expected timeout panic");
+}
+
 fn assert_success(output: &Output) {
     assert!(
         output.status.success(),

--- a/examples/shadi_demo_bot/tests/cli_integration.rs
+++ b/examples/shadi_demo_bot/tests/cli_integration.rs
@@ -30,6 +30,19 @@ fn stderr_text(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+#[cfg(unix)]
+fn wait_for_file(path: &std::path::Path, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!("timed out waiting for {}", path.display());
+}
+
 fn assert_success(output: &Output) {
     assert!(
         output.status.success(),
@@ -156,16 +169,21 @@ fn feature_bot_surfaces_memory_path_errors() {
 #[cfg(unix)]
 #[test]
 fn shell_ticker_handles_sigterm() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let ready_file = temp_dir.path().join("shell-ticker.ready");
+
     let child = Command::new(demo_bot_binary())
         .arg("shell-ticker")
         .arg("--tick-seconds")
         .arg("1")
+        .arg("--ready-file")
+        .arg(&ready_file)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn shell ticker");
 
-    thread::sleep(Duration::from_millis(750));
+    wait_for_file(&ready_file, Duration::from_secs(5));
 
     let status = Command::new("kill")
         .arg("-TERM")

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,9 @@
 [workspace]
 release_always = false
+publish = true
 publish_no_verify = true
+publish_timeout = "30m"
+
+[[package]]
+name = "shadi_demo_bot"
+release = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"


### PR DESCRIPTION
## Summary
Switch SHADI's A2A integration to the official `a2aproject/a2a-rs` crates and wire the workspace release flow so `release-plz` can publish public crates with `CARGO_REGISTRY_TOKEN`.

## What changed
- migrate `shadi_a2a`, `shadictl`, and the demo bot manifests from the legacy `agntcy-a2a*` crates to the official `a2a-lf`, `a2a-client-lf`, `a2a-server-lf`, and `a2a-slimrpc` crates
- pin the workspace and Rust workflows to Rust `1.88.0`, which matches the resolved dependency MSRV
- document the official SDK-backed SLIM/A2A path in the relevant docs and changelogs
- make `release-plz` explicitly publish public workspace crates
- require `CARGO_REGISTRY_TOKEN` in the publish job and exclude `shadi_demo_bot` from release processing
- make the demo shell ticker integration test wait for explicit readiness before sending `SIGTERM`

## Verification
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo test -p agntcy-shadi-a2a`
- `cargo test -p agntcy-shadi-cli --test slim_cli_integration`
- `cargo test -p shadi_demo_bot --test cli_integration`
- `just coverage`

Refs: #66
