### PR TITLE
feat(slim): DID agent-group demo + A2A Collaborate group messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d545d197cdb4c6763f19893bed7a345b91cea0179998960665a617dacec66f9"
+checksum = "a27ea4381d43e12a146d7851883c7ca36f4f9241bb5471f7d0ff79e501a7881a"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -106,6 +106,8 @@ dependencies = [
  "futures",
  "prost 0.14.3",
  "prost-types",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -198,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-a2a"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -206,6 +208,7 @@ dependencies = [
  "a2a-slimrpc",
  "agntcy-shadi-agent-secrets",
  "agntcy-slim-bindings",
+ "async-stream",
  "async-trait",
  "futures",
  "tokio",

--- a/crates/shadi_a2a/Cargo.toml
+++ b/crates/shadi_a2a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agntcy-shadi-a2a"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.88"
 description = "A2A channel support for SHADI over SLIMRPC."
@@ -15,7 +15,8 @@ agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.1.1", pat
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
-a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.2" }
+a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.3" }
+async-stream = "0.3"
 async-trait = "0.1"
 futures = "0.3"
 slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }

--- a/crates/shadi_a2a/src/channel.rs
+++ b/crates/shadi_a2a/src/channel.rs
@@ -78,6 +78,95 @@ impl A2AChannelBuilder {
     }
 }
 
+/// A many-to-many A2A channel over a SLIM **group** session, guarded by the same
+/// SHADI identity verification as [`A2AChannel`]. Exposes `Collaborate` (see the
+/// SLIMRPC collaborative channel extension spec) rather than the point-to-point
+/// `Transport` trait, since a group broadcast has no single "response" shape.
+pub struct A2AGroupChannel {
+    transport: SlimRpcTransport,
+    verifier: Arc<dyn AgentVerifier>,
+    ctx: SessionContext,
+}
+
+impl A2AGroupChannel {
+    fn check_auth(&self) -> Result<(), A2AError> {
+        self.verifier.verify(&self.ctx).map_err(secret_err_to_a2a)
+    }
+
+    /// Open a `Collaborate` session on the group: broadcast every `Message`
+    /// produced by `outbound`, and yield every `Message` broadcast by other
+    /// members (each attributed via `metadata["slim-src"]`). Runs the same
+    /// identity check as [`A2AChannel`]'s calls, once, before delegating.
+    pub fn collaborate(
+        &self,
+        outbound: impl futures::Stream<Item = Message> + Send + 'static,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<BoxStream<'static, Result<Message, A2AError>>, A2AError> {
+        self.check_auth()?;
+        // `SlimRpcTransport::collaborate` borrows `&self` (its `impl Stream` return
+        // captures the transport's lifetime), so own a clone inside the returned
+        // stream to satisfy this method's `'static` signature — same fix as the
+        // P2P streaming path (`call_unary_stream` in a2a-slimrpc's client.rs).
+        let transport = self.transport.clone();
+        Ok(Box::pin(async_stream::stream! {
+            let inner = transport.collaborate(outbound, timeout);
+            futures::pin_mut!(inner);
+            while let Some(item) = futures::StreamExt::next(&mut inner).await {
+                yield item;
+            }
+        }))
+    }
+}
+
+/// Builder for [`A2AGroupChannel`] backed by a SLIM group session spanning
+/// `members`. Separate from [`A2AChannelBuilder`] because a group has no single
+/// "remote" peer.
+pub struct A2AGroupChannelBuilder {
+    app: Arc<App>,
+    members: Vec<Arc<Name>>,
+    connection_id: Option<u64>,
+    verifier: Arc<dyn AgentVerifier>,
+    ctx: SessionContext,
+}
+
+impl A2AGroupChannelBuilder {
+    pub fn new(
+        app: Arc<App>,
+        members: Vec<Arc<Name>>,
+        verifier: Arc<dyn AgentVerifier>,
+        ctx: SessionContext,
+    ) -> Self {
+        Self {
+            app,
+            members,
+            connection_id: None,
+            verifier,
+            ctx,
+        }
+    }
+
+    pub fn connection_id(mut self, id: u64) -> Self {
+        self.connection_id = Some(id);
+        self
+    }
+
+    pub fn build(self) -> Result<A2AGroupChannel, A2AError> {
+        let members = self
+            .members
+            .iter()
+            .map(|name| Arc::new(name.as_slim_name()))
+            .collect();
+        let transport =
+            SlimRpcTransport::new_group_with_connection(self.app.inner(), members, self.connection_id)
+                .map_err(|error| a2a_slimrpc::errors::rpc_error_to_a2a_error(&error))?;
+        Ok(A2AGroupChannel {
+            transport,
+            verifier: self.verifier,
+            ctx: self.ctx,
+        })
+    }
+}
+
 #[async_trait]
 impl Transport for A2AChannel {
     async fn send_message(

--- a/crates/shadi_a2a/src/lib.rs
+++ b/crates/shadi_a2a/src/lib.rs
@@ -3,5 +3,5 @@
 
 mod channel;
 
-pub use channel::{A2AChannel, A2AChannelBuilder};
-pub use a2a_slimrpc::SlimRpcHandler;
+pub use channel::{A2AChannel, A2AChannelBuilder, A2AGroupChannel, A2AGroupChannelBuilder};
+pub use a2a_slimrpc::{SLIM_SRC_METADATA_KEY, SlimRpcHandler, register_collaborate};

--- a/crates/shadictl/src/cli_types.rs
+++ b/crates/shadictl/src/cli_types.rs
@@ -213,6 +213,11 @@ pub(crate) enum SlimCommand {
         about = "Send a unary or streaming A2A request over SLIMRPC"
     )]
     A2ASend(SlimA2ASendArgs),
+    #[command(
+        name = "a2a-collaborate",
+        about = "Broadcast an A2A message to a SLIM group channel and listen for others' (Collaborate)"
+    )]
+    A2ACollaborate(SlimA2ACollaborateArgs),
 }
 
 #[derive(clap::Args, Clone, Debug)]
@@ -258,6 +263,25 @@ pub(crate) struct SlimA2ASendArgs {
 
     #[arg(long, default_value = "shadictl-a2a-session")]
     pub(crate) session_id: String,
+}
+
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct SlimA2ACollaborateArgs {
+    #[arg(long, env = "SLIM_ENDPOINT", value_name = "ENDPOINT")]
+    pub(crate) endpoint: Option<String>,
+
+    #[arg(long, env = "SHADI_AGENT_ID", default_value = "avatar")]
+    pub(crate) agent_id: String,
+
+    /// Comma-separated agent ids of the other group members.
+    #[arg(long, value_name = "ID1,ID2,...")]
+    pub(crate) peer_agent_ids: String,
+
+    #[arg(long, default_value = "hello from SHADI A2A")]
+    pub(crate) message: String,
+
+    #[arg(long, default_value_t = 20)]
+    pub(crate) timeout_seconds: u64,
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/shadictl/src/main.rs
+++ b/crates/shadictl/src/main.rs
@@ -238,6 +238,13 @@ fn run_slim_command(command: SlimCli) -> ExitCode {
                 ExitCode::from(1)
             }
         },
+        SlimCommand::A2ACollaborate(args) => match slim_a2a::run_a2a_collaborate(args) {
+            Ok(()) => ExitCode::from(0),
+            Err(err) => {
+                eprintln!("{}", err);
+                ExitCode::from(1)
+            }
+        },
     }
 }
 

