### PR TITLE
add Linux installer for shadictl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Set Python for PyO3 (macOS)
         if: runner.os == 'macOS'
         run: echo "PYO3_PYTHON=/opt/homebrew/opt/python@3.12/bin/python3.12" >> "$GITHUB_ENV"
+      - name: Validate Linux installer
+        if: runner.os == 'Linux'
+        run: bash scripts/test_install_shadictl.sh
       - name: Build and test
         if: runner.os != 'Windows'
         run: cargo test --workspace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,16 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    plus `.sha256` checksum files to each published `agntcy-shadi-cli-v*`
    GitHub release in the same workflow run that `release-plz` uses to create
    the release.
+- The hosted Linux installer at `https://agntcy.github.io/shadi/install.sh`
+   is sourced from `docs/install.sh` and consumes the released Linux archives
+   `shadictl-v<version>-x86_64-unknown-linux-gnu.tar.gz` or
+   `shadictl-v<version>-aarch64-unknown-linux-gnu.tar.gz` plus their `.sha256`
+   sidecars.
+- The Linux installer resolves the latest published `agntcy-shadi-cli-v*`
+   release automatically unless `SHADI_VERSION` is set, so normal CLI releases
+   do not require a per-release installer update. Only changes to asset names,
+   supported Linux targets, or the hosting location require updates to
+   `docs/install.sh` and `docs/install.md`.
 - WinGet publication uses the released Windows archive
    `shadictl-v<version>-x86_64-pc-windows-msvc.zip` plus its `.sha256` sidecar
    as the source of truth for the WinGet installer manifest.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ SHADI is for teams that want agents to work with real tools and real credentials
 
 ## Install the CLI
 
