### PR TITLE
packaging: add WinGet distribution for shadictl

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -58,9 +58,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  resolve-shadictl-release:
+    name: Resolve shadictl release
+    needs: release-crates
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+    steps:
+      - name: Resolve CLI release tag
+        id: release
+        shell: bash
+        env:
+          RELEASES: ${{ needs.release-crates.outputs.releases }}
+        run: |
+          release_tag=$(python - <<'PY'
+          import json
+          import os
+
+          releases = json.loads(os.environ["RELEASES"])
+          for release in releases:
+              if release["package_name"] == "agntcy-shadi-cli":
+                  print(release["tag"])
+                  break
+          else:
+              raise SystemExit("agntcy-shadi-cli release not found in release-plz outputs")
+          PY
+          )
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
   release-shadictl-binaries:
     name: Release shadictl binaries (${{ matrix.name }})
-    needs: release-crates
+    needs:
+      - release-crates
+      - resolve-shadictl-release
     if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -129,34 +160,13 @@ jobs:
           "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Resolve CLI release tag
-        id: release
-        shell: bash
-        env:
-          RELEASES: ${{ needs.release-crates.outputs.releases }}
-        run: |
-          release_tag=$(python - <<'PY'
-          import json
-          import os
-
-          releases = json.loads(os.environ["RELEASES"])
-          for release in releases:
-              if release["package_name"] == "agntcy-shadi-cli":
-                  print(release["tag"])
-                  break
-          else:
-              raise SystemExit("agntcy-shadi-cli release not found in release-plz outputs")
-          PY
-          )
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-
       - name: Resolve release metadata
         id: metadata
         shell: bash
         run: |
           python scripts/resolve_shadictl_release_metadata.py \
             --event-name release \
-            --release-tag "${{ steps.release.outputs.release_tag }}" \
+            --release-tag "${{ needs.resolve-shadictl-release.outputs.release_tag }}" \
             --target "${{ matrix.target }}" \
             --github-output "$GITHUB_OUTPUT"
 
@@ -184,6 +194,28 @@ jobs:
             "${{ steps.package.outputs.checksum_path }}" \
             --repo "${{ github.repository }}" \
             --clobber
+
+  release-shadictl-winget:
+    name: Publish shadictl WinGet manifests
+    needs:
+      - release-crates
+      - resolve-shadictl-release
+      - release-shadictl-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-shadictl-release.outputs.release_tag }}
+    steps:
+      - name: Trigger WinGet manifest workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run winget-manifests.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f release_tag="$RELEASE_TAG"
 
   release-crates-pr:
     name: Release crates - PR

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -1,0 +1,119 @@
+name: Publish WinGet Manifests
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: CLI release tag to render into WinGet manifests
+        required: true
+        type: string
+    secrets:
+      WINGET_PKGS_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: CLI release tag to render into WinGet manifests
+        required: true
+        type: string
+
+jobs:
+  publish-winget-manifests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Render WinGet manifests
+        id: render
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/render_winget_manifests.py \
+            --tag "$RELEASE_TAG" \
+            --output-dir dist/winget \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload WinGet manifest artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: winget-manifests-${{ steps.render.outputs.package_version }}
+          path: dist/winget/manifests
+
+      - name: Open or update winget-pkgs PR
+        env:
+          WINGET_PKGS_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}
+          MANIFEST_DIR: ${{ steps.render.outputs.manifest_dir }}
+          MANIFEST_REL_DIR: ${{ steps.render.outputs.manifest_rel_dir }}
+          PACKAGE_IDENTIFIER: ${{ steps.render.outputs.package_identifier }}
+          PACKAGE_VERSION: ${{ steps.render.outputs.package_version }}
+          RELEASE_URL: ${{ steps.render.outputs.release_url }}
+        run: |
+          if [ -z "$WINGET_PKGS_TOKEN" ]; then
+            echo "::notice::WINGET_PKGS_TOKEN is not configured; uploaded generated WinGet manifests as a workflow artifact only."
+            exit 0
+          fi
+
+          fork_owner=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh api user --jq '.login')
+
+          if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo view "$fork_owner/winget-pkgs" >/dev/null 2>&1; then
+            GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo fork microsoft/winget-pkgs --clone=false --remote=false --default-branch-only
+          fi
+
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo sync "$fork_owner/winget-pkgs" --source microsoft/winget-pkgs --branch master
+
+          rm -rf /tmp/winget-pkgs
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1 --branch master
+
+          branch="automation/winget-shadictl-$PACKAGE_VERSION"
+
+          cd /tmp/winget-pkgs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+
+          mkdir -p "$(dirname "$MANIFEST_REL_DIR")"
+          rm -rf "$MANIFEST_REL_DIR"
+          cp -R "$MANIFEST_DIR" "$(dirname "$MANIFEST_REL_DIR")/"
+
+          if git diff --quiet -- "$MANIFEST_REL_DIR"; then
+            echo "WinGet manifests are already up to date for $RELEASE_TAG"
+            exit 0
+          fi
+
+          git add "$MANIFEST_REL_DIR"
+          git commit -m "release: add WinGet manifest for shadictl v$PACKAGE_VERSION"
+          git push --force --set-upstream origin "$branch"
+
+          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
+          if [ -n "$pr_number" ]; then
+            echo "Updated existing PR #$pr_number"
+            exit 0
+          fi
+
+          cat > /tmp/winget-pr-body.md <<EOF
+          Add WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION.
+
+          - publishes the Windows portable ZIP for shadictl
+          - points WinGet at the SHADI GitHub release asset and checksum-backed digest
+          - generated from the SHADI CLI release automation
+
+          Upstream release: $RELEASE_URL
+          Refs agntcy/shadi#69
+          EOF
+
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
+            --repo microsoft/winget-pkgs \
+            --base master \
+            --head "$fork_owner:$branch" \
+            --title "Add WinGet manifest for AGNTCY.shadictl version $PACKAGE_VERSION" \
+            --body-file /tmp/winget-pr-body.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,20 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    plus `.sha256` checksum files to each published `agntcy-shadi-cli-v*`
    GitHub release in the same workflow run that `release-plz` uses to create
    the release.
