### PR TITLE
feat(identity): route remaining create_app sites through DID auth + moderator role UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "agntcy-agentbridge",
  "agntcy-shadi-a2a",
  "agntcy-shadi-agent-secrets",
+ "agntcy-shadi-identity",
  "agntcy-shadi-mas",
  "agntcy-slim-bindings",
  "agntcy-slim-rpc",
@@ -227,6 +228,7 @@ name = "agntcy-shadi-agent-transport-slim"
 version = "0.1.2"
 dependencies = [
  "agntcy-shadi-agent-secrets",
+ "agntcy-shadi-identity",
  "agntcy-slim-bindings",
 ]
 
@@ -298,6 +300,7 @@ dependencies = [
  "agntcy-shadi-a2a",
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-agent-transport-slim",
+ "agntcy-shadi-identity",
  "agntcy-slim-bindings",
  "serde",
  "serde_json",
@@ -5877,6 +5880,7 @@ dependencies = [
  "agntcy-shadi-a2a",
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-agent-transport-slim",
+ "agntcy-shadi-identity",
  "agntcy-shadi-memory",
  "agntcy-shadi-sandbox",
  "agntcy-slim-bindings",

--- a/crates/agent_transport_slim/Cargo.toml
+++ b/crates/agent_transport_slim/Cargo.toml
@@ -15,4 +15,5 @@ slim = []
 
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }
+shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
 slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }

