### PR TITLE
packaging: add Homebrew shadictl distribution

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -1,0 +1,95 @@
+name: Refresh Homebrew Formula
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: CLI release tag to render into Formula/shadictl.rb
+        required: true
+        type: string
+
+jobs:
+  refresh-homebrew-formula:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'agntcy-shadi-cli-v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release tag
+        id: release
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+
+          case "$tag" in
+            agntcy-shadi-cli-v*)
+              version="${tag#agntcy-shadi-cli-v}"
+              ;;
+            *)
+              echo "::error::expected an agntcy-shadi-cli-v* tag, got $tag"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Render Homebrew formula
+        run: python3 scripts/render_homebrew_formula.py --tag "${{ steps.release.outputs.tag }}" --output Formula/shadictl.rb
+
+      - name: Open formula refresh PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- Formula/shadictl.rb; then
+            echo "Formula already up to date for ${{ steps.release.outputs.tag }}"
+            exit 0
+          fi
+
+          branch="automation/homebrew-shadictl-${{ steps.release.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Formula/shadictl.rb
+          git commit -m "release: update Homebrew formula for shadictl v${{ steps.release.outputs.version }}"
+          git push --force --set-upstream origin "$branch"
+
+          pr_number=$(gh pr list --repo agntcy/shadi --head "$branch" --base main --state open --json number --jq 'first(.[].number) // ""')
+          if [ -n "$pr_number" ]; then
+            echo "Updated existing PR #$pr_number"
+            exit 0
+          fi
+
+          cat > /tmp/homebrew-formula-pr-body.md <<EOF
+          Update Formula/shadictl.rb for ${{ steps.release.outputs.tag }}.
+
+          - refreshes the source tarball SHA256
+          - keeps the Homebrew install path aligned with the latest CLI release
+
+          Refs #68
+          EOF
+
+          gh pr create \
+            --repo agntcy/shadi \
+            --base main \
+            --head "$branch" \
+            --title "release: update Homebrew formula for shadictl v${{ steps.release.outputs.version }}" \
+            --body-file /tmp/homebrew-formula-pr-body.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,9 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    fails early if the token is missing.
 - Non-publishable workspace members such as `shadi_demo_bot` are excluded from
    release-plz so they do not generate release tags or publish attempts.
+- `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that
+   refreshes `Formula/shadictl.rb` when an `agntcy-shadi-cli-v*` release is
+   published.
 
 ## Developer's Certificate of Origin
 

--- a/Formula/shadictl.rb
+++ b/Formula/shadictl.rb
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 class Shadictl < Formula
   desc "Command-line interface for SHADI policy, secrets, memory, and SLIM operations."
   homepage "https://github.com/agntcy/shadi"

--- a/Formula/shadictl.rb
+++ b/Formula/shadictl.rb
@@ -1,0 +1,25 @@
+class Shadictl < Formula
+  desc "Command-line interface for SHADI policy, secrets, memory, and SLIM operations."
+  homepage "https://github.com/agntcy/shadi"
+  url "https://github.com/agntcy/shadi/archive/refs/tags/agntcy-shadi-cli-v0.1.0.tar.gz"
+  sha256 "b11b9409d453c15c0669b2bf542e4bf73321ec0d4607749fbff6bcc508a707e3"
+  license "Apache-2.0"
+  head "https://github.com/agntcy/shadi.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "nettle"
+  depends_on "openssl@3"
+  depends_on "python@3.12"
+
+  def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["PYO3_PYTHON"] = Formula["python@3.12"].opt_bin/"python3.12"
+
+    system "cargo", "install", "--locked", "--path", "crates/shadictl", *std_cargo_args
+  end
+
+  test do
+    assert_match "shadictl", shell_output("#{bin}/shadictl --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ SHADI is for teams that want agents to work with real tools and real credentials
 - [`agent_transport_slim`](docs/architecture.md#4-transport-layer): secure transport and stdio bridge support.
 - [`examples/shadi_demo_bot`](examples/shadi_demo_bot/README.md): a Rust demo bot that exercises the main SHADI features, including SLIM messaging.
 
+## Install the CLI
+
+On macOS, you can install the latest released `shadictl` formula with Homebrew:
+
+```bash
+brew tap agntcy/shadi https://github.com/agntcy/shadi
+brew install agntcy/shadi/shadictl
+```
+
+The Homebrew formula builds from the published `agntcy-shadi-cli` release tag.
+For unreleased changes or non-macOS hosts, use the source build flow below.
+
 ## Quick Start
 
 ```bash

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,6 +15,16 @@ By the end of this guide, you will have:
 
 ## Before You Begin
 
