### PR TITLE
ci: fix WinGet fork command

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -89,7 +89,7 @@ jobs:
           fork_owner="$FORK_OWNER"
 
           if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo view "$fork_owner/winget-pkgs" >/dev/null 2>&1; then
-            GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo fork microsoft/winget-pkgs --clone=false --remote=false --default-branch-only
+            GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo fork microsoft/winget-pkgs --org "$fork_owner" --clone=false --default-branch-only
           fi
 
           GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo sync "$fork_owner/winget-pkgs" --source microsoft/winget-pkgs --branch master

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -8,7 +8,9 @@ on:
         required: true
         type: string
     secrets:
-      WINGET_PKGS_TOKEN:
+      PROJECT_APP_ID:
+        required: false
+      PROJECT_APP_KEY:
         required: false
   workflow_dispatch:
     inputs:
@@ -24,6 +26,7 @@ jobs:
       contents: read
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
+      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -49,9 +52,29 @@ jobs:
           name: winget-manifests-${{ steps.render.outputs.package_version }}
           path: dist/winget/manifests
 
+      - name: Authenticate with GitHub App Bot
+        if: env.APP_AUTH_CONFIGURED == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve GitHub App Bot user id
+        if: ${{ steps.app-token.outputs.token != '' }}
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "user_id=$(gh api '/users/${{ steps.app-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Open or update winget-pkgs PR
         env:
-          WINGET_PKGS_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}
+          WINGET_PKGS_TOKEN: ${{ steps.app-token.outputs.token }}
+          FORK_OWNER: ${{ github.repository_owner }}
+          GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
           MANIFEST_DIR: ${{ steps.render.outputs.manifest_dir }}
           MANIFEST_REL_DIR: ${{ steps.render.outputs.manifest_rel_dir }}
           PACKAGE_IDENTIFIER: ${{ steps.render.outputs.package_identifier }}
@@ -59,11 +82,11 @@ jobs:
           RELEASE_URL: ${{ steps.render.outputs.release_url }}
         run: |
           if [ -z "$WINGET_PKGS_TOKEN" ]; then
-            echo "::notice::WINGET_PKGS_TOKEN is not configured; uploaded generated WinGet manifests as a workflow artifact only."
+            echo "::notice::PROJECT_APP_ID / PROJECT_APP_KEY are not configured; uploaded generated WinGet manifests as a workflow artifact only."
             exit 0
           fi
 
-          fork_owner=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh api user --jq '.login')
+          fork_owner="$FORK_OWNER"
 
           if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo view "$fork_owner/winget-pkgs" >/dev/null 2>&1; then
             GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo fork microsoft/winget-pkgs --clone=false --remote=false --default-branch-only
@@ -77,8 +100,8 @@ jobs:
           branch="automation/winget-shadictl-$PACKAGE_VERSION"
 
           cd /tmp/winget-pkgs
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
           git checkout -B "$branch"
 
           mkdir -p "$(dirname "$MANIFEST_REL_DIR")"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,11 +134,12 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
 - `.github/workflows/winget-manifests.yml` can be run manually with a release
    tag, and `.github/workflows/release-rust.yml` calls it automatically after
    the release assets are uploaded so WinGet publication tracks CLI releases.
-- When the repository secret `WINGET_PKGS_TOKEN` is configured,
-   `.github/workflows/winget-manifests.yml` syncs a fork of
-   `microsoft/winget-pkgs`, commits the generated manifests, and opens or
-   updates the upstream PR. Without that secret, the workflow still uploads the
-   generated manifest tree as an artifact for manual submission.
+- When the repository secrets `PROJECT_APP_ID` and `PROJECT_APP_KEY` are
+   configured, `.github/workflows/winget-manifests.yml` authenticates as the
+   project GitHub App bot, syncs a fork of `microsoft/winget-pkgs`, commits the
+   generated manifests, and opens or updates the upstream PR. Without those
+   secrets, the workflow still uploads the generated manifest tree as an
+   artifact for manual submission.
 - `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that
    refreshes `Formula/shadictl.rb` when an `agntcy-shadi-cli-v*` release is
    published.


### PR DESCRIPTION
## Summary

- fix the `gh repo fork` invocation in the WinGet workflow after the GitHub App auth change
- remove the unsupported `--remote=false` usage when a repository argument is provided
- create the fork explicitly in the `agntcy` organization, which matches the workflow's `FORK_OWNER` handling

## Context

The failing run was not caused by the `app-id` deprecation warning. The actual error was:

```text
the `--remote` flag is unsupported when a repository argument is provided
```

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/winget-manifests.yml")'`
- `git diff --check`
