### PR TITLE
fix: automate Homebrew formula refresh

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -217,6 +217,28 @@ jobs:
             --ref "${{ github.ref_name }}" \
             -f release_tag="$RELEASE_TAG"
 
+  release-shadictl-homebrew:
+    name: Publish shadictl Homebrew formula
+    needs:
+      - release-crates
+      - resolve-shadictl-release
+      - release-shadictl-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-shadictl-release.outputs.release_tag }}
+    steps:
+      - name: Trigger Homebrew formula workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run homebrew-formula.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f tag="$RELEASE_TAG"
+
   release-crates-pr:
     name: Release crates - PR
     runs-on: ubuntu-latest

--- a/Formula/shadictl.rb
+++ b/Formula/shadictl.rb
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 class Shadictl < Formula
   desc "Command-line interface for SHADI policy, secrets, memory, and SLIM operations."
   homepage "https://github.com/agntcy/shadi"

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -18,6 +18,13 @@ WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
 CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
 DEFAULT_OUTPUT = ROOT / "Formula" / "shadictl.rb"
 TAG_PATTERN = re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+FORMULA_HEADER = textwrap.dedent(
+    """\
+    # Copyright AGNTCY Contributors (https://github.com/agntcy)
+    # SPDX-License-Identifier: Apache-2.0
+
+    """
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -85,7 +92,7 @@ def render_formula(tag: str) -> str:
     source_sha256 = fetch_sha256(source_url)
     git_url = homepage if homepage.endswith(".git") else f"{homepage}.git"
 
-    return textwrap.dedent(
+    formula_body = textwrap.dedent(
         f"""\
         class Shadictl < Formula
           desc \"{ruby_string(description)}\"
@@ -114,6 +121,8 @@ def render_formula(tag: str) -> str:
         end
         """
     )
+
+    return f"{FORMULA_HEADER}{formula_body}"
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- dispatch `homebrew-formula.yml` from `release-rust.yml` after `shadictl` release binaries are uploaded
- keep Homebrew publication aligned with the release flow without requiring a manual workflow dispatch
- restore the standard copyright and SPDX header in generated `Formula/shadictl.rb`

## Validation

- `python3 -m py_compile scripts/render_homebrew_formula.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-rust.yml"); YAML.load_file(".github/workflows/homebrew-formula.yml")'`
- `python3 scripts/render_homebrew_formula.py --tag agntcy-shadi-cli-v0.1.1 --output "$tmpfile"` output matches `Formula/shadictl.rb`
- `git diff --check`
