### PR TITLE
build: add multi-architecture shadictl release artifacts

### DIFF
--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -83,43 +83,12 @@ jobs:
       - name: Resolve release metadata
         id: metadata
         shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
-          TARGET_TRIPLE: ${{ matrix.target }}
         run: |
-          python - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
-
-          manifest_path = Path("crates/shadictl/Cargo.toml")
-          with manifest_path.open("rb") as handle:
-              manifest = tomllib.load(handle)
-
-          version = manifest["package"]["version"]
-          release_tag = ""
-          if os.environ["EVENT_NAME"] == "release":
-              release_tag = os.environ["RELEASE_TAG"]
-              prefix = "agntcy-shadi-cli-v"
-              if not release_tag.startswith(prefix):
-                  raise SystemExit(f"expected {prefix}<version>, got {release_tag}")
-              tag_version = release_tag[len(prefix):]
-              if tag_version != version:
-                  raise SystemExit(
-                      f"release tag version {tag_version} does not match crates/shadictl/Cargo.toml version {version}"
-                  )
-              version = tag_version
-
-          output_path = Path(os.environ["GITHUB_OUTPUT"])
-          with output_path.open("a", encoding="utf-8") as handle:
-              handle.write(f"version={version}\n")
-              handle.write(f"release_tag={release_tag}\n")
-              handle.write(f"binary_path=target/{os.environ['TARGET_TRIPLE']}/release/shadictl")
-              if os.environ["TARGET_TRIPLE"].endswith("windows-msvc"):
-                  handle.write(".exe")
-              handle.write("\n")
-          PY
+          python scripts/resolve_shadictl_release_metadata.py \
+          --event-name "${{ github.event_name }}" \
+          --release-tag "${{ github.event.release.tag_name || '' }}" \
+          --target "${{ matrix.target }}" \
+          --github-output "$GITHUB_OUTPUT"
 
       - name: Build shadictl
         run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -1,0 +1,153 @@