--- a/crates/agent_transport_slim/src/native.rs
+++ b/crates/agent_transport_slim/src/native.rs
@@ -54,7 +54,8 @@ impl NativeSlimSession {
     pub fn from_env(bootstrap: NativeSlimBootstrap) -> Result<Self, String> {
         let local_name = resolve_local_name()?;
         let local_name_ref = Arc::new(parse_name(&local_name)?);
-        let shared_secret = resolve_shared_secret()?;
+        // DID derivation uses the app (last) component of the local name.
+        let agent_id = local_name.rsplit('/').next().unwrap_or(&local_name).to_string();
         let client_config = build_client_config()?;
         let service = Service::new(client_service_name());
 
@@ -67,8 +68,11 @@ impl NativeSlimSession {
             let connected_id = service.connect(client_config).map_err(format_slim_error)?;
             connection_id = Some(connected_id);
 
-            let created_app = service
-                .create_app_with_secret(local_name_ref.clone(), shared_secret)
+            let auth = match shadi_identity::did_auth_from_env(&agent_id) {
+                Some(result) => result.map_err(|e| e.to_string())?,
+                None => shadi_identity::SlimAuth::SharedSecret(resolve_shared_secret()?),
+            };
+            let created_app = shadi_identity::create_app(&service, local_name_ref.clone(), &auth)
                 .map_err(format_slim_error)?;
             created_app
                 .subscribe(local_name_ref.clone(), Some(connected_id))

--- a/crates/agentbridge_cli/Cargo.toml
+++ b/crates/agentbridge_cli/Cargo.toml
@@ -20,6 +20,7 @@ slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.7" }
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }
+shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
 async-trait = "0.1"
 futures = "0.3"
 anyhow = "1"

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -383,8 +383,11 @@ fn run_slim_listener(
         .map_err(|e| format!("SLIM connect failed: {e:?}"))?;
 
     let name_ref = Arc::new(parse_name(&agent_name)?);
-    let app = service
-        .create_app_with_secret(name_ref.clone(), shared_secret.to_string())
+    let auth = match shadi_identity::did_auth_from_env(agent_id) {
+        Some(result) => result.map_err(|e| format!("SLIM auth error: {e}"))?,
+        None => shadi_identity::SlimAuth::SharedSecret(shared_secret.to_string()),
+    };
+    let app = shadi_identity::create_app(&service, name_ref.clone(), &auth)
         .map_err(|e| format!("SLIM create_app failed: {e:?}"))?;
     app.subscribe(name_ref.clone(), Some(connection_id))
         .map_err(|e| format!("SLIM subscribe failed: {e:?}"))?;

--- a/crates/shadi_identity/src/auth.rs
+++ b/crates/shadi_identity/src/auth.rs
@@ -78,6 +78,53 @@ pub fn create_app(
     service.create_app(name, provider, verifier)
 }
 
+/// Build DID-JWT auth for `agent_id`: derive the agent key from `human_seed` (via
+/// SHADI's HKDF agent derivation) and trust the comma-separated `member_dids` as the
+/// allow-list. Pure (no environment access) so it is easy to unit-test.
+pub fn build_did_auth(
+    human_seed: &[u8],
+    member_dids: &str,
+    agent_id: &str,
+) -> Result<SlimAuth, IdentityError> {
+    let dids: Vec<&str> = member_dids
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if dids.is_empty() {
+        return Err(IdentityError::Config(
+            "member DID allow-list is empty".to_string(),
+        ));
+    }
+    let agent = AgentIdentity::derive(human_seed, agent_id)?;
+    SlimAuth::did(&agent, dids)
+}
+
+/// Resolve how `agent_id` should authenticate to the SLIM mesh, from the environment.
+///
+/// Returns `Some(..)` iff `SHADI_SLIM_AUTH=did`, in which case the agent key is
+/// derived from `SLIM_HUMAN_SEED` and the allow-list is `SLIM_MEMBER_DIDS`
+/// (comma-separated `did:key`s). Returns `None` for any other mode, signalling the
+/// caller to fall back to its own shared secret. This is the single env contract
+/// shared by every SHADI `create_app` site.
+pub fn did_auth_from_env(agent_id: &str) -> Option<Result<SlimAuth, IdentityError>> {
+    let mode = std::env::var("SHADI_SLIM_AUTH").unwrap_or_default();
+    if !mode.eq_ignore_ascii_case("did") {
+        return None;
+    }
+    Some(resolve_did_env(agent_id))
+}
+
+fn resolve_did_env(agent_id: &str) -> Result<SlimAuth, IdentityError> {
+    let human_seed = std::env::var("SLIM_HUMAN_SEED").map_err(|_| {
+        IdentityError::Config("SHADI_SLIM_AUTH=did requires SLIM_HUMAN_SEED".to_string())
+    })?;
+    let members = std::env::var("SLIM_MEMBER_DIDS").map_err(|_| {
+        IdentityError::Config("SHADI_SLIM_AUTH=did requires SLIM_MEMBER_DIDS".to_string())
+    })?;
+    build_did_auth(human_seed.as_bytes(), &members, agent_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,4 +160,49 @@ mod tests {
         assert!(matches!(v, IdentityVerifierConfig::Jwt { .. }));
     }
 
+    #[test]
+    fn build_did_auth_builds_did_for_members() {
+        let a = AgentIdentity::derive(b"seed", "agent-x").unwrap();
+        let p = AgentIdentity::derive(b"seed", "peer").unwrap();
+        let members = format!("{}, {}", a.did(), p.did());
+        let auth = build_did_auth(b"seed", &members, "agent-x").expect("did auth");
+        assert!(matches!(auth, SlimAuth::Did { .. }));
+    }
+
+    #[test]
+    fn build_did_auth_rejects_empty_and_invalid_members() {
+        assert!(matches!(
+            build_did_auth(b"seed", "  ,  ", "agent-x"),
+            Err(IdentityError::Config(_))
+        ));
+        assert!(build_did_auth(b"seed", "not-a-did-key", "agent-x").is_err());
+    }
+
+    #[test]
+    fn did_auth_from_env_selects_mode() {
+        // These env vars are touched by no other test in this crate, so a single
+        // sequential test needs no cross-test lock.
+        use std::env;
+        let member = AgentIdentity::derive(b"human", "avatar").unwrap().did();
+
+        env::remove_var("SHADI_SLIM_AUTH");
+        assert!(did_auth_from_env("avatar").is_none());
+
+        env::set_var("SHADI_SLIM_AUTH", "did");
+        env::set_var("SLIM_HUMAN_SEED", "human");
+        env::set_var("SLIM_MEMBER_DIDS", &member);
+        assert!(matches!(
+            did_auth_from_env("avatar"),
+            Some(Ok(SlimAuth::Did { .. }))
+        ));
+
+        env::remove_var("SLIM_HUMAN_SEED");
+        assert!(matches!(
+            did_auth_from_env("avatar"),
+            Some(Err(IdentityError::Config(_)))
+        ));
+
+        env::remove_var("SHADI_SLIM_AUTH");
+        env::remove_var("SLIM_MEMBER_DIDS");
+    }
 }

--- a/crates/shadi_identity/src/lib.rs
+++ b/crates/shadi_identity/src/lib.rs
@@ -20,7 +20,7 @@ use pkcs8::LineEnding;
 pub mod auth;
 pub mod config;
 
-pub use auth::{create_app, SlimAuth};
+pub use auth::{build_did_auth, create_app, did_auth_from_env, SlimAuth};
 
 /// Multicodec prefix for an Ed25519 public key (`0xed` varint-encoded).
 const ED25519_MULTICODEC: [u8; 2] = [0xed, 0x01];
@@ -30,6 +30,7 @@ pub enum IdentityError {
     KeyGen(String),
     Pkcs8(String),
     InvalidDid(String),
+    Config(String),
 }
 
 impl fmt::Display for IdentityError {
@@ -38,6 +39,7 @@ impl fmt::Display for IdentityError {
             IdentityError::KeyGen(e) => write!(f, "key generation failed: {e}"),
             IdentityError::Pkcs8(e) => write!(f, "PKCS#8 error: {e}"),
             IdentityError::InvalidDid(e) => write!(f, "invalid did:key: {e}"),
+            IdentityError::Config(e) => write!(f, "auth configuration error: {e}"),
         }
     }
 }

--- a/crates/shadi_mas/Cargo.toml
+++ b/crates/shadi_mas/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", path = "../agent_secrets" }
+shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
 agent_transport_slim = { package = "agntcy-shadi-agent-transport-slim", version = "0.1.2", path = "../agent_transport_slim" }
 shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.1", path = "../shadi_a2a" }
 slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }

--- a/crates/shadi_mas/src/experiments/mod.rs
+++ b/crates/shadi_mas/src/experiments/mod.rs
@@ -160,8 +160,13 @@ impl LiveA2ATaskAdapter {
                 let local_name_ref = Arc::new(parse_slim_name(&local_name)?);
                 let remote_name_ref = Arc::new(parse_slim_name(&destination)?);
 
-                let app = service
-                    .create_app_with_secret(local_name_ref.clone(), self.config.shared_secret.clone())
+                let auth = match shadi_identity::did_auth_from_env(&self.config.agent_id) {
+                    Some(result) => result.map_err(|e| e.to_string())?,
+                    None => {
+                        shadi_identity::SlimAuth::SharedSecret(self.config.shared_secret.clone())
+                    }
+                };
+                let app = shadi_identity::create_app(&service, local_name_ref.clone(), &auth)
                     .map_err(format_slim_error)?;
                 app.subscribe(local_name_ref.clone(), Some(connection_id))
                     .map_err(format_slim_error)?;

--- a/crates/shadictl/src/shell_command.rs
+++ b/crates/shadictl/src/shell_command.rs
@@ -419,6 +419,7 @@ impl Completer for ShellHelper {
                 "create",
                 "invite",
                 "join",
+                "whoami",
             ];
             for sub in subs {
                 if sub.starts_with(sub_input) {
@@ -602,9 +603,10 @@ impl ShellSession {
                 "create" => self.cmd_slim_create(&parts[2..]),
                 "invite" => self.cmd_slim_invite(&parts[2..]),
                 "join" => self.cmd_slim_join(&parts[2..]),
+                "whoami" => self.cmd_slim_whoami(),
                 _ => {
                     eprintln!("unknown slim subcommand: {}", parts[1]);
-                    eprintln!("  available: status, start node, a2a-echo-peer, a2a-send, create, invite, join");
+                    eprintln!("  available: status, start node, a2a-echo-peer, a2a-send, create, invite, join, whoami");
                     LoopAction::Continue
                 }
             },
@@ -1118,6 +1120,14 @@ impl ShellSession {
         match self.slim.invite_participant(args[0]) {
             Ok(message) => println!("{}", message),
             Err(err) => eprintln!("error inviting SLIM participant: {}", err),
+        }
+        LoopAction::Continue
+    }
+
+    fn cmd_slim_whoami(&mut self) -> LoopAction {
+        match self.slim.whoami() {
+            Ok(message) => println!("{}", message),
+            Err(err) => eprintln!("error resolving SLIM identity: {}", err),
         }
         LoopAction::Continue
     }

--- a/crates/shadictl/src/slim_shell.rs
+++ b/crates/shadictl/src/slim_shell.rs
@@ -137,15 +137,11 @@ impl SlimShellState {
 
         let local = self.local_name_string()?;
         let agent_id = self.agent_id()?;
-        Ok(match did_identity_for_display(&agent_id) {
-            Some((moderator_did, human)) => format!(
-                "created channel {channel_name} as moderator {local} ({moderator_did}){}",
-                human
-                    .map(|h| format!(" — human {h}"))
-                    .unwrap_or_default()
-            ),
-            None => format!("created group session for channel {channel_name} as {local}"),
-        })
+        Ok(format_create_channel_message(
+            &channel_name.to_string(),
+            &local,
+            did_identity_for_display(&agent_id),
+        ))
     }
 
     pub(crate) fn invite_participant(&mut self, participant: &str) -> Result<String, String> {
@@ -167,12 +163,11 @@ impl SlimShellState {
             .clone()
             .unwrap_or_else(|| "<unknown>".to_string());
         let agent_id = self.agent_id()?;
-        Ok(match did_identity_for_display(&agent_id) {
-            Some((moderator_did, _)) => {
-                format!("invited {participant_name} to {channel} (moderator {moderator_did})")
-            }
-            None => format!("invited {participant_name} to {channel}"),
-        })
+        Ok(format_invite_message(
+            &participant_name.to_string(),
+            &channel,
+            did_identity_for_display(&agent_id),
+        ))
     }
 
     pub(crate) fn join_group_session(
@@ -618,6 +613,36 @@ fn did_identity_for_display(agent_id: &str) -> Option<(String, Option<String>)> 
     Some((agent.did(), human))
 }
 
+/// Format the `create-channel` result: moderator DID (+ human DID) under DID auth,
+/// legacy text under shared-secret. Pure so the role-visible output is unit-tested.
+fn format_create_channel_message(
+    channel: &str,
+    local: &str,
+    did: Option<(String, Option<String>)>,
+) -> String {
+    match did {
+        Some((moderator_did, human)) => format!(
+            "created channel {channel} as moderator {local} ({moderator_did}){}",
+            human.map(|h| format!(" — human {h}")).unwrap_or_default()
+        ),
+        None => format!("created group session for channel {channel} as {local}"),
+    }
+}
+
+/// Format the `invite` result: annotate with the moderator DID under DID auth.
+fn format_invite_message(
+    participant: &str,
+    channel: &str,
+    did: Option<(String, Option<String>)>,
+) -> String {
+    match did {
+        Some((moderator_did, _)) => {
+            format!("invited {participant} to {channel} (moderator {moderator_did})")
+        }
+        None => format!("invited {participant} to {channel}"),
+    }
+}
+
 fn client_identity_candidates(base_dir: &Path, agent_id: Option<&str>) -> Vec<(PathBuf, PathBuf)> {
     let mut candidates = Vec::new();
 
@@ -781,6 +806,48 @@ mod tests {
         let _guard = lock_env();
         let _auth = ScopedEnvVar::unset("SHADI_SLIM_AUTH");
         assert!(did_identity_for_display("avatar").is_none());
+    }
+
+    #[test]
+    fn format_create_channel_message_covers_all_modes() {
+        // Shared-secret: legacy text, no DID.
+        assert_eq!(
+            format_create_channel_message("agntcy/shadi/room", "agntcy/shadi/avatar", None),
+            "created group session for channel agntcy/shadi/room as agntcy/shadi/avatar"
+        );
+        // DID, no human DID.
+        let did = format_create_channel_message(
+            "agntcy/shadi/room",
+            "agntcy/shadi/avatar",
+            Some(("did:key:zMOD".to_string(), None)),
+        );
+        assert!(did.contains("as moderator agntcy/shadi/avatar (did:key:zMOD)"), "{did}");
+        assert!(!did.contains("human"), "{did}");
+        // DID + human DID.
+        let both = format_create_channel_message(
+            "agntcy/shadi/room",
+            "agntcy/shadi/avatar",
+            Some(("did:key:zMOD".to_string(), Some("did:key:zHUMAN".to_string()))),
+        );
+        assert!(both.contains("(did:key:zMOD)"), "{both}");
+        assert!(both.contains("human did:key:zHUMAN"), "{both}");
+    }
+
+    #[test]
+    fn format_invite_message_covers_all_modes() {
+        assert_eq!(
+            format_invite_message("agntcy/shadi/secops-a", "agntcy/shadi/room", None),
+            "invited agntcy/shadi/secops-a to agntcy/shadi/room"
+        );
+        let did = format_invite_message(
+            "agntcy/shadi/secops-a",
+            "agntcy/shadi/room",
+            Some(("did:key:zMOD".to_string(), Some("did:key:zHUMAN".to_string()))),
+        );
+        assert_eq!(
+            did,
+            "invited agntcy/shadi/secops-a to agntcy/shadi/room (moderator did:key:zMOD)"
+        );
     }
 
     #[test]

--- a/crates/shadictl/src/slim_shell.rs
+++ b/crates/shadictl/src/slim_shell.rs
@@ -14,6 +14,24 @@ const DEFAULT_LOCAL_NAMESPACE: &str = "shadi";
 const DEFAULT_LOCAL_APP: &str = "agent";
 const DEFAULT_SHARED_SECRET_KEY: &str = "secops/slim_shared_secret";
 
+/// Membership role in the active SLIM group session.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlimRole {
+    /// Created the channel and invites members (bound to a human identity under DID auth).
+    Moderator,
+    /// Joined a channel created by a moderator.
+    Participant,
+}
+
+impl SlimRole {
+    fn as_str(self) -> &'static str {
+        match self {
+            SlimRole::Moderator => "moderator",
+            SlimRole::Participant => "participant",
+        }
+    }
+}
+
 pub(crate) struct SlimShellState {
     node_service: Option<Service>,
     client_service: Option<Service>,
@@ -25,6 +43,7 @@ pub(crate) struct SlimShellState {
     active_channel: Option<String>,
     subscribed_channel: Option<String>,
     node_started: bool,
+    role: Option<SlimRole>,
 }
 
 pub(crate) struct SlimStatus {
@@ -56,6 +75,7 @@ impl SlimShellState {
             active_channel: None,
             subscribed_channel: None,
             node_started: false,
+            role: None,
         }
     }
 
@@ -113,12 +133,19 @@ impl SlimShellState {
             .map_err(format_slim_error)?;
 
         self.replace_active_session(app, session, channel_name.to_string())?;
+        self.role = Some(SlimRole::Moderator);
 
-        Ok(format!(
-            "created group session for channel {} as {}",
-            channel_name,
-            self.local_name_string()?
-        ))
+        let local = self.local_name_string()?;
+        let agent_id = self.agent_id()?;
+        Ok(match did_identity_for_display(&agent_id) {
+            Some((moderator_did, human)) => format!(
+                "created channel {channel_name} as moderator {local} ({moderator_did}){}",
+                human
+                    .map(|h| format!(" — human {h}"))
+                    .unwrap_or_default()
+            ),
+            None => format!("created group session for channel {channel_name} as {local}"),
+        })
     }
 
     pub(crate) fn invite_participant(&mut self, participant: &str) -> Result<String, String> {
@@ -139,7 +166,13 @@ impl SlimShellState {
             .active_channel
             .clone()
             .unwrap_or_else(|| "<unknown>".to_string());
-        Ok(format!("invited {} to {}", participant_name, channel))
+        let agent_id = self.agent_id()?;
+        Ok(match did_identity_for_display(&agent_id) {
+            Some((moderator_did, _)) => {
+                format!("invited {participant_name} to {channel} (moderator {moderator_did})")
+            }
+            None => format!("invited {participant_name} to {channel}"),
+        })
     }
 
     pub(crate) fn join_group_session(
@@ -165,6 +198,7 @@ impl SlimShellState {
         }
 
         self.replace_active_session(app, session, actual_name.clone())?;
+        self.role = Some(SlimRole::Participant);
 
         Ok(format!(
             "joined group session for channel {} as {}",
@@ -234,10 +268,13 @@ impl SlimShellState {
 
         let connection_id = self.ensure_connection()?;
         let local_name = self.local_name()?;
-        let shared_secret = self.shared_secret()?;
-        let app = self
-            .client_service_mut()
-            .create_app_with_secret(local_name.clone(), shared_secret)
+        // DID derivation uses the app (last) component of the local name as the agent id.
+        let agent_id = local_name.components().last().cloned().unwrap_or_default();
+        let auth = match shadi_identity::did_auth_from_env(&agent_id) {
+            Some(result) => result.map_err(|e| e.to_string())?,
+            None => shadi_identity::SlimAuth::SharedSecret(self.shared_secret()?),
+        };
+        let app = shadi_identity::create_app(self.client_service_mut(), local_name.clone(), &auth)
             .map_err(format_slim_error)?;
 
         app.subscribe(local_name, Some(connection_id))
@@ -294,6 +331,31 @@ impl SlimShellState {
 
     fn local_name_string(&mut self) -> Result<String, String> {
         Ok(self.local_name()?.to_string())
+    }
+
+    /// Agent id used for DID derivation: the app (last) component of the local name.
+    fn agent_id(&mut self) -> Result<String, String> {
+        Ok(self
+            .local_name()?
+            .components()
+            .last()
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// Report this agent's identity and role: agent name, auth mode, session role,
+    /// and (under DID auth) its derived DID plus the human DID it belongs to.
+    pub(crate) fn whoami(&mut self) -> Result<String, String> {
+        let local = self.local_name_string()?;
+        let agent_id = self.agent_id()?;
+        let role = self.role.map(SlimRole::as_str).unwrap_or("none");
+        Ok(match did_identity_for_display(&agent_id) {
+            Some((did, human)) => format!(
+                "agent {local}\n  auth:  did\n  role:  {role}\n  did:   {did}\n  human: {}",
+                human.unwrap_or_else(|| "<unset SLIM_HUMAN_DID>".to_string())
+            ),
+            None => format!("agent {local}\n  auth:  shared-secret\n  role:  {role}"),
+        })
     }
 
     fn shared_secret(&mut self) -> Result<String, String> {
@@ -525,43 +587,35 @@ pub(crate) fn resolve_default_shared_secret() -> Result<String, String> {
 
 /// Resolve how this agent authenticates to the SLIM mesh.
 ///
-/// `SHADI_SLIM_AUTH=did` selects DID-JWT admission: the agent's key is derived
-/// from the human root secret (`SLIM_HUMAN_SEED`) via SHADI's HKDF agent
-/// derivation, and the allow-list is `SLIM_MEMBER_DIDS` (comma-separated
-/// `did:key`s). Anything else (default) uses the shared-secret mesh key.
+/// `SHADI_SLIM_AUTH=did` selects DID-JWT admission (agent key derived from
+/// `SLIM_HUMAN_SEED`, allow-list `SLIM_MEMBER_DIDS`); anything else uses the
+/// shared-secret mesh key. The DID env contract lives in
+/// [`shadi_identity::did_auth_from_env`], shared by every SHADI create_app site.
 pub(crate) fn resolve_slim_auth(agent_id: &str) -> Result<shadi_identity::SlimAuth, String> {
-    let mode = std::env::var("SHADI_SLIM_AUTH").unwrap_or_else(|_| "shared-secret".to_string());
-    if mode.eq_ignore_ascii_case("did") {
-        let human_seed = std::env::var("SLIM_HUMAN_SEED")
-            .map_err(|_| "SHADI_SLIM_AUTH=did requires SLIM_HUMAN_SEED".to_string())?;
-        let members = std::env::var("SLIM_MEMBER_DIDS")
-            .map_err(|_| "SHADI_SLIM_AUTH=did requires SLIM_MEMBER_DIDS".to_string())?;
-        build_did_auth(human_seed.as_bytes(), &members, agent_id)
-    } else {
-        Ok(shadi_identity::SlimAuth::SharedSecret(
+    match shadi_identity::did_auth_from_env(agent_id) {
+        Some(result) => result.map_err(|e| e.to_string()),
+        None => Ok(shadi_identity::SlimAuth::SharedSecret(
             resolve_default_shared_secret()?,
-        ))
+        )),
     }
 }
 
-/// Build DID-JWT auth for `agent_id`: derive the agent key from `human_seed` and
-/// trust the comma-separated `member_dids` allow-list. Pure (no env) for testing.
-fn build_did_auth(
-    human_seed: &[u8],
-    member_dids: &str,
-    agent_id: &str,
-) -> Result<shadi_identity::SlimAuth, String> {
-    let dids: Vec<&str> = member_dids
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .collect();
-    if dids.is_empty() {
-        return Err("SLIM_MEMBER_DIDS is empty".to_string());
+/// The DID identity to display for `agent_id` when DID auth is active: its derived
+/// `did:key` plus the human DID it belongs to (`SLIM_HUMAN_DID`, optional). Returns
+/// `None` under shared-secret auth, so callers keep their legacy output.
+fn did_identity_for_display(agent_id: &str) -> Option<(String, Option<String>)> {
+    if !std::env::var("SHADI_SLIM_AUTH")
+        .unwrap_or_default()
+        .eq_ignore_ascii_case("did")
+    {
+        return None;
     }
-    let agent =
-        shadi_identity::AgentIdentity::derive(human_seed, agent_id).map_err(|e| e.to_string())?;
-    shadi_identity::SlimAuth::did(&agent, dids).map_err(|e| e.to_string())
+    let seed = std::env::var("SLIM_HUMAN_SEED").ok()?;
+    let agent = shadi_identity::AgentIdentity::derive(seed.as_bytes(), agent_id).ok()?;
+    let human = std::env::var("SLIM_HUMAN_DID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    Some((agent.did(), human))
 }
 
 fn client_identity_candidates(base_dir: &Path, agent_id: Option<&str>) -> Vec<(PathBuf, PathBuf)> {
@@ -672,21 +726,6 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn build_did_auth_builds_did_slim_auth_for_members() {
-        let a = shadi_identity::AgentIdentity::derive(b"seed", "agent-x").unwrap();
-        let p = shadi_identity::AgentIdentity::derive(b"seed", "peer").unwrap();
-        let members = format!("{}, {}", a.did(), p.did());
-        let auth = build_did_auth(b"seed", &members, "agent-x").expect("did auth");
-        assert!(matches!(auth, shadi_identity::SlimAuth::Did { .. }));
-    }
-
-    #[test]
-    fn build_did_auth_rejects_empty_and_invalid_members() {
-        assert!(build_did_auth(b"seed", "  ,  ", "agent-x").is_err());
-        assert!(build_did_auth(b"seed", "not-a-did-key", "agent-x").is_err());
-    }
-
     #[cfg(not(windows))]
     const TEST_SHARED_SECRET: &str = "my_shared_secret_for_testing_purposes_only";
 
@@ -720,6 +759,60 @@ mod tests {
                 None => std::env::remove_var(self.name),
             }
         }
+    }
+
+    #[test]
+    fn did_identity_for_display_selects_did_mode() {
+        let _guard = lock_env();
+        let _auth = ScopedEnvVar::set("SHADI_SLIM_AUTH", "did");
+        let _seed = ScopedEnvVar::set("SLIM_HUMAN_SEED", "human-root");
+        let _human = ScopedEnvVar::set("SLIM_HUMAN_DID", "did:key:zHUMAN");
+
+        let (did, human) = did_identity_for_display("avatar").expect("did identity");
+        assert!(did.starts_with("did:key:z"));
+        assert_eq!(human.as_deref(), Some("did:key:zHUMAN"));
+        // Deterministic, and name-scoped.
+        assert_eq!(did_identity_for_display("avatar").unwrap().0, did);
+        assert_ne!(did_identity_for_display("secops-a").unwrap().0, did);
+    }
+
+    #[test]
+    fn did_identity_for_display_none_under_shared_secret() {
+        let _guard = lock_env();
+        let _auth = ScopedEnvVar::unset("SHADI_SLIM_AUTH");
+        assert!(did_identity_for_display("avatar").is_none());
+    }
+
+    #[test]
+    fn whoami_reports_moderator_did_and_human() {
+        let _guard = lock_env();
+        let _custom = ScopedEnvVar::unset("SHADI_SLIM_LOCAL_NAME");
+        let _agent = ScopedEnvVar::set("SHADI_AGENT_ID", "avatar");
+        let _auth = ScopedEnvVar::set("SHADI_SLIM_AUTH", "did");
+        let _seed = ScopedEnvVar::set("SLIM_HUMAN_SEED", "human-root");
+        let _human = ScopedEnvVar::set("SLIM_HUMAN_DID", "did:key:zHUMAN");
+
+        let mut state = SlimShellState::new();
+        state.role = Some(SlimRole::Moderator);
+        let out = state.whoami().expect("whoami");
+        assert!(out.contains("role:  moderator"), "{out}");
+        assert!(out.contains("auth:  did"), "{out}");
+        assert!(out.contains("did:key:zHUMAN"), "{out}");
+        assert!(out.contains("agntcy/shadi/avatar"), "{out}");
+    }
+
+    #[test]
+    fn whoami_shared_secret_has_no_did_lines() {
+        let _guard = lock_env();
+        let _custom = ScopedEnvVar::unset("SHADI_SLIM_LOCAL_NAME");
+        let _agent = ScopedEnvVar::set("SHADI_AGENT_ID", "avatar");
+        let _auth = ScopedEnvVar::unset("SHADI_SLIM_AUTH");
+
+        let mut state = SlimShellState::new();
+        let out = state.whoami().expect("whoami");
+        assert!(out.contains("auth:  shared-secret"), "{out}");
+        assert!(out.contains("role:  none"), "{out}");
+        assert!(!out.contains("did:key:"), "{out}");
     }
 
     struct TestDir {

--- a/examples/shadi_demo_bot/Cargo.toml
+++ b/examples/shadi_demo_bot/Cargo.toml
@@ -10,12 +10,13 @@ a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", path = "../../crates/agent_secrets" }
+shadi_identity = { package = "agntcy-shadi-identity", path = "../../crates/shadi_identity" }
 agent_transport_slim = { package = "agntcy-shadi-agent-transport-slim", path = "../../crates/agent_transport_slim" }
 async-trait = "0.1"
 shadi_memory = { package = "agntcy-shadi-memory", path = "../../crates/shadi_memory" }
 shadi_sandbox = { package = "agntcy-shadi-sandbox", path = "../../crates/shadi_sandbox" }
 shadi_a2a = { package = "agntcy-shadi-a2a", path = "../../crates/shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.7" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
 slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
 clap = { version = "4.6", features = ["derive", "env"] }
 ctrlc = "3.5"

--- a/examples/shadi_demo_bot/src/lib.rs
+++ b/examples/shadi_demo_bot/src/lib.rs
@@ -1352,8 +1352,11 @@ fn run_slim_echo_peer(args: SlimEchoPeerArgs) -> Result<(), String> {
         .connect(build_client_config(&args.endpoint, &client_tls))
         .map_err(format_slim_error)?;
     let peer_name_ref = Arc::new(parse_name(&peer_name)?);
-    let app = service
-        .create_app_with_secret(peer_name_ref.clone(), args.shared_secret.clone())
+    let auth = match shadi_identity::did_auth_from_env(peer_name.rsplit('/').next().unwrap_or(&peer_name)) {
+        Some(result) => result.map_err(|e| e.to_string())?,
+        None => shadi_identity::SlimAuth::SharedSecret(args.shared_secret.clone()),
+    };
+    let app = shadi_identity::create_app(&service, peer_name_ref.clone(), &auth)
         .map_err(format_slim_error)?;
     app.subscribe(peer_name_ref.clone(), Some(connection_id))
         .map_err(format_slim_error)?;
@@ -1413,8 +1416,11 @@ fn run_a2a_echo_peer(args: A2AEchoPeerArgs) -> Result<(), String> {
         .connect(build_client_config(&args.endpoint, &client_tls))
         .map_err(format_slim_error)?;
     let peer_name_ref = Arc::new(parse_name(&peer_name)?);
-    let app = service
-        .create_app_with_secret(peer_name_ref.clone(), args.shared_secret.clone())
+    let auth = match shadi_identity::did_auth_from_env(peer_name.rsplit('/').next().unwrap_or(&peer_name)) {
+        Some(result) => result.map_err(|e| e.to_string())?,
+        None => shadi_identity::SlimAuth::SharedSecret(args.shared_secret.clone()),
+    };
+    let app = shadi_identity::create_app(&service, peer_name_ref.clone(), &auth)
         .map_err(format_slim_error)?;
     app.subscribe(peer_name_ref.clone(), Some(connection_id))
         .map_err(format_slim_error)?;
@@ -1523,8 +1529,11 @@ fn run_a2a_send_once(args: &A2ASendArgs) -> Result<String, String> {
         .map_err(format_slim_error)?;
     let local_name_ref = Arc::new(parse_name(&local_name)?);
     let remote_name_ref = Arc::new(parse_name(&destination)?);
-    let app = service
-        .create_app_with_secret(local_name_ref.clone(), args.shared_secret.clone())
+    let auth = match shadi_identity::did_auth_from_env(local_name.rsplit('/').next().unwrap_or(&local_name)) {
+        Some(result) => result.map_err(|e| e.to_string())?,
+        None => shadi_identity::SlimAuth::SharedSecret(args.shared_secret.clone()),
+    };
+    let app = shadi_identity::create_app(&service, local_name_ref.clone(), &auth)
         .map_err(format_slim_error)?;
     app.subscribe(local_name_ref.clone(), Some(connection_id))
         .map_err(format_slim_error)?;


### PR DESCRIPTION
Follow-up to #94.

## 1. Route remaining create_app sites through DID auth
Promotes the env-based auth resolver into `shadi_identity`:
- `build_did_auth(human_seed, member_dids, agent_id)` (moved from shadictl)
- `did_auth_from_env(agent_id)` — the single `SHADI_SLIM_AUTH=did` contract (derive agent key from `SLIM_HUMAN_SEED`, allow-list `SLIM_MEMBER_DIDS`); `None` ⇒ caller uses its own shared secret.

The remaining production `create_app_with_secret` sites now go through `shadi_identity::create_app`, so they can join a DID mesh: shadictl `ensure_app`, `agentbridge_cli` register, `shadi_mas` experiments, `agent_transport_slim` native, `shadi_demo_bot`. Shared-secret remains the default — **no behavior change** unless `SHADI_SLIM_AUTH=did`. shadictl's `resolve_slim_auth` delegates to the shared resolver (dropping its local copy).

## 2. Layer B — moderator role + role-visible shell UX
- `SlimShellState` tracks a role: **Moderator** on `/slim create-channel`, **Participant** on `/slim join`.
- Under DID auth, `/slim create-channel` and `/slim invite` show the moderator's derived `did:key` and — when `SLIM_HUMAN_DID` is set — the human DID it belongs to.
- New `/slim whoami`: agent name, auth mode, role, moderator/agent DID, human DID.
- Shared-secret output is unchanged.

## Notes
- Adds `IdentityError::Config`.
- Deferred (out of scope): non-interactive `shadictl slim create-channel/invite` CLI; populating `SessionContext.did` from the verified slim peer (needs upstream slim to expose peer identity).

## Test
- `shadi_identity`: `did_auth_from_env` (did / shared-secret / missing-seed) + `build_did_auth`.
- `slim_shell`: `did_identity_for_display` + `whoami` (moderator DID + human DID; shared-secret has no DID lines).
- Full slim integration suite green: shared-secret round-trips + `given_did_auth_when_member_peer_and_sender_run_then_round_trip_succeeds`. 662 shadictl unit + 19 shadi_identity tests pass; workspace builds.