### PR TITLE
ci: reuse existing winget fork for publication

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -89,10 +89,11 @@ jobs:
           fork_owner="$FORK_OWNER"
 
           if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo view "$fork_owner/winget-pkgs" >/dev/null 2>&1; then
-            GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo fork microsoft/winget-pkgs --org "$fork_owner" --clone=false --default-branch-only
+            echo "::error::Expected an existing fork at $fork_owner/winget-pkgs. Create and maintain that fork before running this workflow."
+            exit 1
           fi
 
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo sync "$fork_owner/winget-pkgs" --source microsoft/winget-pkgs --branch master
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh auth setup-git >/dev/null
 
           rm -rf /tmp/winget-pkgs
           GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1 --branch master
@@ -100,9 +101,11 @@ jobs:
           branch="automation/winget-shadictl-$PACKAGE_VERSION"
 
           cd /tmp/winget-pkgs
+          git remote add upstream https://github.com/microsoft/winget-pkgs.git
+          git fetch --depth 1 upstream master
           git config user.name "$GIT_AUTHOR_NAME"
           git config user.email "$GIT_AUTHOR_EMAIL"
-          git checkout -B "$branch"
+          git checkout -B "$branch" upstream/master
 
           mkdir -p "$(dirname "$MANIFEST_REL_DIR")"
           rm -rf "$MANIFEST_REL_DIR"

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -96,7 +96,7 @@ jobs:
           GH_TOKEN="$WINGET_PKGS_TOKEN" gh auth setup-git >/dev/null
 
           rm -rf /tmp/winget-pkgs
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1 --branch master
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1
 
           branch="automation/winget-shadictl-$PACKAGE_VERSION"
 

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -101,7 +101,11 @@ jobs:
           branch="automation/winget-shadictl-$PACKAGE_VERSION"
 
           cd /tmp/winget-pkgs
-          git remote add upstream https://github.com/microsoft/winget-pkgs.git
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/microsoft/winget-pkgs.git
+          else
+            git remote add upstream https://github.com/microsoft/winget-pkgs.git
+          fi
           git fetch --depth 1 upstream master
           git config user.name "$GIT_AUTHOR_NAME"
           git config user.email "$GIT_AUTHOR_EMAIL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,9 @@ Rust crate releases are driven by `.github/workflows/release-rust.yml` using
    the release assets are uploaded so WinGet publication tracks CLI releases.
 - When the repository secrets `PROJECT_APP_ID` and `PROJECT_APP_KEY` are
    configured, `.github/workflows/winget-manifests.yml` authenticates as the
-   project GitHub App bot, syncs a fork of `microsoft/winget-pkgs`, commits the
-   generated manifests, and opens or updates the upstream PR. Without those
+   project GitHub App bot, expects an existing `agntcy/winget-pkgs` fork of
+   `microsoft/winget-pkgs`, branches from the latest `upstream/master`, commits
+   the generated manifests, and opens or updates the upstream PR. Without those
    secrets, the workflow still uploads the generated manifest tree as an
    artifact for manual submission.
 - `.github/workflows/homebrew-formula.yml` opens or updates a follow-up PR that


### PR DESCRIPTION
## Summary
Update the WinGet publication workflow to reuse an existing `agntcy/winget-pkgs` fork instead of calling GitHub endpoints the project app cannot use.

## What Changed
- require a pre-created `agntcy/winget-pkgs` fork instead of attempting to create one on demand
- replace `gh repo sync` with a clone of the existing fork plus a fetch from `upstream/master`
- make upstream remote setup idempotent for fork clones
- stop hard-coding the fork default branch when cloning
- document the pre-created fork requirement in `CONTRIBUTING.md`

## Validation
- reproduced the pre-fix failure on `main`: run `24722363681` failed on `merge-upstream`
- validated the updated workflow on the branch: run `24722727851` completed successfully
- successful branch run confirmed the existing-fork flow works end to end and exited cleanly because `AGNTCY.shadictl` `0.1.1` is already up to date on `upstream/master`

Refs #69