### PR TITLE
docs: add shadictl WinGet release note

### DIFF
--- a/crates/shadictl/CHANGELOG.md
+++ b/crates/shadictl/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add WinGet distribution support for Windows installs of `shadictl`
+
 ## [0.1.1](https://github.com/agntcy/shadi/compare/agntcy-shadi-cli-v0.1.0...agntcy-shadi-cli-v0.1.1) - 2026-04-20
 
 ### Other


### PR DESCRIPTION
## Summary

- record the WinGet distribution work under `crates/shadictl/CHANGELOG.md`
- make the `shadictl` package show a package-scoped change so `release-plz` can open the next CLI release PR

## Notes

- this is the minimal follow-up needed because the merged WinGet implementation lived in workflows/scripts/docs and was skipped by `release-plz` for package release generation
