### PR TITLE
release: upload shadictl binaries in release workflow

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -10,6 +10,9 @@ jobs:
   release-crates:
     name: Release crates
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
+      releases: ${{ steps.release-plz.outputs.releases }}
     permissions:
       contents: write
       pull-requests: read
@@ -47,12 +50,140 @@ jobs:
           fi
 
       - name: Run release-plz publish
+        id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release
           manifest_path: ./Cargo.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-shadictl-binaries:
+    name: Release shadictl binaries (${{ matrix.name }})
+    needs: release-crates
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-2022
+            target: x86_64-pc-windows-msvc
+    env:
+      PYO3_PYTHON: python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.88.0
+          targets: ${{ matrix.target }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config nettle-dev libssl-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nettle pkg-config
+
+      - name: Set OpenSSL env vars (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
+          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $opensslDir) {
+            choco install openssl -y --no-progress
+            $opensslDir = "C:\Program Files\OpenSSL-Win64"
+          }
+          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
+          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Resolve CLI release tag
+        id: release
+        shell: bash
+        env:
+          RELEASES: ${{ needs.release-crates.outputs.releases }}
+        run: |
+          release_tag=$(python - <<'PY'
+          import json
+          import os
+
+          releases = json.loads(os.environ["RELEASES"])
+          for release in releases:
+              if release["package_name"] == "agntcy-shadi-cli":
+                  print(release["tag"])
+                  break
+          else:
+              raise SystemExit("agntcy-shadi-cli release not found in release-plz outputs")
+          PY
+          )
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python scripts/resolve_shadictl_release_metadata.py \
+            --event-name release \
+            --release-tag "${{ steps.release.outputs.release_tag }}" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build shadictl
+        run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_shadictl_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ steps.metadata.outputs.release_tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber
 
   release-crates-pr:
     name: Release crates - PR

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -5,16 +5,10 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
 
 jobs:
   build-shadictl-release-artifacts:
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'agntcy-shadi-cli-v') }}
     runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -85,10 +79,10 @@ jobs:
         shell: bash
         run: |
           python scripts/resolve_shadictl_release_metadata.py \
-          --event-name "${{ github.event_name }}" \
-          --release-tag "${{ github.event.release.tag_name || '' }}" \
-          --target "${{ matrix.target }}" \
-          --github-output "$GITHUB_OUTPUT"
+            --event-name "${{ github.event_name }}" \
+            --release-tag "" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Build shadictl
         run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}
@@ -103,15 +97,3 @@ jobs:
             --version "${{ steps.metadata.outputs.version }}" \
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
-
-      - name: Upload release assets
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          gh release upload "${{ steps.metadata.outputs.release_tag }}" \
-            "${{ steps.package.outputs.archive_path }}" \
-            "${{ steps.package.outputs.checksum_path }}" \
-            --repo "${{ github.repository }}" \
-            --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,10 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`, macOS
    `aarch64-apple-darwin` and `x86_64-apple-darwin`, and Windows
    `x86_64-pc-windows-msvc`.
-- The same workflow uploads `.tar.gz` or `.zip` archives plus `.sha256`
-   checksum files to each published `agntcy-shadi-cli-v*` GitHub release.
+- `.github/workflows/release-rust.yml` uploads `.tar.gz` or `.zip` archives
+   plus `.sha256` checksum files to each published `agntcy-shadi-cli-v*`
+   GitHub release in the same workflow run that `release-plz` uses to create
+   the release.
 - `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that
    refreshes `Formula/shadictl.rb` when an `agntcy-shadi-cli-v*` release is
    published.


### PR DESCRIPTION
## Summary
- move shadictl binary uploads into `.github/workflows/release-rust.yml`, using `release-plz` outputs from the same workflow run that creates GitHub releases
- keep `.github/workflows/shadictl-binaries.yml` as a validation workflow for pull requests and `main` pushes only
- update the release documentation note in `CONTRIBUTING.md`

## Why
`release-plz` creates releases with `GITHUB_TOKEN`, so downstream `release.published` workflows do not fire. That meant the validation workflow ran on pushes, but the release upload path never executed and release pages stayed empty.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-rust.yml"); YAML.load_file(".github/workflows/shadictl-binaries.yml")'`
- editor/workspace validation for both workflow files
- confirmed `gh release view agntcy-shadi-cli-v0.1.0 --json assets` returns an empty asset list on `main`, matching the reported issue