### PR TITLE
fix(slim): adopt #1869 MLS fix; drop require_header_mac workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b5f6e36293bdb1f00cd9a11c4ef0620219d1a48a1e71cf0962538c39a9157"
+checksum = "251745c4bdc466c97b76ddbf24646e4951f9c8ef9ffeaf189a7440b136834918"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66113694cf5d85dc7768f77a0e6551431c45e5030ef1c263adabc18b23fd4ac"
+checksum = "a52b1d8d21542e2a93b03d522cd4d4b078407bff518f22440bc08c016618d571"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-service",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9acd36127fe01f3175795bd46e0f0ced9ced4a6dfaf56a2bdc3e08c4c09fd9"
+checksum = "41b98ca02a9e0d5239129100897e5e94c1aceb12ff38d5736e69623523c6821e"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8653a4fa636a752de62bd06a9a2faf5bd2b54a7c90c0ff33e06a5489e9fd7f90"
+checksum = "43e7091f9d845268746880829d5adfa311df70fe8e8b46e46e3c68b423ab67f0"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c230d21b7ff14b039ce0eef5fd9b5912d819fe6c0b21c653348c69ac400c13"
+checksum = "d2da3f6ff7aa525e6122cd94256758ffb2173d2f3826f94c2a715c1bdc2576a5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300285f29418c4860d1965bf4bb24ad091e9fc64ea0ceec015a75be7f03abe"
+checksum = "27977052e5632be864cc1a7c79b3363477e55cac17c5ce1ae5628ae862e69616"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb174b04bc4c03c1a36b9febedac279a051399a52e090bd96236a162cb277be2"
+checksum = "e49518aa0031c476830224bc133f6af354f5241ee0a1acca398d96d20b95499e"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432e81905ee835155199bc8c3b82378a9fa7e98b49a890df539efae43277c115"
+checksum = "182a3ee8b786612d5077d0d6c499a741932db874785e98d7d33e443cef459a81"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2245bddf34d2adb4b88ed3ae7f519234e8814cb77172befcbb361afd5442b1"
+checksum = "2792f4ee0962ac6658ee6cfe3af76d5d0af87f14303ff3bf0b99b5420f182dcc"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cef44142dc56469439ed3e5ef5c2aec41df026a0a9a82e267702519fa00aee9"
+checksum = "8cea5d59109d3996016323aef1a05e4fb49393dfdfe4515177a63c5bf2925e9a"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cacf0892e82d5deef34286441788a483f5f49bdfdb103584b128090c5199b3f"
+checksum = "8ba9f9d0ff0342914cebb2886fe6c052086015b07fafc38e84fd1f583b54052f"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3436a6202933b26de20a965c3d53d18b5201f7ef589a7023cee8697fc7f946d5"
+checksum = "123b71d61965341381948e5ac4a989f421a1f9b06ee879cd97b6326b79ac2c45"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289a5c0fcc673c1c7892a943900a4e2b12b57fc21584e0c655282d28e5b5db8f"
+checksum = "b1291fda899bb54b565fdfa447c2880fc9c1d48037948ccea3083c394e6e582f"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabfc55cd2966cb3ef605ca1dae3246cdf94ff7aa3b58ddcdc18403930ae5609"
+checksum = "29966bdaa2e170d2653c56233b717af02d777554128497cb6f3b30ea7b46beda"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa135cef8d8920ceb361b1c27f23636a6b3226fa3173726931339ddd18a4eae"
+checksum = "424fbe0dd7171dc6bf184fdc3a55df805058e9b69e5c63711d8bd484ef11125d"
 
 [[package]]
 name = "ahash"
@@ -2294,7 +2294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4022,7 +4022,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4748,7 +4748,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4998,7 +4998,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5374,7 +5374,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5433,7 +5433,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6156,7 +6156,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6165,7 +6165,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7282,7 +7282,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/agent_transport_slim/Cargo.toml
+++ b/crates/agent_transport_slim/Cargo.toml
@@ -15,4 +15,4 @@ slim = []
 
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }

