### PR TITLE
chore: add missing script copyright headers

### DIFF
--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = 'Stop'
 
 function Get-OnePasswordSecret {

--- a/scripts/demo_slim_shell.sh
+++ b/scripts/demo_slim_shell.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/launch_slim.ps1
+++ b/scripts/launch_slim.ps1
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = 'Stop'
 
 $rootDir = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path

--- a/scripts/launch_slim.sh
+++ b/scripts/launch_slim.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/run_coverage.ps1
+++ b/scripts/run_coverage.ps1
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 param(
     [ValidateSet('lcov', 'html')]
     [string]$Mode = 'lcov',

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 mode="${1:-lcov}"

--- a/tools/generate_slim_mtls_certs.sh
+++ b/tools/generate_slim_mtls_certs.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 CERT_DIR="${1:-./tmp/shadi-slim-mtls}"

--- a/tools/run_sandboxed_agent.py
+++ b/tools/run_sandboxed_agent.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 import os

--- a/tools/sitecustomize.py
+++ b/tools/sitecustomize.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import socket
 from typing import Any


### PR DESCRIPTION
## Summary

- add the standard AGNTCY copyright and SPDX header to script files that were missing it
- cover the remaining shell, PowerShell, and Python scripts in `scripts/` and `tools/`
- keep the change header-only with no behavior changes

## Validation

- repository script header coverage check for `scripts/*.sh`, `scripts/*.ps1`, `scripts/*.py`, `tools/*.sh`, `tools/*.py`, and `examples/shell_demo/*.sh`
- `python3 -m py_compile tools/run_sandboxed_agent.py tools/sitecustomize.py`
- editor diagnostics on all touched files
- `git diff --check`