+On Linux, install the latest released `shadictl` with:
+
+```bash
+curl -fsSL https://agntcy.github.io/shadi/install.sh | bash
+```
+
+For pinned versions, custom install paths, and installer environment overrides,
+see [docs/install.md](docs/install.md).
+
 On macOS, you can install the latest released `shadictl` formula with Homebrew:
 
 ```bash

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,6 +15,15 @@ By the end of this guide, you will have:
 
 ## Before You Begin
 
+If you only need the released CLI on Linux, install it with the hosted bash
+installer:
+
+```bash
+curl -fsSL https://agntcy.github.io/shadi/install.sh | bash
+```
+
+For version pinning or install path overrides, see [Install the CLI](install.md).
+
 If you only need the released CLI on macOS, install it with Homebrew:
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,83 @@
+# Install the CLI
+
+This page covers the supported released-install flows for `shadictl`.
+
+## Linux
+
+Install the latest released `shadictl` with a single command:
+
+```bash
+curl -fsSL https://agntcy.github.io/shadi/install.sh | bash
+```
+
+The installer currently supports these published Linux release archives:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+
+For each install, it downloads the matching release archive and its `.sha256`
+sidecar from the published `agntcy-shadi-cli-v*` GitHub release, verifies the
+archive checksum, and only then installs `shadictl`.
+
+## Install Paths
+
+By default, the installer chooses a writable binary directory:
+
+- non-root: `${XDG_BIN_HOME:-$HOME/.local/bin}`
+- root: `/usr/local/bin`
+
+To install somewhere else, set `SHADI_INSTALL_DIR` on the `bash` side of the
+pipeline:
+
+```bash
+curl -fsSL https://agntcy.github.io/shadi/install.sh | env SHADI_INSTALL_DIR="$HOME/bin" bash
+```
+
+If the target directory is not already on `PATH`, the installer prints the
+export command needed to add it.
+
+## Pinning and Upgrades
+
+With no version override, rerunning the installer upgrades `shadictl` to the
+latest published CLI release.
+
+To install or downgrade to a specific release, set `SHADI_VERSION`:
+
+```bash
+curl -fsSL https://agntcy.github.io/shadi/install.sh | env SHADI_VERSION=0.1.1 bash
+```
+
+`SHADI_VERSION` accepts `0.1.1`, `v0.1.1`, or the full release tag
+`agntcy-shadi-cli-v0.1.1`.
+
+The installer replaces the existing `shadictl` binary in place. If the archive
+download or checksum validation fails, the existing binary is left untouched.
+
+## Environment Overrides
+
+These environment variables are supported by the installer:
+
+- `SHADI_VERSION`: install a specific published CLI release instead of the latest one.
+- `SHADI_INSTALL_DIR`: install `shadictl` into a specific directory.
+- `SHADI_RELEASE_API_URL`: advanced override for the latest-release metadata endpoint.
+- `SHADI_RELEASE_DOWNLOAD_BASE_URL`: advanced override for the release asset base URL.
+
+The two advanced overrides are primarily useful for mirrors, staging, and local
+validation of the installer script.
+
+## macOS and Windows
+
+On macOS, install the released CLI with Homebrew:
+
+```bash
+brew tap agntcy/shadi https://github.com/agntcy/shadi
+brew install agntcy/shadi/shadictl
+```
+
+On Windows, once the matching manifest has landed in the default WinGet source,
+install or upgrade with:
+
+```powershell
+winget install --id AGNTCY.shadictl -e
+winget upgrade --id AGNTCY.shadictl -e
+```

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_OWNER="agntcy"
+REPO_NAME="shadi"
+RELEASE_PREFIX="agntcy-shadi-cli-v"
+DEFAULT_RELEASE_API_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
+DEFAULT_RELEASE_DOWNLOAD_BASE_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download"
+TARGET_X86_64="x86_64-unknown-linux-gnu"
+TARGET_ARM64="aarch64-unknown-linux-gnu"
+
+usage() {
+  cat <<'EOF'
+Install shadictl from published GitHub release assets.
+
+Usage:
+  bash install.sh
+
+Environment overrides:
+  SHADI_VERSION                    Install a specific version such as 0.1.1,
+                                   v0.1.1, or agntcy-shadi-cli-v0.1.1.
+  SHADI_INSTALL_DIR                Directory to place the shadictl binary.
+  SHADI_RELEASE_API_URL            Override the latest-release metadata URL.
+  SHADI_RELEASE_DOWNLOAD_BASE_URL  Override the release asset download base URL.
+EOF
+}
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+require_cmd() {
+  have_cmd "$1" || die "$1 is required"
+}
+
+fetch_to_file() {
+  local url="$1"
+  local destination="$2"
+
+  if have_cmd curl; then
+    curl -fsSL --retry 3 "$url" -o "$destination"
+    return
+  fi
+
+  if have_cmd wget; then
+    wget -qO "$destination" "$url"
+    return
+  fi
+
+  die "curl or wget is required"
+}
+
+fetch_text() {
+  local url="$1"
+
+  if have_cmd curl; then
+    curl -fsSL --retry 3 -H 'Accept: application/vnd.github+json' "$url"
+    return
+  fi
+
+  if have_cmd wget; then
+    wget -qO- --header='Accept: application/vnd.github+json' "$url"
+    return
+  fi
+
+  die "curl or wget is required"
+}
+
+normalize_version() {
+  local requested="$1"
+
+  case "$requested" in
+    "${RELEASE_PREFIX}"*)
+      printf '%s\n' "${requested#${RELEASE_PREFIX}}"
+      ;;
+    v*)
+      printf '%s\n' "${requested#v}"
+      ;;
+    *)
+      printf '%s\n' "$requested"
+      ;;
+  esac
+}
+
+resolve_release_tag() {
+  if [[ -n "${SHADI_VERSION:-}" ]]; then
+    local requested_version
+    requested_version="$(normalize_version "$SHADI_VERSION")"
+    [[ -n "$requested_version" ]] || die "SHADI_VERSION must not be empty"
+    printf '%s\n' "${RELEASE_PREFIX}${requested_version}"
+    return
+  fi
+
+  local api_url
+  api_url="${SHADI_RELEASE_API_URL:-$DEFAULT_RELEASE_API_URL}"
+
+  local response
+  response="$(fetch_text "$api_url")"
+
+  local tag
+  tag="$(printf '%s\n' "$response" | sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n1)"
+  [[ -n "$tag" ]] || die "failed to resolve the latest release tag from $api_url"
+  [[ "$tag" == ${RELEASE_PREFIX}* ]] || die "latest release tag $tag does not match ${RELEASE_PREFIX}<version>"
+  printf '%s\n' "$tag"
+}
+
+resolve_target() {
+  [[ "$(uname -s)" == "Linux" ]] || die "this installer only supports Linux hosts"
+
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\n' "$TARGET_X86_64"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "$TARGET_ARM64"
+      ;;
+    *)
+      die "unsupported Linux architecture $(uname -m); supported targets are x86_64 and aarch64"
+      ;;
+  esac
+}
+
+resolve_install_dir() {
+  if [[ -n "${SHADI_INSTALL_DIR:-}" ]]; then
+    printf '%s\n' "$SHADI_INSTALL_DIR"
+    return
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    printf '/usr/local/bin\n'
+    return
+  fi
+
+  if [[ -n "${XDG_BIN_HOME:-}" ]]; then
+    printf '%s\n' "$XDG_BIN_HOME"
+    return
+  fi
+
+  printf '%s/.local/bin\n' "$HOME"
+}
+
+compute_sha256() {
+  local path="$1"
+
+  if have_cmd sha256sum; then
+    sha256sum "$path" | awk '{print $1}'
+    return
+  fi
+
+  if have_cmd shasum; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return
+  fi
+
+  if have_cmd openssl; then
+    openssl dgst -sha256 "$path" | awk '{print $NF}'
+    return
+  fi
+
+  die "sha256sum, shasum, or openssl is required"
+}
+
+cleanup() {
+  if [[ -n "${work_dir:-}" && -d "${work_dir:-}" ]]; then
+    rm -rf "$work_dir"
+  fi
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+require_cmd tar
+require_cmd mktemp
+require_cmd install
+require_cmd mv
+
+release_tag="$(resolve_release_tag)"
+version="${release_tag#${RELEASE_PREFIX}}"
+target="$(resolve_target)"
+install_dir="$(resolve_install_dir)"
+release_download_base_url="${SHADI_RELEASE_DOWNLOAD_BASE_URL:-$DEFAULT_RELEASE_DOWNLOAD_BASE_URL}"
+release_dir_url="${release_download_base_url%/}/${release_tag}"
+archive_name="shadictl-v${version}-${target}.tar.gz"
+checksum_name="${archive_name}.sha256"
+archive_url="${release_dir_url}/${archive_name}"
+checksum_url="${release_dir_url}/${checksum_name}"
+
+work_dir="$(mktemp -d)"
+trap cleanup EXIT
+
+archive_path="${work_dir}/${archive_name}"
+checksum_path="${work_dir}/${checksum_name}"
+extract_dir="${work_dir}/extract"
+
+log "downloading ${archive_name}"
+fetch_to_file "$archive_url" "$archive_path"
+
+log "downloading ${checksum_name}"
+fetch_to_file "$checksum_url" "$checksum_path"
+
+expected_sha="$(awk 'NF { print $1; exit }' "$checksum_path" | tr '[:upper:]' '[:lower:]')"
+actual_sha="$(compute_sha256 "$archive_path" | tr '[:upper:]' '[:lower:]')"
+[[ -n "$expected_sha" ]] || die "checksum file ${checksum_name} did not contain a SHA-256 value"
+[[ "$expected_sha" == "$actual_sha" ]] || die "downloaded archive checksum mismatch"
+
+log "verified ${archive_name}"
+
+mkdir -p "$extract_dir"
+tar -xzf "$archive_path" -C "$extract_dir"
+
+archive_stem="shadictl-v${version}-${target}"
+binary_path="${extract_dir}/${archive_stem}/shadictl"
+[[ -f "$binary_path" ]] || die "release archive did not contain ${archive_stem}/shadictl"
+
+mkdir -p "$install_dir" || die "could not create ${install_dir}; rerun with sudo or set SHADI_INSTALL_DIR"
+[[ -w "$install_dir" ]] || die "could not write to ${install_dir}; rerun with sudo or set SHADI_INSTALL_DIR"
+
+destination="${install_dir}/shadictl"
+staged_destination="${install_dir}/.shadictl.tmp.$$"
+
+install -m 0755 "$binary_path" "$staged_destination"
+mv "$staged_destination" "$destination"
+
+log "installed shadictl ${version} to ${destination}"
+
+case ":${PATH}:" in
+  *":${install_dir}:"*)
+    ;;
+  *)
+    warn "${install_dir} is not on PATH"
+    warn "add it with: export PATH=\"${install_dir}:\$PATH\""
+    ;;
+esac

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: SHADI
 site_description: Secure Host Agentic AI Dynamic Instantiation
-site_url: https://example.com/shadi
-repo_url: https://github.com/your-org/shadi
+site_url: https://agntcy.github.io/shadi
+repo_url: https://github.com/agntcy/shadi
 repo_name: shadi
 
 extra:
@@ -59,6 +59,7 @@ nav:
       - Security Notes: security.md
       - Design Overview: design.md
   - Guides:
+      - Install the CLI: install.md
       - Getting Started: getting_started.md
       - Operations: operations.md
       - Telemetry: telemetry.md

--- a/scripts/test_install_shadictl.sh
+++ b/scripts/test_install_shadictl.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="${ROOT}/docs/install.sh"
+TARGET="x86_64-unknown-linux-gnu"
+DOWNLOADS_ROOT=""
+INSTALL_DIR=""
+TEST_TMP_DIR=""
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
+    rm -rf "$TEST_TMP_DIR"
+  fi
+}
+
+make_stub_binary() {
+  local path="$1"
+  local version="$2"
+
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+printf 'shadictl %s\n' '${version}'
+EOF
+  chmod +x "$path"
+}
+
+package_release() {
+  local version="$1"
+  local checksum_mode="$2"
+  local tag="agntcy-shadi-cli-v${version}"
+  local release_dir="${DOWNLOADS_ROOT}/${tag}"
+  local stub_binary="${TEST_TMP_DIR}/stub-${version}-shadictl"
+  local archive_name="shadictl-v${version}-${TARGET}.tar.gz"
+  local checksum_name="${archive_name}.sha256"
+
+  mkdir -p "$release_dir"
+  make_stub_binary "$stub_binary" "$version"
+
+  python3 "${ROOT}/scripts/package_shadictl_release.py" \
+    --binary "$stub_binary" \
+    --target "$TARGET" \
+    --version "$version" \
+    --output-dir "$release_dir" \
+    >/dev/null
+
+  if [[ "$checksum_mode" == "bad" ]]; then
+    printf '0000000000000000000000000000000000000000000000000000000000000000  %s\n' "$archive_name" > "${release_dir}/${checksum_name}"
+  fi
+}
+
+assert_installed_version() {
+  local expected="$1"
+  local binary_path="${INSTALL_DIR}/shadictl"
+
+  [[ -x "$binary_path" ]] || fail "expected installed binary at ${binary_path}"
+
+  local output
+  output="$($binary_path)"
+  [[ "$output" == "shadictl ${expected}" ]] || fail "expected installed version ${expected}, got: ${output}"
+}
+
+main() {
+  [[ "$(uname -s)" == "Linux" ]] || fail "installer validation only runs on Linux"
+
+  bash -n "$INSTALLER"
+
+  TEST_TMP_DIR="$(mktemp -d)"
+  trap cleanup EXIT
+
+  DOWNLOADS_ROOT="${TEST_TMP_DIR}/downloads"
+  INSTALL_DIR="${TEST_TMP_DIR}/bin"
+  mkdir -p "$DOWNLOADS_ROOT" "$INSTALL_DIR"
+
+  package_release "9.9.9" "good"
+  package_release "9.9.10" "good"
+  package_release "9.9.11" "bad"
+
+  local latest_api_json="${TEST_TMP_DIR}/latest.json"
+  cat > "$latest_api_json" <<'EOF'
+{"tag_name":"agntcy-shadi-cli-v9.9.9"}
+EOF
+
+  env \
+    SHADI_INSTALL_DIR="$INSTALL_DIR" \
+    SHADI_RELEASE_API_URL="file://${latest_api_json}" \
+    SHADI_RELEASE_DOWNLOAD_BASE_URL="file://${DOWNLOADS_ROOT}" \
+    bash "$INSTALLER"
+
+  assert_installed_version "9.9.9"
+
+  env \
+    SHADI_VERSION="9.9.10" \
+    SHADI_INSTALL_DIR="$INSTALL_DIR" \
+    SHADI_RELEASE_DOWNLOAD_BASE_URL="file://${DOWNLOADS_ROOT}" \
+    bash "$INSTALLER"
+
+  assert_installed_version "9.9.10"
+
+  if env \
+    SHADI_VERSION="9.9.11" \
+    SHADI_INSTALL_DIR="$INSTALL_DIR" \
+    SHADI_RELEASE_DOWNLOAD_BASE_URL="file://${DOWNLOADS_ROOT}" \
+    bash "$INSTALLER"; then
+    fail "installer succeeded unexpectedly for a corrupted checksum"
+  fi
+
+  assert_installed_version "9.9.10"
+
+  printf 'installer validation passed\n'
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Add a hosted Linux installer flow for released `shadictl` builds.

## What Changed
- add `docs/install.sh` as a checksum-validating installer for released Linux archives
- add `scripts/test_install_shadictl.sh` and run it in Linux CI
- document the `curl -fsSL https://agntcy.github.io/shadi/install.sh | bash` flow and release-maintenance expectations
- update MkDocs site metadata and nav so the installer is published and discoverable

## Validation
- `bash scripts/test_install_shadictl.sh` via Linux host shim on macOS
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file("mkdocs.yml")'`

Fixes #70