+If you only need the released CLI on macOS, install it with Homebrew:
+
+```bash
+brew tap agntcy/shadi https://github.com/agntcy/shadi
+brew install agntcy/shadi/shadictl
+```
+
+Use the source-build path below if you are developing SHADI or need unreleased
+changes from the workspace.
+
 Install the local tooling SHADI expects:
 
 - Rust stable with Cargo

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import re
+import textwrap
+import tomllib
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
+CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
+DEFAULT_OUTPUT = ROOT / "Formula" / "shadictl.rb"
+TAG_PATTERN = re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render the Homebrew formula for the released shadictl CLI tag."
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag in the form agntcy-shadi-cli-v<version>",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Formula output path (default: {DEFAULT_OUTPUT})",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def resolve_workspace_value(package: dict, workspace_package: dict, key: str) -> str:
+    value = package.get(key)
+    if isinstance(value, dict) and value.get("workspace"):
+        return workspace_package[key]
+    if value is None:
+        return workspace_package[key]
+    return value
+
+
+def fetch_sha256(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "GitHub-Copilot"})
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(request, timeout=60) as response:
+        while True:
+            chunk = response.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ruby_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def render_formula(tag: str) -> str:
+    match = TAG_PATTERN.match(tag)
+    if not match:
+        raise SystemExit(f"expected agntcy-shadi-cli-v<version> tag, got: {tag}")
+
+    workspace = load_toml(WORKSPACE_MANIFEST)
+    cli_manifest = load_toml(CLI_MANIFEST)
+    workspace_package = workspace["workspace"]["package"]
+    package = cli_manifest["package"]
+
+    description = package["description"]
+    homepage = resolve_workspace_value(package, workspace_package, "repository")
+    license_id = resolve_workspace_value(package, workspace_package, "license")
+    source_url = f"{homepage}/archive/refs/tags/{tag}.tar.gz"
+    source_sha256 = fetch_sha256(source_url)
+    git_url = homepage if homepage.endswith(".git") else f"{homepage}.git"
+
+    return textwrap.dedent(
+        f"""\
+        class Shadictl < Formula
+          desc \"{ruby_string(description)}\"
+          homepage \"{ruby_string(homepage)}\"
+          url \"{ruby_string(source_url)}\"
+          sha256 \"{source_sha256}\"
+          license \"{ruby_string(license_id)}\"
+          head \"{ruby_string(git_url)}\", branch: \"main\"
+
+          depends_on \"pkgconf\" => :build
+          depends_on \"rust\" => :build
+          depends_on \"nettle\"
+          depends_on \"openssl@3\"
+          depends_on \"python@3.12\"
+
+          def install
+            ENV[\"OPENSSL_DIR\"] = Formula[\"openssl@3\"].opt_prefix
+            ENV[\"PYO3_PYTHON\"] = Formula[\"python@3.12\"].opt_bin/\"python3.12\"
+
+            system \"cargo\", \"install\", \"--locked\", \"--path\", \"crates/shadictl\", *std_cargo_args
+          end
+
+          test do
+            assert_match \"shadictl\", shell_output("#{{bin}}/shadictl --help")
+          end
+        end
+        """
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    formula = render_formula(args.tag)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(formula, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 


### PR DESCRIPTION
Add a Homebrew distribution path for the released `shadictl` CLI.

- add `Formula/shadictl.rb` for the current `agntcy-shadi-cli` release stream
- add `scripts/render_homebrew_formula.py` to regenerate the formula and checksum from a CLI tag
- add a workflow that opens or updates a formula refresh PR when a CLI release is published
- document the explicit `brew tap agntcy/shadi https://github.com/agntcy/shadi` install flow
- preserve the repository's copyright/SPDX header convention in the new code files

Refs #68
Stacked on #67