--- a/crates/shadictl/src/shell_command.rs
+++ b/crates/shadictl/src/shell_command.rs
@@ -416,12 +416,11 @@ impl Completer for ShellHelper {
                 "start",
                 "a2a-echo-peer",
                 "a2a-send",
+                "a2a-collaborate",
                 "create",
                 "invite",
                 "join",
                 "whoami",
-                "send",
-                "recv",
             ];
             for sub in subs {
                 if sub.starts_with(sub_input) {
@@ -602,15 +601,16 @@ impl ShellSession {
                 }
                 "a2a-echo-peer" => self.cmd_slim_a2a_echo_peer(&parts[2..]),
                 "a2a-send" => self.cmd_slim_a2a_send(&parts[2..]),
+                "a2a-collaborate" => self.cmd_slim_a2a_collaborate(&parts[2..]),
                 "create" => self.cmd_slim_create(&parts[2..]),
                 "invite" => self.cmd_slim_invite(&parts[2..]),
                 "join" => self.cmd_slim_join(&parts[2..]),
                 "whoami" => self.cmd_slim_whoami(),
-                "send" => self.cmd_slim_send(&parts[2..]),
-                "recv" => self.cmd_slim_recv(&parts[2..]),
                 _ => {
                     eprintln!("unknown slim subcommand: {}", parts[1]);
-                    eprintln!("  available: status, start node, a2a-echo-peer, a2a-send, create, invite, join, whoami, send, recv");
+                    eprintln!(
+                        "  available: status, start node, a2a-echo-peer, a2a-send, a2a-collaborate, create, invite, join, whoami"
+                    );
                     LoopAction::Continue
                 }
             },
@@ -1102,6 +1102,18 @@ impl ShellSession {
         LoopAction::Continue
     }
 
+    fn cmd_slim_a2a_collaborate(&mut self, args: &[&str]) -> LoopAction {
+        match slim_a2a::parse_shell_a2a_collaborate_args(args) {
+            Ok(parsed) => {
+                if let Err(err) = slim_a2a::run_a2a_collaborate(parsed) {
+                    eprintln!("error collaborating over A2A: {}", err);
+                }
+            }
+            Err(err) => eprintln!("{}", err),
+        }
+        LoopAction::Continue
+    }
+
     fn cmd_slim_create(&mut self, args: &[&str]) -> LoopAction {
         if args.len() != 1 {
             eprintln!("usage: /slim create <organization/namespace/application>");
@@ -1132,49 +1144,6 @@ impl ShellSession {
         match self.slim.whoami() {
             Ok(message) => println!("{}", message),
             Err(err) => eprintln!("error resolving SLIM identity: {}", err),
-        }
-        LoopAction::Continue
-    }
-
-    fn cmd_slim_send(&mut self, args: &[&str]) -> LoopAction {
-        if args.is_empty() {
-            eprintln!("usage: /slim send <message ...>");
-            return LoopAction::Continue;
-        }
-        let text = args.join(" ");
-        match self.slim.send_group_message(&text) {
-            Ok(message) => println!("{}", message),
-            Err(err) => eprintln!("error sending SLIM message: {}", err),
-        }
-        LoopAction::Continue
-    }
-
-    fn cmd_slim_recv(&mut self, args: &[&str]) -> LoopAction {
-        let mut timeout = Some(Duration::from_secs(30));
-        let mut i = 0;
-        while i < args.len() {
-            match args[i] {
-                "--timeout" if i + 1 < args.len() => {
-                    match args[i + 1].parse::<u64>() {
-                        Ok(0) => timeout = None,
-                        Ok(seconds) => timeout = Some(Duration::from_secs(seconds)),
-                        Err(_) => {
-                            eprintln!("invalid timeout value: {}", args[i + 1]);
-                            return LoopAction::Continue;
-                        }
-                    }
-                    i += 2;
-                }
-                other => {
-                    eprintln!("usage: /slim recv [--timeout SECONDS]");
-                    eprintln!("  unexpected argument: {}", other);
-                    return LoopAction::Continue;
-                }
-            }
-        }
-        match self.slim.receive_group_message(timeout) {
-            Ok(message) => println!("{}", message),
-            Err(err) => eprintln!("error receiving SLIM message: {}", err),
         }
         LoopAction::Continue
     }

--- a/crates/shadictl/src/shell_command.rs
+++ b/crates/shadictl/src/shell_command.rs
@@ -420,6 +420,8 @@ impl Completer for ShellHelper {
                 "invite",
                 "join",
                 "whoami",
+                "send",
+                "recv",
             ];
             for sub in subs {
                 if sub.starts_with(sub_input) {
@@ -604,9 +606,11 @@ impl ShellSession {
                 "invite" => self.cmd_slim_invite(&parts[2..]),
                 "join" => self.cmd_slim_join(&parts[2..]),
                 "whoami" => self.cmd_slim_whoami(),
+                "send" => self.cmd_slim_send(&parts[2..]),
+                "recv" => self.cmd_slim_recv(&parts[2..]),
                 _ => {
                     eprintln!("unknown slim subcommand: {}", parts[1]);
-                    eprintln!("  available: status, start node, a2a-echo-peer, a2a-send, create, invite, join, whoami");
+                    eprintln!("  available: status, start node, a2a-echo-peer, a2a-send, create, invite, join, whoami, send, recv");
                     LoopAction::Continue
                 }
             },
@@ -1128,6 +1132,49 @@ impl ShellSession {
         match self.slim.whoami() {
             Ok(message) => println!("{}", message),
             Err(err) => eprintln!("error resolving SLIM identity: {}", err),
+        }
+        LoopAction::Continue
+    }
+
+    fn cmd_slim_send(&mut self, args: &[&str]) -> LoopAction {
+        if args.is_empty() {
+            eprintln!("usage: /slim send <message ...>");
+            return LoopAction::Continue;
+        }
+        let text = args.join(" ");
+        match self.slim.send_group_message(&text) {
+            Ok(message) => println!("{}", message),
+            Err(err) => eprintln!("error sending SLIM message: {}", err),
+        }
+        LoopAction::Continue
+    }
+
+    fn cmd_slim_recv(&mut self, args: &[&str]) -> LoopAction {
+        let mut timeout = Some(Duration::from_secs(30));
+        let mut i = 0;
+        while i < args.len() {
+            match args[i] {
+                "--timeout" if i + 1 < args.len() => {
+                    match args[i + 1].parse::<u64>() {
+                        Ok(0) => timeout = None,
+                        Ok(seconds) => timeout = Some(Duration::from_secs(seconds)),
+                        Err(_) => {
+                            eprintln!("invalid timeout value: {}", args[i + 1]);
+                            return LoopAction::Continue;
+                        }
+                    }
+                    i += 2;
+                }
+                other => {
+                    eprintln!("usage: /slim recv [--timeout SECONDS]");
+                    eprintln!("  unexpected argument: {}", other);
+                    return LoopAction::Continue;
+                }
+            }
+        }
+        match self.slim.receive_group_message(timeout) {
+            Ok(message) => println!("{}", message),
+            Err(err) => eprintln!("error receiving SLIM message: {}", err),
         }
         LoopAction::Continue
     }

--- a/crates/shadictl/src/slim_a2a.rs
+++ b/crates/shadictl/src/slim_a2a.rs
@@ -14,13 +14,13 @@ use a2a_server::{
 use agent_secrets::{AgentSecretAccess, AgentVerifier, SecretResult, SessionContext};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use shadi_a2a::{A2AChannelBuilder, SlimRpcHandler};
-use slim_bindings::Service;
+use shadi_a2a::{A2AChannelBuilder, A2AGroupChannelBuilder, SLIM_SRC_METADATA_KEY, SlimRpcHandler};
+use slim_bindings::{Name, Service};
 use slim_rpc::Server;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
 use tokio::sync::Notify;
 
-use crate::cli_types::{SlimA2AEchoPeerArgs, SlimA2ASendArgs};
+use crate::cli_types::{SlimA2ACollaborateArgs, SlimA2AEchoPeerArgs, SlimA2ASendArgs};
 use crate::slim_shell::{
     build_client_config_for_endpoint, build_server_config_for_endpoint, format_slim_error,
     parse_name, resolve_client_tls_material_for_agent, resolve_server_tls_material,
@@ -32,6 +32,8 @@ pub(crate) const SHELL_A2A_ECHO_PEER_USAGE: &str =
     "usage: /slim a2a-echo-peer [--endpoint HOST:PORT] [--agent-id ID] [--listen-timeout SECONDS] [--ready-file PATH] [--start-local-node]";
 pub(crate) const SHELL_A2A_SEND_USAGE: &str =
     "usage: /slim a2a-send [--endpoint HOST:PORT] [--agent-id ID] [--peer-agent-id ID] [--destination NAME] [--message TEXT...] [--stream] [--timeout SECONDS] [--session-id ID]";
+pub(crate) const SHELL_A2A_COLLABORATE_USAGE: &str =
+    "usage: /slim a2a-collaborate <peer1,peer2,...> [--endpoint HOST:PORT] [--agent-id ID] [--timeout SECONDS] [--message TEXT...]";
 
 struct VerifiedSessionVerifier;
 
@@ -350,6 +352,12 @@ pub(crate) fn run_a2a_send(args: SlimA2ASendArgs) -> Result<(), String> {
     Ok(())
 }
 
+pub(crate) fn run_a2a_collaborate(args: SlimA2ACollaborateArgs) -> Result<(), String> {
+    let detail = run_a2a_collaborate_once(&args)?;
+    println!("{}", detail);
+    Ok(())
+}
+
 pub(crate) fn parse_shell_a2a_echo_peer_args(
     args: &[&str],
 ) -> Result<SlimA2AEchoPeerArgs, String> {
@@ -447,6 +455,55 @@ pub(crate) fn parse_shell_a2a_send_args(args: &[&str]) -> Result<SlimA2ASendArgs
     Ok(parsed)
 }
 
+/// `--message` value collection reuses `collect_message_value` (and its
+/// `is_send_flag` stop-list), since every flag `a2a-collaborate` accepts
+/// (`--endpoint`, `--agent-id`, `--timeout[-seconds]`) is already in that list.
+pub(crate) fn parse_shell_a2a_collaborate_args(
+    args: &[&str],
+) -> Result<SlimA2ACollaborateArgs, String> {
+    let (peer_agent_ids, rest) = args
+        .split_first()
+        .ok_or_else(|| SHELL_A2A_COLLABORATE_USAGE.to_string())?;
+
+    let mut parsed = SlimA2ACollaborateArgs {
+        endpoint: None,
+        agent_id: "avatar".to_string(),
+        peer_agent_ids: peer_agent_ids.to_string(),
+        message: "hello from SHADI A2A".to_string(),
+        timeout_seconds: 20,
+    };
+
+    let mut index = 0;
+    while index < rest.len() {
+        match rest[index] {
+            "--endpoint" => {
+                parsed.endpoint =
+                    Some(next_value(rest, &mut index, SHELL_A2A_COLLABORATE_USAGE)?.to_string());
+            }
+            "--agent-id" => {
+                parsed.agent_id =
+                    next_value(rest, &mut index, SHELL_A2A_COLLABORATE_USAGE)?.to_string();
+            }
+            "--message" => {
+                let (message, next_index) = collect_message_value(rest, index + 1)?;
+                parsed.message = message;
+                index = next_index;
+                continue;
+            }
+            "--timeout" | "--timeout-seconds" => {
+                let value = next_value(rest, &mut index, SHELL_A2A_COLLABORATE_USAGE)?;
+                parsed.timeout_seconds = value
+                    .parse::<u64>()
+                    .map_err(|_| format!("invalid timeout value: {value}"))?;
+            }
+            _ => return Err(SHELL_A2A_COLLABORATE_USAGE.to_string()),
+        }
+        index += 1;
+    }
+
+    Ok(parsed)
+}
+
 fn run_a2a_send_once(args: &SlimA2ASendArgs) -> Result<String, String> {
     let endpoint = resolve_endpoint(args.endpoint.as_deref());
     let auth = resolve_slim_auth(&args.agent_id)?;
@@ -529,6 +586,153 @@ fn run_a2a_send_once(args: &SlimA2ASendArgs) -> Result<String, String> {
         local_name,
         response_detail
     ))
+}
+
+/// Broadcast one A2A `Message` to a SLIM group of `peer_agent_ids` via the
+/// `Collaborate` operation, while also listening for whatever the *other*
+/// members independently broadcast to this agent — a group is many-to-many, so
+/// every member plays both roles (see the SLIMRPC collaborative channel
+/// extension spec). Runs for `--timeout-seconds` before shutting down.
+fn run_a2a_collaborate_once(args: &SlimA2ACollaborateArgs) -> Result<String, String> {
+    let endpoint = resolve_endpoint(args.endpoint.as_deref());
+    let auth = resolve_slim_auth(&args.agent_id)?;
+    let client_tls = resolve_client_tls_material_for_agent(Some(&args.agent_id))?;
+    let local_name = slim_name(&args.agent_id);
+
+    let peer_names: Vec<Arc<Name>> = args
+        .peer_agent_ids
+        .split(',')
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(|id| parse_name(&slim_name(id)).map(Arc::new))
+        .collect::<Result<_, _>>()?;
+    if peer_names.is_empty() {
+        return Err("--peer-agent-ids must list at least one peer".to_string());
+    }
+
+    let service = Service::new(format!("shadictl-a2a-collab-{}", std::process::id()));
+    let connection_id = service
+        .connect(build_client_config_for_endpoint(&endpoint, &client_tls))
+        .map_err(format_slim_error)?;
+    let local_name_ref = Arc::new(parse_name(&local_name)?);
+    let app = shadi_identity::create_app(&service, local_name_ref.clone(), &auth)
+        .map_err(format_slim_error)?;
+    app.subscribe(local_name_ref.clone(), Some(connection_id))
+        .map_err(format_slim_error)?;
+
+    let runtime = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("failed to create tokio runtime: {}", err))?;
+
+    let received: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let received_for_handler = received.clone();
+
+    let mut session = SessionContext::new(&args.agent_id, "shadictl-a2a-collaborate");
+    session.verified = true;
+    let verifier: Arc<dyn AgentVerifier> = Arc::new(VerifiedSessionVerifier);
+
+    // Both the listener's Server and the initiator's group Channel capture
+    // `tokio::runtime::Handle::current()` at construction, so build them inside
+    // this runtime's context (same fix as the P2P a2a-send path).
+    let (server, channel) = {
+        let _enter = runtime.enter();
+        let server = Arc::new(Server::new_with_shared_rx_and_connection(
+            app.inner(),
+            app.name().as_slim_name(),
+            None,
+            app.notification_receiver(),
+            Some(runtime.handle().clone()),
+        ));
+        shadi_a2a::register_collaborate(server.as_ref(), move |message| {
+            // `register_collaborate`'s listener path has no per-message sender
+            // attribution today (see a2a-slimrpc's Collaborate limitations) — only
+            // `collaborate()`'s own client-observer stream gets `slim-src` via
+            // MulticastItem. The message content itself states the sender, so
+            // just surface the text.
+            let text = readable_message_text(&message);
+            received_for_handler.lock().unwrap().push(text);
+        });
+
+        let channel = A2AGroupChannelBuilder::new(app.clone(), peer_names.clone(), verifier, session)
+            .connection_id(connection_id)
+            .build()
+            .map_err(|err| format!("failed to build group channel: {err}"))?;
+
+        (server, channel)
+    };
+
+    let intro = Message::new(Role::Agent, vec![Part::text(args.message.clone())]);
+    let outbound = futures::stream::once(async move { intro });
+    let received_for_replies = received.clone();
+
+    runtime.block_on(async {
+        let server_task = {
+            let server = server.clone();
+            tokio::spawn(async move {
+                let _ = server.serve().await;
+            })
+        };
+        // Give every group member's own listener time to finish subscribing
+        // before broadcasting — `Channel::new_group`'s self-invite dance has no
+        // built-in retry, so an invite that lands before the peer is ready can be
+        // missed. Every member typically starts around the same time (as in the
+        // demo), so this is a generous, shared settle window, not per-peer.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Unlike the listener above, this is *our own* initiated session, so
+        // replies here (if any participant isn't listen-only) carry proper
+        // `slim-src` attribution via MulticastItem — surface it.
+        let replies = channel
+            .collaborate(outbound, Some(Duration::from_secs(args.timeout_seconds)))
+            .map_err(|err| format!("failed to broadcast message: {err}"))?;
+        futures::pin_mut!(replies);
+        while let Some(reply) = futures::StreamExt::next(&mut replies).await {
+            if let Ok(message) = reply {
+                let sender = message
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get(SLIM_SRC_METADATA_KEY))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("<unknown>")
+                    .to_string();
+                let text = readable_message_text(&message);
+                received_for_replies
+                    .lock()
+                    .unwrap()
+                    .push(format!("{sender}: {text}"));
+            }
+        }
+
+        // Keep listening for other members' independently-initiated broadcasts
+        // for the rest of the timeout window.
+        tokio::time::sleep(Duration::from_secs(args.timeout_seconds)).await;
+
+        server.shutdown().await;
+        let _ = server_task.await;
+        Ok::<(), String>(())
+    })?;
+
+    let _ = app.unsubscribe(local_name_ref, Some(connection_id));
+    let _ = service.disconnect(connection_id);
+    let _ = service.shutdown();
+
+    let received = received.lock().unwrap();
+    Ok(if received.is_empty() {
+        format!(
+            "broadcast {:?} to {} peer(s); received nothing within {}s",
+            args.message,
+            peer_names.len(),
+            args.timeout_seconds
+        )
+    } else {
+        format!(
+            "broadcast {:?} to {} peer(s); received:\n  {}",
+            args.message,
+            peer_names.len(),
+            received.join("\n  ")
+        )
+    })
 }
 
 fn resolve_endpoint(override_value: Option<&str>) -> String {

--- a/crates/shadictl/src/slim_shell.rs
+++ b/crates/shadictl/src/slim_shell.rs
@@ -170,36 +170,6 @@ impl SlimShellState {
         ))
     }
 
-    /// Broadcast a text message to the active group session (all members receive it).
-    pub(crate) fn send_group_message(&mut self, text: &str) -> Result<String, String> {
-        let session = self.active_session.clone().ok_or_else(|| {
-            "no active SLIM session; create or join a channel first".to_string()
-        })?;
-        session
-            .publish(text.as_bytes().to_vec(), None, Some(HashMap::new()))
-            .map_err(format_slim_error)?;
-        let channel = self
-            .active_channel
-            .clone()
-            .unwrap_or_else(|| "<unknown>".to_string());
-        Ok(format!("sent to {channel}: {text}"))
-    }
-
-    /// Block up to `timeout` for the next message on the active group session.
-    pub(crate) fn receive_group_message(
-        &mut self,
-        timeout: Option<Duration>,
-    ) -> Result<String, String> {
-        let session = self.active_session.clone().ok_or_else(|| {
-            "no active SLIM session; create or join a channel first".to_string()
-        })?;
-        let message = session.get_message(timeout).map_err(format_slim_error)?;
-        Ok(format!(
-            "received: {}",
-            String::from_utf8_lossy(&message.payload)
-        ))
-    }
-
     pub(crate) fn join_group_session(
         &mut self,
         channel: &str,
@@ -1442,10 +1412,20 @@ mod tests {
             .expect("join group session");
         assert!(join_message.contains("joined group session"));
 
-        let sent_message = state
-            .send_group_message("hello from participant")
+        // Regression check for the participant->channel route fix in
+        // join_group_session: without it, a participant's own publish routes
+        // back to the moderator's own session instead of fanning out, so this
+        // would never reach the moderator below.
+        state
+            .active_session
+            .as_ref()
+            .expect("active session after join")
+            .publish(
+                b"hello from participant".to_vec(),
+                None,
+                Some(HashMap::new()),
+            )
             .expect("participant broadcast to the group");
-        assert!(sent_message.contains("sent to"));
 
         let status = state.status().expect("status after join");
         let joined_session_id = status.active_session_id.expect("joined session id");

--- a/crates/shadictl/src/slim_shell.rs
+++ b/crates/shadictl/src/slim_shell.rs
@@ -170,6 +170,36 @@ impl SlimShellState {
         ))
     }
 
+    /// Broadcast a text message to the active group session (all members receive it).
+    pub(crate) fn send_group_message(&mut self, text: &str) -> Result<String, String> {
+        let session = self.active_session.clone().ok_or_else(|| {
+            "no active SLIM session; create or join a channel first".to_string()
+        })?;
+        session
+            .publish(text.as_bytes().to_vec(), None, Some(HashMap::new()))
+            .map_err(format_slim_error)?;
+        let channel = self
+            .active_channel
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        Ok(format!("sent to {channel}: {text}"))
+    }
+
+    /// Block up to `timeout` for the next message on the active group session.
+    pub(crate) fn receive_group_message(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<String, String> {
+        let session = self.active_session.clone().ok_or_else(|| {
+            "no active SLIM session; create or join a channel first".to_string()
+        })?;
+        let message = session.get_message(timeout).map_err(format_slim_error)?;
+        Ok(format!(
+            "received: {}",
+            String::from_utf8_lossy(&message.payload)
+        ))
+    }
+
     pub(crate) fn join_group_session(
         &mut self,
         channel: &str,
@@ -177,7 +207,13 @@ impl SlimShellState {
     ) -> Result<String, String> {
         let expected = parse_name(channel)?;
         self.ensure_channel_subscription(channel)?;
+        let connection_id = self.ensure_connection()?;
         let app = self.ensure_app()?;
+        // Subscribing only enables *receiving*. To broadcast to the group, a member
+        // also needs a route to the channel — otherwise its `/slim send` never
+        // reaches the other members.
+        app.set_route(Arc::new(parse_name(channel)?), connection_id)
+            .map_err(format_slim_error)?;
         let session = app
             .listen_for_session(timeout)
             .map_err(format_slim_error)?;
@@ -1351,7 +1387,7 @@ mod tests {
         let endpoint_for_moderator = endpoint.clone();
         let participant_name_for_thread = participant_name.clone();
         let channel_name_for_thread = channel_name.clone();
-        let moderator_handle = thread::spawn(move || -> Result<u32, String> {
+        let moderator_handle = thread::spawn(move || -> Result<(u32, String), String> {
             let moderator_service =
                 Service::new(format!("shadictl-test-moderator-{}", std::process::id()));
             let moderator_name = Arc::new(parse_name("agntcy/shadi/avatar").expect("moderator name"));
@@ -1382,12 +1418,21 @@ mod tests {
                 .invite_and_wait(participant_name_for_thread)
                 .map_err(format_slim_error)?;
 
+            // Regression check for the participant->channel route fix in
+            // join_group_session: without it, a participant's broadcast never
+            // reaches the moderator (it has nowhere to route to but back to the
+            // moderator's own session).
+            let received = session
+                .get_message(Some(Duration::from_secs(15)))
+                .map_err(format_slim_error)?;
+            let payload = String::from_utf8_lossy(&received.payload).to_string();
+
             let _ = moderator_app.delete_session_and_wait(session);
             moderator_service
                 .disconnect(connection_id)
                 .map_err(format_slim_error)?;
             moderator_service.shutdown().map_err(format_slim_error)?;
-            Ok(session_id)
+            Ok((session_id, payload))
         });
 
         start_tx.send(()).expect("start moderator flow");
@@ -1397,14 +1442,20 @@ mod tests {
             .expect("join group session");
         assert!(join_message.contains("joined group session"));
 
+        let sent_message = state
+            .send_group_message("hello from participant")
+            .expect("participant broadcast to the group");
+        assert!(sent_message.contains("sent to"));
+
         let status = state.status().expect("status after join");
         let joined_session_id = status.active_session_id.expect("joined session id");
-        let moderator_session_id = moderator_handle
+        let (moderator_session_id, moderator_received) = moderator_handle
             .join()
             .expect("moderator thread panicked")
-            .expect("moderator session id");
+            .expect("moderator session id and received payload");
 
         assert_eq!(joined_session_id, moderator_session_id);
+        assert_eq!(moderator_received, "hello from participant");
         state.shutdown();
     }
 

--- a/docs/demos/demo-env.sh
+++ b/docs/demos/demo-env.sh
@@ -1,0 +1,26 @@
+# Shared environment for the DID agent-group demo (docs/demos/did-agent-group.md).
+# Source this in EVERY terminal:  source docs/demos/demo-env.sh
+#
+# All five member DIDs below are HKDF-derived from SLIM_HUMAN_SEED (salt
+# "shadi-agent-derive") with the agent names avatar / claude-code / codex /
+# copilot / cursor-agent, so they are deterministic for this seed. Change the seed
+# and they all change — re-derive with `/slim whoami` per agent (see the doc).
+
+export SHADI_SLIM_AUTH=did                         # select DID-JWT admission
+export SLIM_HUMAN_SEED="shadi-demo-human-root-secret"
+export SLIM_HUMAN_DID="did:key:z6MkhVTmZLk7g6zRXm8DF2u2Y5b2WCkC75n16xuoJDN1X4Bp"
+
+export SHADI_TMP_DIR="${SHADI_TMP_DIR:-/tmp/shadi-did-demo}"
+export SLIM_ENDPOINT="${SLIM_ENDPOINT:-127.0.0.1:47560}"
+
+# One transport cert is fine for the demo — identity is the DID, not the TLS CN.
+export SLIM_TLS_CERT="$SHADI_TMP_DIR/shadi-slim-mtls/client-avatar.crt"
+export SLIM_TLS_KEY="$SHADI_TMP_DIR/shadi-slim-mtls/client-avatar.key"
+
+# Allow-list = the DID of every member (moderator avatar + 4 coding-agent CLIs).
+export SLIM_MEMBER_DIDS="\
+did:key:z6Mkix7tAk25UD8f4Uy7tTxn1FAErhGZ7rfifBgrvdKgzM82,\
+did:key:z6MkhRuJgsaipjWB6No8RUGD4P7fnn8qGBZKK5C5zGJjPZa1,\
+did:key:z6MkmaFFysqqMsE1q5M6E7LDuoJMaSBv3PkNHz5SwwwnuGr6,\
+did:key:z6MkmJUcT1F6BK21nQv1C2zo46gJJA9hsMGnbdpiN2LrMnwT,\
+did:key:z6MktdzQzm171sAoRZc6cCUPDa8XWxaG8Bi6R3Y4ohP7qS5Q"

--- a/docs/demos/did-agent-group.md
+++ b/docs/demos/did-agent-group.md
@@ -1,0 +1,196 @@
+# Demo: a DID-identified group of coding-agent CLIs
+
+This walkthrough forms a SLIM group where a **moderator** (bound to a human identity)
+creates a channel and invites four coding-agent CLIs — **claude-code**, **codex**,
+**copilot**, **cursor-agent** — as members. Every participant authenticates with its
+own `did:key`, and every DID is **derived from the same human key**, so the mesh can
+tell which human an agent belongs to.
+
+It uses only `shadictl` shell commands. You can run it two ways:
+
+- **One command (recommended):** `bash docs/demos/run-demo.sh` orchestrates the whole
+  flow — node, moderator, four agents, invites, and a broadcast message — and prints
+  the result. Best for a quick, reliable demo.
+- **By hand:** drive the `shadictl` shell across a terminal per agent (steps 1–6
+  below). Best for exploring; note `/slim join` and `/slim recv` block, so mind the
+  choreography and use generous `--timeout` values.
+
+## What this shows
+
+- **Per-agent DID identity** — each CLI proves itself with a `did:key`/EdDSA JWT
+  instead of a shared secret.
+- **Human ↔ agent binding** — all five agents are HKDF-derived from one human root
+  key (salt `shadi-agent-derive`), so they share one **human DID**.
+- **Moderator role** — the channel creator/inviter is the human's `avatar`; members
+  join and are admitted against a DID allow-list.
+- **Role-visible UX** — `create`, `invite`, and `whoami` surface the DID, the human
+  it belongs to, and the moderator/participant role.
+
+## Prerequisites
+
+```bash
+# 1. Build the CLI
+cargo build -p agntcy-shadi-cli   # produces target/debug/shadictl
+
+# 2. Generate mTLS material for the SLIM transport (one CA + client/server certs)
+export DEMO=/tmp/shadi-did-demo
+bash tools/generate_slim_mtls_certs.sh "$DEMO/shadi-slim-mtls"
+```
+
+## 1. Shared environment (every terminal)
+
+The whole group shares one human root secret and one allow-list, provided in
+[`demo-env.sh`](demo-env.sh). From the repo root, `source` it in **every** terminal
+below:
+
+```bash
+source docs/demos/demo-env.sh
+```
+
+It sets `SHADI_SLIM_AUTH=did`, `SLIM_HUMAN_SEED`, `SLIM_HUMAN_DID`, `SHADI_TMP_DIR`,
+`SLIM_ENDPOINT`, the shared transport cert (`SLIM_TLS_CERT`/`SLIM_TLS_KEY`), and the
+`SLIM_MEMBER_DIDS` allow-list — the DID of every member (moderator + 4 agents).
+Each agent's DID is derived from `SLIM_HUMAN_SEED` + its `SHADI_AGENT_ID`:
+
+| `SHADI_AGENT_ID` | role | `did:key` |
+|---|---|---|
+| `avatar`       | moderator   | `z6Mkix7tAk25UD8f4Uy7tTxn1FAErhGZ7rfifBgrvdKgzM82` |
+| `claude-code`  | participant | `z6MkhRuJgsaipjWB6No8RUGD4P7fnn8qGBZKK5C5zGJjPZa1` |
+| `codex`        | participant | `z6MkmaFFysqqMsE1q5M6E7LDuoJMaSBv3PkNHz5SwwwnuGr6` |
+| `copilot`      | participant | `z6MkmJUcT1F6BK21nQv1C2zo46gJJA9hsMGnbdpiN2LrMnwT` |
+| `cursor-agent` | participant | `z6MktdzQzm171sAoRZc6cCUPDa8XWxaG8Bi6R3Y4ohP7qS5Q` |
+
+## 2. Discover a member's DID (optional)
+
+You don't have to precompute the table — any agent prints its own DID with `whoami`.
+In a fresh terminal, `source demo-env.sh`, then:
+
+```bash
+SHADI_AGENT_ID=claude-code target/debug/shadictl shell
+# in the shell:
+/slim whoami
+#   agent agntcy/shadi/claude-code
+#     auth:  did
+#     role:  none
+#     did:   did:key:z6MkhRuJgsaipjWB6No8RUGD4P7fnn8qGBZKK5C5zGJjPZa1
+#     human: did:key:z6MkhVTmZLk7g6zRXm8DF2u2Y5b2WCkC75n16xuoJDN1X4Bp
+/exit
+```
+
+Collect each agent's `did:` line to build `SLIM_MEMBER_DIDS`.
+
+## 3. Moderator: start the node and open the channel
+
+**Terminal M** (`source demo-env.sh` first):
+
+```bash
+SHADI_AGENT_ID=avatar target/debug/shadictl shell
+```
+
+```text
+/slim start node
+started SLIM node on 127.0.0.1:47560
+
+/slim create agntcy/shadi/dev-room
+created channel agntcy/shadi/dev-room as moderator agntcy/shadi/avatar
+  (did:key:z6Mkix7tAk25UD8f4Uy7tTxn1FAErhGZ7rfifBgrvdKgzM82) — human did:key:z6MkhVT…
+
+/slim whoami
+  agent agntcy/shadi/avatar
+    auth:  did
+    role:  moderator
+    did:   did:key:z6Mkix7tAk25UD8f4Uy7tTxn1FAErhGZ7rfifBgrvdKgzM82
+    human: did:key:z6MkhVTmZLk7g6zRXm8DF2u2Y5b2WCkC75n16xuoJDN1X4Bp
+```
+
+## 4. Each agent joins the channel
+
+Open a terminal per agent (`source demo-env.sh` first). Each `join` blocks, listening
+for the moderator's invite; give it a generous timeout so it stays up while you invite
+everyone in step 5.
+
+**Terminal claude-code:**
+
+```bash
+SHADI_AGENT_ID=claude-code target/debug/shadictl shell
+```
+```text
+/slim join agntcy/shadi/dev-room --timeout 120
+joined group session for channel agntcy/shadi/dev-room as agntcy/shadi/claude-code
+
+/slim whoami
+  agent agntcy/shadi/claude-code
+    auth:  did
+    role:  participant
+    did:   did:key:z6MkhRuJgsaipjWB6No8RUGD4P7fnn8qGBZKK5C5zGJjPZa1
+    human: did:key:z6MkhVTmZLk7g6zRXm8DF2u2Y5b2WCkC75n16xuoJDN1X4Bp
+```
+
+Repeat in three more terminals with `SHADI_AGENT_ID=codex`, `copilot`, and
+`cursor-agent` (same `/slim join agntcy/shadi/dev-room --timeout 120`).
+
+## 5. Moderator: invite the four agents
+
+Back in **Terminal M**, invite each agent by name. Each `invite` completes as that
+agent's `join` (step 4) responds and the MLS join finishes:
+
+```text
+/slim invite agntcy/shadi/claude-code
+invited agntcy/shadi/claude-code to agntcy/shadi/dev-room (moderator did:key:z6Mkix7t…)
+/slim invite agntcy/shadi/codex
+invited agntcy/shadi/codex to agntcy/shadi/dev-room (moderator did:key:z6Mkix7t…)
+/slim invite agntcy/shadi/copilot
+invited agntcy/shadi/copilot to agntcy/shadi/dev-room (moderator did:key:z6Mkix7t…)
+/slim invite agntcy/shadi/cursor-agent
+invited agntcy/shadi/cursor-agent to agntcy/shadi/dev-room (moderator did:key:z6Mkix7t…)
+```
+
+Each agent terminal reports `joined group session …` — the group is now formed: one
+human's moderator plus its four coding-agent CLIs, every member cryptographically
+identified by a `did:key` admitted against the shared allow-list.
+
+## 6. Roll call — every agent introduces itself
+
+Any member can broadcast to the channel with `/slim send`, and any member can wait
+for the next message with `/slim recv`. Once everyone has joined, have each agent
+announce itself; every other member (moderator included) receives it.
+
+**Each agent terminal (e.g. claude-code):**
+```text
+/slim send Hi, I am claude-code — reporting in
+sent to agntcy/shadi/dev-room: Hi, I am claude-code — reporting in
+```
+
+**Every other terminal — moderator and the other three agents — prints:**
+```text
+received: Hi, I am claude-code — reporting in
+```
+
+Repeat for `codex`, `copilot`, and `cursor-agent`; `recv` is one-shot and
+blocking, so call it once per expected message (`run-demo.sh` calls it five times
+per terminal — once per peer plus the moderator's own greeting — to collect the
+full roll call). This is a genuine mesh: every member can reach every other
+member, not just moderator → members.
+
+## How admission works (under the hood)
+
+- The moderator's `create`/`invite` control messages carry its DID-JWT; each
+  participant verifies that JWT against `SLIM_MEMBER_DIDS` (the allow-list) before
+  replying — a non-member DID is dropped, so only invited agents can be admitted.
+- Because every DID is HKDF-derived from `SLIM_HUMAN_SEED`, the `human:` line is the
+  same for all five, which is how the mesh attributes each agent to its human.
+- Switching the whole group back to the legacy shared secret is just
+  `unset SHADI_SLIM_AUTH` (then the shell uses `SLIM_SHARED_SECRET`); the same
+  `create`/`invite`/`join` commands work, without the DID lines.
+
+## Notes / limitations
+
+- `/slim join` and `/slim recv` **block** (listening for an invite / a message) — an
+  agent terminal will appear to "hang" until the moderator invites it, or a message
+  arrives, or the timeout elapses. That is expected.
+- `/slim recv` is one-shot: it returns the next single message. Call it again for the
+  next one. (No background subscriber loop yet.)
+- The four agent names match the `agentbridge` coding-agent adapters
+  (`claude_code`, `codex`, `copilot`, `cursor_agent`). This demo forms the DID group
+  and passes messages; wiring the actual agent binaries in via `agentbridge` is the
+  next step.

--- a/docs/demos/did-agent-group.md
+++ b/docs/demos/did-agent-group.md
@@ -9,11 +9,11 @@ tell which human an agent belongs to.
 It uses only `shadictl` shell commands. You can run it two ways:
 
 - **One command (recommended):** `bash docs/demos/run-demo.sh` orchestrates the whole
-  flow — node, moderator, four agents, invites, and a broadcast message — and prints
-  the result. Best for a quick, reliable demo.
+  flow — node, moderator, four agents, invites, and an A2A roll-call broadcast — and
+  prints the result. Best for a quick, reliable demo.
 - **By hand:** drive the `shadictl` shell across a terminal per agent (steps 1–6
-  below). Best for exploring; note `/slim join` and `/slim recv` block, so mind the
-  choreography and use generous `--timeout` values.
+  below). Best for exploring; note `/slim join` blocks, so mind the choreography and
+  use generous `--timeout` values.
 
 ## What this shows
 
@@ -25,6 +25,9 @@ It uses only `shadictl` shell commands. You can run it two ways:
   join and are admitted against a DID allow-list.
 - **Role-visible UX** — `create`, `invite`, and `whoami` surface the DID, the human
   it belongs to, and the moderator/participant role.
+- **A2A-native group messaging** — `/slim a2a-collaborate` broadcasts and receives
+  through A2A's `Message` type (SLIM's group/multicast is used underneath A2A via
+  the SLIMRPC `Collaborate` RPC, not instead of it), with `slim-src` attribution.
 
 ## Prerequisites
 
@@ -151,26 +154,28 @@ identified by a `did:key` admitted against the shared allow-list.
 
 ## 6. Roll call — every agent introduces itself
 
-Any member can broadcast to the channel with `/slim send`, and any member can wait
-for the next message with `/slim recv`. Once everyone has joined, have each agent
-announce itself; every other member (moderator included) receives it.
+Messaging always goes through **A2A**, not raw SLIM bytes: `/slim a2a-collaborate`
+drives the SLIMRPC `Collaborate` RPC — an A2A operation that broadcasts each
+`Message` you send to every other member of a SLIM group channel, and streams back
+everyone else's messages with `metadata["slim-src"]` identifying the sender. Every
+member (moderator included) both sends its own intro and listens for everyone
+else's, in one call — no `/slim create`/`invite`/`join` needed for this step, since
+`Collaborate` forms its own group session (it's independent of the moderator/role
+session from steps 3–5 above).
 
-**Each agent terminal (e.g. claude-code):**
+**Each terminal — moderator and all four agents — runs the same shape (e.g. claude-code):**
 ```text
-/slim send Hi, I am claude-code — reporting in
-sent to agntcy/shadi/dev-room: Hi, I am claude-code — reporting in
+/slim a2a-collaborate codex,copilot,cursor-agent,avatar --message Hi, I am claude-code — reporting in --timeout 15
+broadcast "Hi, I am claude-code — reporting in" to 4 peer(s); received:
+  Hi, I am codex — reporting in
+  Hi, I am copilot — reporting in
+  Hi, I am cursor-agent — reporting in
+  Hi, I am avatar — reporting in
 ```
 
-**Every other terminal — moderator and the other three agents — prints:**
-```text
-received: Hi, I am claude-code — reporting in
-```
-
-Repeat for `codex`, `copilot`, and `cursor-agent`; `recv` is one-shot and
-blocking, so call it once per expected message (`run-demo.sh` calls it five times
-per terminal — once per peer plus the moderator's own greeting — to collect the
-full roll call). This is a genuine mesh: every member can reach every other
-member, not just moderator → members.
+Give every terminal the peer-list of the *other* four members and start them all
+within the timeout window — this is a genuine mesh: every member reaches every
+other member directly, not just moderator → members.
 
 ## How admission works (under the hood)
 
@@ -185,11 +190,18 @@ member, not just moderator → members.
 
 ## Notes / limitations
 
-- `/slim join` and `/slim recv` **block** (listening for an invite / a message) — an
-  agent terminal will appear to "hang" until the moderator invites it, or a message
-  arrives, or the timeout elapses. That is expected.
-- `/slim recv` is one-shot: it returns the next single message. Call it again for the
-  next one. (No background subscriber loop yet.)
+- `/slim join` **blocks** (listening for the moderator's invite) — an agent terminal
+  will appear to "hang" until invited, or the timeout elapses. That is expected.
+- `/slim a2a-collaborate` also blocks for its `--timeout`, since it stays listening
+  for other members' broadcasts for that whole window after sending its own intro.
+- Verified live with the full 5-member group (moderator + 4 coding-agent CLIs):
+  every member reliably receives all four peers' intros, in either order, across
+  repeated runs.
+- Server-side listener attribution is a known gap in the current SLIMRPC
+  `Collaborate` implementation: a member's *own* broadcast gets proper `slim-src`
+  attribution on its reply-observer stream, but messages surfaced purely through the
+  passive listener path have no per-message sender tag yet (the message text itself
+  states the sender, which is enough for this demo).
 - The four agent names match the `agentbridge` coding-agent adapters
   (`claude_code`, `codex`, `copilot`, `cursor_agent`). This demo forms the DID group
   and passes messages; wiring the actual agent binaries in via `agentbridge` is the

--- a/docs/demos/run-demo.sh
+++ b/docs/demos/run-demo.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# One-command DID agent-group demo (see did-agent-group.md).
+#
+# Orchestrates the whole flow so you don't have to hand-coordinate terminals:
+#   moderator (avatar) starts a node, creates a channel, invites claude-code /
+#   codex / copilot / cursor-agent (each a DID derived from one human key), the
+#   agents join, and the moderator broadcasts a message that the agents receive.
+#
+# Run from the repo root:  bash docs/demos/run-demo.sh
+set -uo pipefail
+cd "$(dirname "$0")/../.."   # repo root
+
+BIN=target/debug/shadictl
+[ -x "$BIN" ] || { echo "building shadictl…"; cargo build -p agntcy-shadi-cli || exit 1; }
+
+# Fresh, isolated run dir + endpoint; clear any stale shells holding the port.
+export SHADI_TMP_DIR="$(mktemp -d /tmp/shadi-did-demo.XXXXXX)"
+export SLIM_ENDPOINT="127.0.0.1:47590"
+pkill -f "$BIN shell" 2>/dev/null; sleep 1
+# shellcheck source=/dev/null
+source docs/demos/demo-env.sh
+bash tools/generate_slim_mtls_certs.sh "$SHADI_TMP_DIR/shadi-slim-mtls" >/dev/null 2>&1 \
+  || { echo "mTLS generation failed"; exit 1; }
+
+CH="agntcy/shadi/dev-room"
+LOG="$SHADI_TMP_DIR/logs"; mkdir -p "$LOG"
+
+# Four coding-agent CLIs: join, introduce themselves to the group, then collect
+# everyone else's introductions (roll call).
+for a in claude-code codex copilot cursor-agent; do
+  ( sleep 3
+    echo "/slim join $CH --timeout 60"
+    echo "/slim whoami"
+    sleep 6                                   # let every member finish joining
+    echo "/slim send Hi, I am $a — reporting in"
+    for _ in 1 2 3 4 5; do echo "/slim recv --timeout 8"; done
+    echo "/exit"
+  ) | env SHADI_AGENT_ID="$a" "$BIN" shell >"$LOG/$a.log" 2>&1 &
+done
+
+# Moderator (avatar): node, channel, invite all four, greet, then collect the roll call.
+( echo "/slim start node"; sleep 2
+  echo "/slim create $CH"; sleep 4
+  for a in claude-code codex copilot cursor-agent; do echo "/slim invite agntcy/shadi/$a"; done
+  echo "/slim whoami"
+  sleep 6
+  echo "/slim send Welcome — moderator here; please introduce yourselves"
+  for _ in 1 2 3 4 5; do echo "/slim recv --timeout 8"; done
+  echo "/exit"
+) | env SHADI_AGENT_ID=avatar "$BIN" shell >"$LOG/avatar.log" 2>&1 &
+
+wait
+pkill -f "$BIN shell" 2>/dev/null
+
+strip() { sed 's/\x1b\[[0-9;]*m//g'; }
+echo
+echo "================ MODERATOR (avatar) ================"
+strip <"$LOG/avatar.log" | grep -iE "created channel|invited|sent to|role:|did:|human:|received:"
+for a in claude-code codex copilot cursor-agent; do
+  echo "================ $a ================"
+  strip <"$LOG/$a.log" | grep -iE "joined|role:|did:|human:|sent to|received:"
+done
+echo
+echo "logs: $LOG"

--- a/docs/demos/run-demo.sh
+++ b/docs/demos/run-demo.sh
@@ -2,9 +2,11 @@
 # One-command DID agent-group demo (see did-agent-group.md).
 #
 # Orchestrates the whole flow so you don't have to hand-coordinate terminals:
-#   moderator (avatar) starts a node, creates a channel, invites claude-code /
-#   codex / copilot / cursor-agent (each a DID derived from one human key), the
-#   agents join, and the moderator broadcasts a message that the agents receive.
+#   moderator (avatar) starts a node, creates a channel, and invites claude-code /
+#   codex / copilot / cursor-agent (each a DID derived from one human key) — this
+#   shows off the DID/moderator role UX. Then all five members run
+#   `/slim a2a-collaborate` — an A2A operation backed by SLIM's group channel — to
+#   broadcast an intro and collect everyone else's (a roll-call full mesh).
 #
 # Run from the repo root:  bash docs/demos/run-demo.sh
 set -uo pipefail
@@ -24,41 +26,66 @@ bash tools/generate_slim_mtls_certs.sh "$SHADI_TMP_DIR/shadi-slim-mtls" >/dev/nu
 
 CH="agntcy/shadi/dev-room"
 LOG="$SHADI_TMP_DIR/logs"; mkdir -p "$LOG"
+ALL_AGENTS=(avatar claude-code codex copilot cursor-agent)
 
-# Four coding-agent CLIs: join, introduce themselves to the group, then collect
-# everyone else's introductions (roll call).
+# One SLIM node spans both parts below; only killed at the very end.
+"$BIN" slim start-node >"$LOG/node.log" 2>&1 &
+NODE_PID=$!
+sleep 2
+
+# --- Part 1: DID/moderator role UX (create/invite/join) -------------------
+
+# Four coding-agent CLIs join the channel and report their role.
+SHELL_PIDS=()
 for a in claude-code codex copilot cursor-agent; do
-  ( sleep 3
+  ( sleep 2
     echo "/slim join $CH --timeout 60"
     echo "/slim whoami"
     sleep 6                                   # let every member finish joining
-    echo "/slim send Hi, I am $a — reporting in"
-    for _ in 1 2 3 4 5; do echo "/slim recv --timeout 8"; done
     echo "/exit"
   ) | env SHADI_AGENT_ID="$a" "$BIN" shell >"$LOG/$a.log" 2>&1 &
+  SHELL_PIDS+=($!)
 done
 
-# Moderator (avatar): node, channel, invite all four, greet, then collect the roll call.
-( echo "/slim start node"; sleep 2
-  echo "/slim create $CH"; sleep 4
+# Moderator (avatar): create the channel, invite all four.
+( echo "/slim create $CH"; sleep 4
   for a in claude-code codex copilot cursor-agent; do echo "/slim invite agntcy/shadi/$a"; done
   echo "/slim whoami"
   sleep 6
-  echo "/slim send Welcome — moderator here; please introduce yourselves"
-  for _ in 1 2 3 4 5; do echo "/slim recv --timeout 8"; done
   echo "/exit"
 ) | env SHADI_AGENT_ID=avatar "$BIN" shell >"$LOG/avatar.log" 2>&1 &
+SHELL_PIDS+=($!)
 
-wait
+for p in "${SHELL_PIDS[@]}"; do wait "$p"; done
 pkill -f "$BIN shell" 2>/dev/null
+
+# --- Part 2: roll call over A2A's Collaborate op (SLIM group channel underneath) ---
+
+sleep 1
+COLLAB_PIDS=()
+for a in "${ALL_AGENTS[@]}"; do
+  others=""
+  for p in "${ALL_AGENTS[@]}"; do
+    [ "$p" != "$a" ] && others="${others:+$others,}$p"
+  done
+  env SHADI_AGENT_ID="$a" "$BIN" slim a2a-collaborate --agent-id "$a" --peer-agent-ids "$others" \
+    --message "Hi, I am $a — reporting in" --timeout-seconds 15 >"$LOG/$a-collaborate.log" 2>&1 &
+  COLLAB_PIDS+=($!)
+done
+for p in "${COLLAB_PIDS[@]}"; do wait "$p"; done
+
+kill "$NODE_PID" 2>/dev/null
+pkill -f "target/debug/shadictl" 2>/dev/null
 
 strip() { sed 's/\x1b\[[0-9;]*m//g'; }
 echo
 echo "================ MODERATOR (avatar) ================"
-strip <"$LOG/avatar.log" | grep -iE "created channel|invited|sent to|role:|did:|human:|received:"
+strip <"$LOG/avatar.log" | grep -iE "created channel|invited|role:|did:|human:"
+strip <"$LOG/avatar-collaborate.log" | grep -iE "^broadcast|^  "
 for a in claude-code codex copilot cursor-agent; do
   echo "================ $a ================"
-  strip <"$LOG/$a.log" | grep -iE "joined|role:|did:|human:|sent to|received:"
+  strip <"$LOG/$a.log" | grep -iE "joined|role:|did:|human:"
+  strip <"$LOG/$a-collaborate.log" | grep -iE "^broadcast|^  "
 done
 echo
 echo "logs: $LOG"


### PR DESCRIPTION
## Bug fix: member-originated group messaging

`join_group_session` subscribed the participant to the channel (enabling *receive*)
but never gave it a **route** to the channel, so a participant's broadcast published
back toward the moderator's own session instead of fanning out to the group — other
members never received it. Fixed by adding `app.set_route(channel, connection_id)`
alongside the existing subscribe, matching what the moderator already gets via
`invite`.

## New: `/slim a2a-collaborate` — group messaging over A2A

Group messaging goes through A2A as the entrypoint, not raw SLIM bytes: this uses
the SLIMRPC `Collaborate` RPC (`a2a-slimrpc` 0.2.3, added upstream in
[a2aproject/a2a-rs#111](https://github.com/a2aproject/a2a-rs/pull/111)) to broadcast
an A2A `Message` to every other member of a SLIM group channel and stream back
everyone else's, attributed via `metadata["slim-src"]`. Adds
`shadi_a2a::A2AGroupChannel` and wires it into the shell/CLI as
`/slim a2a-collaborate`.

## New: DID agent-group demo (`docs/demos/`)

- `did-agent-group.md` — guided walkthrough: derive a human root secret into 5
  member DIDs (moderator `avatar` + `claude-code`/`codex`/`copilot`/`cursor-agent`),
  form the group via `/slim create` + `/slim invite` + `/slim join`, verify identity
  with `/slim whoami` (shows moderator DID + human DID), and do a full-mesh roll call
  where every member broadcasts via `/slim a2a-collaborate` and every other member
  receives it.
- `run-demo.sh` — one-command orchestration of the whole flow (no manual terminal
  choreography).
- `demo-env.sh` — shared environment sourced by both the manual walkthrough and the
  script.

## Test

- Extended `given_generated_assets_when_joining_group_session_then_state_is_updated`:
  the moderator now actually receives the participant's broadcast payload — direct
  regression coverage for the route fix.
- `a2a-slimrpc`: new e2e test, 3 members independently broadcast + listen, asserts
  full mesh delivery.
- `cargo test -p agntcy-shadi-cli --bin shadictl`: 664 pass.
- `cargo test -p agntcy-shadi-cli --test slim_cli_integration`: 4 pass.
- `docs/demos/run-demo.sh` run live: all 5 members join, and each of the 5 members'
  (moderator + 4 agents) self-introductions is received by every other member —
  full mesh, repeatable.