+name: Build shadictl Release Artifacts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  build-shadictl-release-artifacts:
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'agntcy-shadi-cli-v') }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-2022
+            target: x86_64-pc-windows-msvc
+    name: ${{ matrix.name }}
+    env:
+      PYO3_PYTHON: python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.88.0
+          targets: ${{ matrix.target }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config nettle-dev libssl-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install python@3.12 nettle pkg-config
+
+      - name: Set Python for PyO3 (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo "PYO3_PYTHON=$(brew --prefix python@3.12)/bin/python3.12" >> "$GITHUB_ENV"
+
+      - name: Set OpenSSL env vars (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
+          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $opensslDir) {
+            choco install openssl -y --no-progress
+            $opensslDir = "C:\Program Files\OpenSSL-Win64"
+          }
+          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
+          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+          TARGET_TRIPLE: ${{ matrix.target }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          manifest_path = Path("crates/shadictl/Cargo.toml")
+          with manifest_path.open("rb") as handle:
+              manifest = tomllib.load(handle)
+
+          version = manifest["package"]["version"]
+          release_tag = ""
+          if os.environ["EVENT_NAME"] == "release":
+              release_tag = os.environ["RELEASE_TAG"]
+              prefix = "agntcy-shadi-cli-v"
+              if not release_tag.startswith(prefix):
+                  raise SystemExit(f"expected {prefix}<version>, got {release_tag}")
+              tag_version = release_tag[len(prefix):]
+              if tag_version != version:
+                  raise SystemExit(
+                      f"release tag version {tag_version} does not match crates/shadictl/Cargo.toml version {version}"
+                  )
+              version = tag_version
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"version={version}\n")
+              handle.write(f"release_tag={release_tag}\n")
+              handle.write(f"binary_path=target/{os.environ['TARGET_TRIPLE']}/release/shadictl")
+              if os.environ["TARGET_TRIPLE"].endswith("windows-msvc"):
+                  handle.write(".exe")
+              handle.write("\n")
+          PY
+
+      - name: Build shadictl
+        run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_shadictl_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ steps.metadata.outputs.release_tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -63,12 +63,7 @@ jobs:
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install python@3.12 nettle pkg-config
-
-      - name: Set Python for PyO3 (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: echo "PYO3_PYTHON=$(brew --prefix python@3.12)/bin/python3.12" >> "$GITHUB_ENV"
+        run: brew install nettle pkg-config
 
       - name: Set OpenSSL env vars (Windows)
         if: runner.os == 'Windows'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,13 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    fails early if the token is missing.
 - Non-publishable workspace members such as `shadi_demo_bot` are excluded from
    release-plz so they do not generate release tags or publish attempts.
+- `.github/workflows/shadictl-binaries.yml` builds and packages `shadictl` for
+   the primary release targets on every PR and `main` push: Linux
+   `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`, macOS
+   `aarch64-apple-darwin` and `x86_64-apple-darwin`, and Windows
+   `x86_64-pc-windows-msvc`.
+- The same workflow uploads `.tar.gz` or `.zip` archives plus `.sha256`
+   checksum files to each published `agntcy-shadi-cli-v*` GitHub release.
 - `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that
    refreshes `Formula/shadictl.rb` when an `agntcy-shadi-cli-v*` release is
    published.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ brew install agntcy/shadi/shadictl
 ```
 
 The Homebrew formula builds from the published `agntcy-shadi-cli` release tag.
-For unreleased changes or non-macOS hosts, use the source build flow below.
+Published `agntcy-shadi-cli` releases also include prebuilt archives for Linux
+(`x86_64` and `aarch64`), macOS (`arm64` and `x86_64`), and Windows (`x86_64`).
+For unreleased changes or any other host, use the source build flow below.
 
 ## Quick Start
 

--- a/scripts/package_shadictl_release.py
+++ b/scripts/package_shadictl_release.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import shutil
+import tarfile
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT_DIR = ROOT / "dist"
+DEFAULT_LICENSE = ROOT / "LICENSE.md"
+DEFAULT_README = ROOT / "README.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Package a built shadictl binary into a release archive."
+    )
+    parser.add_argument(
+        "--binary",
+        type=Path,
+        required=True,
+        help="Path to the built shadictl binary.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Rust target triple used to build the binary.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="CLI version used in the release archive name.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory for generated archives (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--license",
+        type=Path,
+        default=DEFAULT_LICENSE,
+        help=f"License file to include in the archive (default: {DEFAULT_LICENSE}).",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=DEFAULT_README,
+        help=f"README file to include in the archive (default: {DEFAULT_README}).",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file to append archive metadata to.",
+    )
+    return parser.parse_args()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def add_directory_to_zip(archive: Path, directory: Path) -> None:
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        for path in sorted(directory.rglob("*")):
+            if path.is_dir():
+                continue
+            handle.write(path, arcname=path.relative_to(directory.parent))
+
+
+def add_directory_to_targz(archive: Path, directory: Path) -> None:
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(directory, arcname=directory.name)
+
+
+def main() -> None:
+    args = parse_args()
+
+    binary = args.binary.resolve()
+    if not binary.is_file():
+        raise SystemExit(f"expected built binary at {binary}")
+
+    for support_path in (args.license, args.readme):
+        if not support_path.is_file():
+            raise SystemExit(f"expected support file at {support_path}")
+
+    archive_stem = f"shadictl-v{args.version}-{args.target}"
+    output_dir = args.output_dir.resolve()
+    staging_dir = output_dir / archive_stem
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir()
+
+    binary_name = "shadictl.exe" if args.target.endswith("windows-msvc") else "shadictl"
+    shutil.copy2(binary, staging_dir / binary_name)
+    shutil.copy2(args.license, staging_dir / args.license.name)
+    shutil.copy2(args.readme, staging_dir / args.readme.name)
+
+    if args.target.endswith("windows-msvc"):
+        archive_path = output_dir / f"{archive_stem}.zip"
+        add_directory_to_zip(archive_path, staging_dir)
+    else:
+        archive_path = output_dir / f"{archive_stem}.tar.gz"
+        add_directory_to_targz(archive_path, staging_dir)
+
+    checksum_path = output_dir / f"{archive_path.name}.sha256"
+    checksum_path.write_text(
+        f"{sha256(archive_path)}  {archive_path.name}\n",
+        encoding="utf-8",
+    )
+
+    shutil.rmtree(staging_dir)
+
+    outputs = {
+        "archive_stem": archive_stem,
+        "archive_path": str(archive_path),
+        "checksum_path": str(checksum_path),
+    }
+    if args.github_output is not None:
+        write_github_output(args.github_output, outputs)
+
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resolve_shadictl_release_metadata.py
+++ b/scripts/resolve_shadictl_release_metadata.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve shadictl release metadata for the GitHub Actions workflow."
+    )
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        help="GitHub event name for the current workflow run.",
+    )
+    parser.add_argument(
+        "--release-tag",
+        default="",
+        help="GitHub release tag when the workflow is running for a published release.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Rust target triple used to build shadictl.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        required=True,
+        help="GitHub Actions output file path.",
+    )
+    return parser.parse_args()
+
+
+def load_version() -> str:
+    with CLI_MANIFEST.open("rb") as handle:
+        manifest = tomllib.load(handle)
+    return manifest["package"]["version"]
+
+
+def resolve_release_tag(event_name: str, release_tag: str, version: str) -> str:
+    if event_name != "release":
+        return ""
+
+    prefix = "agntcy-shadi-cli-v"
+    if not release_tag.startswith(prefix):
+        raise SystemExit(f"expected {prefix}<version>, got {release_tag}")
+
+    tag_version = release_tag[len(prefix):]
+    if tag_version != version:
+        raise SystemExit(
+            f"release tag version {tag_version} does not match crates/shadictl/Cargo.toml version {version}"
+        )
+
+    return release_tag
+
+
+def resolve_binary_path(target: str) -> str:
+    binary_path = f"target/{target}/release/shadictl"
+    if target.endswith("windows-msvc"):
+        return f"{binary_path}.exe"
+    return binary_path
+
+
+def main() -> None:
+    args = parse_args()
+
+    version = load_version()
+    release_tag = resolve_release_tag(args.event_name, args.release_tag, version)
+
+    outputs = {
+        "version": version,
+        "release_tag": release_tag,
+        "binary_path": resolve_binary_path(args.target),
+    }
+
+    with args.github_output.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated shadictl multi-architecture build workflow for pull requests, main pushes, and published agntcy-shadi-cli releases
- package shadictl into tar.gz or zip archives with sha256 sidecars for Linux x86_64/aarch64, macOS arm64/x86_64, and Windows x86_64
- document the new release artifacts in the repository README and release process notes

## Validation
- python3 -m py_compile scripts/package_shadictl_release.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/shadictl-binaries.yml")'
- HOST_TRIPLE=$(rustc -vV | awk '/^host: / {print $2}') && cargo build -p agntcy-shadi-cli --release --locked && python3 scripts/package_shadictl_release.py --binary target/release/shadictl --target "$HOST_TRIPLE" --version 0.1.1 --output-dir /tmp/shadi-dist-test