--- a/crates/agent_transport_slim/src/native.rs
+++ b/crates/agent_transport_slim/src/native.rs
@@ -241,10 +241,6 @@ fn build_client_config() -> Result<ClientConfig, String> {
 fn build_client_config_for_endpoint(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
     let mut config = ClientConfig::default();
     config.endpoint = resolve_client_endpoint_value(endpoint);
-    // Pin require_header_mac=false to match the node MessageProcessor and avoid
-    // the rotating link-HMAC key gating the SLIM session handshake (mTLS +
-    // shared-secret already secure the transport).
-    config.require_header_mac = Some(false);
     config.tls = TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,
@@ -554,7 +550,6 @@ mod tests {
     fn build_test_server_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ServerConfig {
         let mut config = slim_bindings::ServerConfig::default();
         config.endpoint = endpoint.to_string();
-        config.require_header_mac = Some(false);
         config.tls = slim_bindings::TlsServerConfig {
             insecure: false,
             source: TlsSource::File {

--- a/crates/agent_transport_slim/tests/slim_stdio_bridge_bin.rs
+++ b/crates/agent_transport_slim/tests/slim_stdio_bridge_bin.rs
@@ -105,7 +105,6 @@ fn server_tls_material(base_dir: &Path) -> TlsMaterial {
 fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ClientConfig {
     let mut config = slim_bindings::ClientConfig::default();
     config.endpoint = format!("https://{endpoint}");
-    config.require_header_mac = Some(false);
     config.tls = slim_bindings::TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,
@@ -126,7 +125,6 @@ fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::Clie
 fn build_server_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ServerConfig {
     let mut config = slim_bindings::ServerConfig::default();
     config.endpoint = endpoint.to_string();
-    config.require_header_mac = Some(false);
     config.tls = slim_bindings::TlsServerConfig {
         insecure: false,
         source: slim_bindings::TlsSource::File {

--- a/crates/agent_transport_slim/tests/stdio_bridge_flow.rs
+++ b/crates/agent_transport_slim/tests/stdio_bridge_flow.rs
@@ -152,7 +152,6 @@ fn server_tls_material(base_dir: &Path) -> TlsMaterial {
 fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ClientConfig {
     let mut config = slim_bindings::ClientConfig::default();
     config.endpoint = format!("https://{endpoint}");
-    config.require_header_mac = Some(false);
     config.tls = slim_bindings::TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,
@@ -172,7 +171,6 @@ fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::Clie
 fn build_server_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ServerConfig {
     let mut config = slim_bindings::ServerConfig::default();
     config.endpoint = endpoint.to_string();
-    config.require_header_mac = Some(false);
     config.tls = slim_bindings::TlsServerConfig {
         insecure: false,
         source: TlsSource::File {

--- a/crates/agentbridge_cli/Cargo.toml
+++ b/crates/agentbridge_cli/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 agentbridge = { package = "agntcy-agentbridge", version = "0.1.0", path = "../agentbridge" }
 shadi_mas = { package = "agntcy-shadi-mas", version = "0.1.1", path = "../shadi_mas" }
 shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.1", path = "../shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.4" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -491,9 +491,6 @@ fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
     };
     let mut config = ClientConfig::default();
     config.endpoint = endpoint_url;
-    // Match the node MessageProcessor (require_header_mac=false) so the rotating
-    // link-HMAC key never gates the SLIM session handshake.
-    config.require_header_mac = Some(false);
     config.tls = TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,

--- a/crates/shadi_a2a/Cargo.toml
+++ b/crates/shadi_a2a/Cargo.toml
@@ -15,10 +15,10 @@ agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", pat
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
-a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.0" }
+a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.1" }
 async-trait = "0.1"
 futures = "0.3"
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/shadi_mas/Cargo.toml
+++ b/crates/shadi_mas/Cargo.toml
@@ -18,7 +18,7 @@ a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }
 agent_transport_slim = { package = "agntcy-shadi-agent-transport-slim", version = "0.1.2", path = "../agent_transport_slim" }
 shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.1", path = "../shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
 tokio = { version = "1", features = ["rt", "time"] }
 tracing = "0.1"
 

--- a/crates/shadi_mas/src/experiments/mod.rs
+++ b/crates/shadi_mas/src/experiments/mod.rs
@@ -303,9 +303,6 @@ fn readable_message_text(message: &Message) -> String {
 fn build_client_config_for_endpoint(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
     let mut config = ClientConfig::default();
     config.endpoint = resolve_client_endpoint_value(endpoint);
-    // Match the node MessageProcessor (require_header_mac=false); see SHADI's
-    // slim config builders.
-    config.require_header_mac = Some(false);
     config.tls = TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -25,8 +25,8 @@ shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.1", path = "../shadi_
 shadi_memory = { package = "agntcy-shadi-memory", version = "0.1.1", path = "../shadi_memory" }
 shadi_telemetry = { package = "agntcy-shadi-telemetry", version = "0.1.0", path = "../shadi_telemetry" }
 slim_mas = { package = "agntcy-shadi-slim-mas", version = "0.1.1", path = "../slim_mas" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.4" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bs58 = "0.5"

--- a/crates/shadictl/src/sandbox_snapshot.rs
+++ b/crates/shadictl/src/sandbox_snapshot.rs
@@ -1423,7 +1423,6 @@ mod tests {
     fn build_test_client_config(endpoint: &str, tls: &TestTlsMaterial) -> slim_bindings::ClientConfig {
         let mut config = slim_bindings::ClientConfig::default();
         config.endpoint = format!("https://{endpoint}");
-        config.require_header_mac = Some(false);
         config.tls = slim_bindings::TlsClientConfig {
             insecure: false,
             insecure_skip_verify: false,
@@ -1444,7 +1443,6 @@ mod tests {
     fn build_test_server_config(endpoint: &str, tls: &TestTlsMaterial) -> slim_bindings::ServerConfig {
         let mut config = slim_bindings::ServerConfig::default();
         config.endpoint = endpoint.to_string();
-        config.require_header_mac = Some(false);
         config.tls = slim_bindings::TlsServerConfig {
             insecure: false,
             source: slim_bindings::TlsSource::File {

--- a/crates/shadictl/src/slim_shell.rs
+++ b/crates/shadictl/src/slim_shell.rs
@@ -406,11 +406,6 @@ pub(crate) fn build_client_config_for_endpoint(endpoint: &str, tls: &TlsMaterial
         include_system_ca_certs_pool: false,
         tls_version: "tls1.3".to_string(),
     };
-    // slim-bindings' run_server builds the node MessageProcessor with
-    // require_header_mac=false, while the config default resolves to true. Pin
-    // both ends to false so the rotating link-HMAC key never gates the SLIM
-    // session handshake (mTLS + shared-secret already secure the transport).
-    config.require_header_mac = Some(false);
     config
 }
 
@@ -435,9 +430,6 @@ pub(crate) fn build_server_config_for_endpoint(endpoint: &str, tls: &TlsMaterial
         tls_version: Some("tls1.3".to_string()),
         reload_client_ca_file: Some(false),
     };
-    // Match the node MessageProcessor (require_header_mac=false); see the client
-    // config builder above.
-    config.require_header_mac = Some(false);
     config
 }
 

--- a/examples/shadi_demo_bot/Cargo.toml
+++ b/examples/shadi_demo_bot/Cargo.toml
@@ -15,8 +15,8 @@ async-trait = "0.1"
 shadi_memory = { package = "agntcy-shadi-memory", path = "../../crates/shadi_memory" }
 shadi_sandbox = { package = "agntcy-shadi-sandbox", path = "../../crates/shadi_sandbox" }
 shadi_a2a = { package = "agntcy-shadi-a2a", path = "../../crates/shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.6" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.4" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
 clap = { version = "4.6", features = ["derive", "env"] }
 ctrlc = "3.5"
 futures = "0.3"

--- a/examples/shadi_demo_bot/src/lib.rs
+++ b/examples/shadi_demo_bot/src/lib.rs
@@ -2052,9 +2052,6 @@ fn server_tls_material(base_dir: &Path) -> TlsMaterial {
 fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
     let mut config = ClientConfig::default();
     config.endpoint = format!("https://{}", endpoint);
-    // Match the node MessageProcessor (require_header_mac=false); see SHADI's
-    // slim config builders.
-    config.require_header_mac = Some(false);
     config.tls = TlsClientConfig {
         insecure: false,
         insecure_skip_verify: false,
@@ -2074,7 +2071,6 @@ fn build_client_config(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
 fn build_server_config(endpoint: &str, tls: &TlsMaterial) -> ServerConfig {
     let mut config = ServerConfig::default();
     config.endpoint = endpoint.to_string();
-    config.require_header_mac = Some(false);
     config.tls = TlsServerConfig {
         insecure: false,
         source: TlsSource::File {


### PR DESCRIPTION
Adopts the slim release carrying [agntcy/slim#1869](https://github.com/agntcy/slim/pull/1869) (mid-handshake MLS signing-key rotation fix) and removes the `require_header_mac = Some(false)` workaround now that the real cause is fixed upstream.

- `agntcy-slim-bindings` 2.0.0-alpha.6 → **2.0.0-alpha.7**
- `a2a-slimrpc` 0.2.0 → **0.2.1** (built against `agntcy-slim-auth 0.13`)
- `agntcy-slim-rpc` alpha.4 → **alpha.5** (pulls auth 0.13, datapath 0.16.5, service 0.11.4, mls 0.2.4, session 0.5.4)
- removes the 14 pinned `require_header_mac = Some(false)` sites → back to defaults

The intermittent `add participant to session: message send retries exhausted` flake was an MLS signing-key ciphersuite mismatch, **not** header MAC. All unit + slim integration tests pass locally (`slim_cli_integration` 15/15).