### PR TITLE
release: skip demo bot publish in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,4 +6,5 @@ publish_timeout = "30m"
 
 [[package]]
 name = "shadi_demo_bot"
+publish = false
 release = false


### PR DESCRIPTION
Fix the failing crates publication workflow on main.

The merged release run at https://github.com/agntcy/shadi/actions/runs/24655419181 failed because `release-plz.toml` inherited `publish = true` from the workspace for `shadi_demo_bot`, while `examples/shadi_demo_bot/Cargo.toml` correctly declares `publish = false`.

This change makes the package override explicit in `release-plz.toml`:

- keep `shadi_demo_bot` out of release creation
- keep `shadi_demo_bot` out of cargo publication
- align release-plz with the package manifest so `release-plz release` no longer aborts before publish