+- WinGet publication uses the released Windows archive
+   `shadictl-v<version>-x86_64-pc-windows-msvc.zip` plus its `.sha256` sidecar
+   as the source of truth for the WinGet installer manifest.
+- `scripts/render_winget_manifests.py` renders the WinGet version,
+   default-locale, and installer manifests for `AGNTCY.shadictl` directly from
+   a released `agntcy-shadi-cli-v*` tag.
+- `.github/workflows/winget-manifests.yml` can be run manually with a release
+   tag, and `.github/workflows/release-rust.yml` calls it automatically after
+   the release assets are uploaded so WinGet publication tracks CLI releases.
+- When the repository secret `WINGET_PKGS_TOKEN` is configured,
+   `.github/workflows/winget-manifests.yml` syncs a fork of
+   `microsoft/winget-pkgs`, commits the generated manifests, and opens or
+   updates the upstream PR. Without that secret, the workflow still uploads the
+   generated manifest tree as an artifact for manual submission.
 - `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that
    refreshes `Formula/shadictl.rb` when an `agntcy-shadi-cli-v*` release is
    published.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ brew tap agntcy/shadi https://github.com/agntcy/shadi
 brew install agntcy/shadi/shadictl
 ```
 
+On Windows, once the matching WinGet manifest has landed in the default source,
+you can install or upgrade `shadictl` with:
+
+```powershell
+winget install --id AGNTCY.shadictl -e
+winget upgrade --id AGNTCY.shadictl -e
+```
+
 The Homebrew formula builds from the published `agntcy-shadi-cli` release tag.
 Published `agntcy-shadi-cli` releases also include prebuilt archives for Linux
 (`x86_64` and `aarch64`), macOS (`arm64` and `x86_64`), and Windows (`x86_64`).

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+import textwrap
+import tomllib
+import urllib.request
+from urllib.error import HTTPError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
+CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
+DEFAULT_OUTPUT_DIR = ROOT / "dist" / "winget"
+
+MANIFEST_VERSION = "1.12.0"
+PACKAGE_IDENTIFIER = "AGNTCY.shadictl"
+PACKAGE_LOCALE = "en-US"
+PUBLISHER = "AGNTCY"
+PACKAGE_NAME = "shadictl"
+MONIKER = "shadictl"
+WINDOWS_ARCHITECTURE = "x64"
+WINDOWS_TARGET = "x86_64-pc-windows-msvc"
+DOCS_URL = "https://agntcy.github.io/shadi"
+TAG_PATTERN = re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+REPOSITORY_PATTERN = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+@dataclass(frozen=True)
+class ReleaseAssets:
+    tag: str
+    version: str
+    release_date: str
+    release_url: str
+    installer_url: str
+    installer_sha256: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render WinGet manifests for a released shadictl CLI tag."
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag in the form agntcy-shadi-cli-v<version>",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output root for generated manifests (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file to append manifest metadata to.",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def resolve_workspace_value(package: dict, workspace_package: dict, key: str) -> str:
+    value = package.get(key)
+    if isinstance(value, dict) and value.get("workspace"):
+        return workspace_package[key]
+    if value is None:
+        return workspace_package[key]
+    if not isinstance(value, str):
+        raise SystemExit(f"expected {key} to resolve to a string")
+    return value
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "GitHub-Copilot",
+    }
+    token = None
+    for env_var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        if env_var in os.environ and os.environ[env_var]:
+            token = os.environ[env_var]
+            break
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_bytes(url: str) -> bytes:
+    request = urllib.request.Request(url, headers=github_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+    except HTTPError as error:
+        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+
+
+def fetch_json(url: str) -> dict:
+    data = fetch_bytes(url)
+    return json.loads(data)
+
+
+def fetch_text(url: str) -> str:
+    return fetch_bytes(url).decode("utf-8")
+
+
+def sha256_for_url(url: str) -> str:
+    request = urllib.request.Request(url, headers=github_headers())
+    digest = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except HTTPError as error:
+        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+    return digest.hexdigest().upper()
+
+
+def parse_repository_slug(repository_url: str) -> str:
+    match = REPOSITORY_PATTERN.match(repository_url)
+    if not match:
+        raise SystemExit(f"expected GitHub repository URL, got: {repository_url}")
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def parse_release_tag(tag: str) -> str:
+    match = TAG_PATTERN.match(tag)
+    if not match:
+        raise SystemExit(f"expected agntcy-shadi-cli-v<version> tag, got: {tag}")
+    return match.group("version")
+
+
+def resolve_release_assets(tag: str, repository_slug: str) -> ReleaseAssets:
+    version = parse_release_tag(tag)
+    release = fetch_json(
+        f"https://api.github.com/repos/{repository_slug}/releases/tags/{tag}"
+    )
+
+    installer_name = f"shadictl-v{version}-{WINDOWS_TARGET}.zip"
+    checksum_name = f"{installer_name}.sha256"
+
+    installer_url = None
+    checksum_url = None
+    for asset in release.get("assets", []):
+        asset_name = asset.get("name")
+        asset_url = asset.get("browser_download_url")
+        if asset_name == installer_name:
+            installer_url = asset_url
+        elif asset_name == checksum_name:
+            checksum_url = asset_url
+
+    if installer_url is None:
+        raise SystemExit(
+            f"release {tag} does not contain the expected Windows asset {installer_name}"
+        )
+
+    if checksum_url is not None:
+        checksum_text = fetch_text(checksum_url)
+        checksum_lines = [line.strip() for line in checksum_text.splitlines() if line.strip()]
+        if not checksum_lines:
+            raise SystemExit(f"checksum asset {checksum_name} is empty")
+        installer_sha256 = checksum_lines[0].split()[0].upper()
+    else:
+        installer_sha256 = sha256_for_url(installer_url)
+
+    release_date = release.get("published_at") or release.get("created_at")
+    if release_date is None:
+        raise SystemExit(f"release {tag} does not expose a publication date")
+
+    return ReleaseAssets(
+        tag=tag,
+        version=version,
+        release_date=release_date[:10],
+        release_url=release["html_url"],
+        installer_url=installer_url,
+        installer_sha256=installer_sha256,
+    )
+
+
+def render_version_manifest(version: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {version}
+        DefaultLocale: {PACKAGE_LOCALE}
+        ManifestType: version
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def render_default_locale_manifest(
+    *,
+    tag: str,
+    version: str,
+    description: str,
+    repository_url: str,
+    license_id: str,
+) -> str:
+    tags = "\n".join(
+        [
+            "Tags:",
+            "- agent",
+            "- cli",
+            "- sandbox",
+            "- security",
+            "- slim",
+        ]
+    )
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {version}
+        PackageLocale: {PACKAGE_LOCALE}
+        Publisher: {PUBLISHER}
+        PublisherUrl: https://github.com/agntcy
+        PublisherSupportUrl: {repository_url}/issues
+        Author: AGNTCY Contributors
+        PackageName: {PACKAGE_NAME}
+        PackageUrl: {repository_url}
+        License: {license_id}
+        LicenseUrl: {repository_url}/blob/{tag}/LICENSE.md
+        ShortDescription: {description}
+        Moniker: {MONIKER}
+        {tags}
+        Documentations:
+        - DocumentLabel: Documentation
+          DocumentUrl: {DOCS_URL}
+        ReleaseNotesUrl: {repository_url}/releases/tag/{tag}
+        ManifestType: defaultLocale
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def render_installer_manifest(release_assets: ReleaseAssets) -> str:
+    relative_file_path = (
+        f"shadictl-v{release_assets.version}-{WINDOWS_TARGET}\\shadictl.exe"
+    )
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {release_assets.version}
+        InstallerType: zip
+        NestedInstallerType: portable
+        Commands:
+        - {MONIKER}
+        ReleaseDate: {release_assets.release_date}
+        Installers:
+        - Architecture: {WINDOWS_ARCHITECTURE}
+          InstallerUrl: {release_assets.installer_url}
+          InstallerSha256: {release_assets.installer_sha256}
+          NestedInstallerFiles:
+          - RelativeFilePath: {relative_file_path}
+            PortableCommandAlias: {MONIKER}
+        ManifestType: installer
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def manifest_directory(output_dir: Path, package_identifier: str, version: str) -> Path:
+    identifier_parts = package_identifier.split(".")
+    return output_dir / "manifests" / identifier_parts[0].lower()[0] / Path(*identifier_parts) / version
+
+
+def write_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    args = parse_args()
+
+    workspace = load_toml(WORKSPACE_MANIFEST)
+    cli_manifest = load_toml(CLI_MANIFEST)
+    workspace_package = workspace["workspace"]["package"]
+    package = cli_manifest["package"]
+
+    repository_url = resolve_workspace_value(package, workspace_package, "repository")
+    repository_slug = parse_repository_slug(repository_url)
+    description = package["description"]
+    license_id = resolve_workspace_value(package, workspace_package, "license")
+
+    release_assets = resolve_release_assets(args.tag, repository_slug)
+
+    output_dir = args.output_dir.resolve()
+    manifests_dir = manifest_directory(output_dir, PACKAGE_IDENTIFIER, release_assets.version)
+    if manifests_dir.exists():
+        shutil.rmtree(manifests_dir)
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.yaml").write_text(
+        render_version_manifest(release_assets.version),
+        encoding="utf-8",
+    )
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.locale.{PACKAGE_LOCALE}.yaml").write_text(
+        render_default_locale_manifest(
+            tag=release_assets.tag,
+            version=release_assets.version,
+            description=description,
+            repository_url=repository_url,
+            license_id=license_id,
+        ),
+        encoding="utf-8",
+    )
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.installer.yaml").write_text(
+        render_installer_manifest(release_assets),
+        encoding="utf-8",
+    )
+
+    outputs = {
+        "manifest_dir": str(manifests_dir),
+        "manifest_rel_dir": manifests_dir.relative_to(output_dir).as_posix(),
+        "package_identifier": PACKAGE_IDENTIFIER,
+        "package_version": release_assets.version,
+        "release_url": release_assets.release_url,
+    }
+    if args.github_output is not None:
+        write_github_output(args.github_output, outputs)
+
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- render WinGet version, locale, and installer manifests from released `agntcy-shadi-cli` Windows assets
- add a manual `winget-manifests.yml` workflow and dispatch it from `release-rust.yml` after release assets are uploaded
- document the WinGet install and upgrade path plus the release publication flow

## Validation

- `python3 -m py_compile scripts/render_winget_manifests.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/winget-manifests.yml"); YAML.load_file(".github/workflows/release-rust.yml")'`
- local smoke test of the WinGet render helpers with a synthetic release payload

## Notes

- a full end-to-end render against a live SHADI CLI release was not possible yet because the current published CLI release predates the Windows asset upload path

Fixes #69
