### PR TITLE
docs(demo): delegate real tasks to claude/codex/copilot via agentbridge

### DIFF
--- a/docs/demos/did-agent-group.md
+++ b/docs/demos/did-agent-group.md
@@ -28,6 +28,9 @@ It uses only `shadictl` shell commands. You can run it two ways:
 - **A2A-native group messaging** — `/slim a2a-collaborate` broadcasts and receives
   through A2A's `Message` type (SLIM's group/multicast is used underneath A2A via
   the SLIMRPC `Collaborate` RPC, not instead of it), with `slim-src` attribution.
+- **Real coding-agent CLIs in the loop** — `agentbridge` wraps the actual `claude`/
+  `codex`/`copilot` binaries as SLIM/A2A listeners under the same DID identity, so a
+  delegated task really executes on that CLI, not a mock.
 
 ## Prerequisites
 
@@ -177,6 +180,59 @@ Give every terminal the peer-list of the *other* four members and start them all
 within the timeout window — this is a genuine mesh: every member reaches every
 other member directly, not just moderator → members.
 
+## 7. Delegate a real task to the coding-agent CLIs
+
+Everything so far shows *identity* and *messaging*. This step wires in the real
+thing: **`agentbridge`** wraps the actual installed `claude`, `codex`, and `copilot`
+CLI binaries as SLIM/A2A listeners, so a delegated task really invokes that CLI and
+returns its real output — using the *same* DID identity from step 1 (agentbridge
+checks `SHADI_SLIM_AUTH=did` the same way `shadictl` does, no separate setup).
+`cursor-agent` doesn't have an `agentbridge register` listener yet, so it's not part
+of this step (it still participates in the roll call above).
+
+**Each agent terminal (e.g. claude-code)** — registers a live adapter backed by the
+real CLI, reachable at `agntcy/shadi/claude-code-a2a`:
+
+```bash
+SHADI_AGENT_ID=claude-code target/debug/agentbridge register --tool claude-code \
+  --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT"
+```
+```text
+Registered Claude Code adapter (agent id: claude-code, dir: /path/to/shadi)
+Starting SLIM A2A listener on 127.0.0.1:47560 as agntcy/shadi/claude-code-a2a ...
+[agentbridge] ready — listening on agntcy/shadi/claude-code-a2a
+```
+
+Repeat for `codex` and `copilot` (same shape, `--tool codex` / `--tool copilot`).
+
+**Moderator terminal** — delegates one real task to each:
+
+```bash
+target/debug/agentbridge delegate "Reply with exactly the single word: PONG" \
+  --to claude-code --agent-id avatar --endpoint "$SLIM_ENDPOINT"
+```
+```text
+Delegating task 09024c44-... to 'claude-code'...
+Response from 'claude-code' (5518ms):
+PONG
+```
+
+The listener terminal prints the same round trip from its side:
+```text
+┌─ A2A recv [claude-code] task ...
+│  Reply with exactly the single word: PONG
+└─────────────────────────────────────────────────────────
+┌─ A2A send [claude-code] (5518 ms)
+│  PONG
+└─────────────────────────────────────────────────────────
+```
+
+This is a genuinely live `claude`/`copilot` process handling the prompt — swap the
+message for any real coding task to see it delegated end to end. `codex`'s success
+depends on your local `codex` CLI/model configuration (an unsupported default model
+returns a `400` from the OpenAI backend, unrelated to SHADI); that's an environment
+issue, not a bug in this wiring.
+
 ## How admission works (under the hood)
 
 - The moderator's `create`/`invite` control messages carry its DID-JWT; each
@@ -202,7 +258,8 @@ other member directly, not just moderator → members.
   attribution on its reply-observer stream, but messages surfaced purely through the
   passive listener path have no per-message sender tag yet (the message text itself
   states the sender, which is enough for this demo).
-- The four agent names match the `agentbridge` coding-agent adapters
-  (`claude_code`, `codex`, `copilot`, `cursor_agent`). This demo forms the DID group
-  and passes messages; wiring the actual agent binaries in via `agentbridge` is the
-  next step.
+- `agentbridge register --tool claude-code|codex|copilot` needs that CLI actually
+  installed (and authenticated) on PATH; `cursor-agent` doesn't have a `register`
+  listener yet. A `delegate` failure usually means the target CLI itself errored
+  (auth, unsupported model, etc.), not the SLIM/A2A wiring — the response text
+  includes the real error from that CLI so it's easy to tell apart.

--- a/docs/demos/did-agent-group.md
+++ b/docs/demos/did-agent-group.md
@@ -232,6 +232,29 @@ The listener terminal prints the same round trip from its side:
 └─────────────────────────────────────────────────────────
 ```
 
+**Chaining a real task across agents** — `run-demo.sh` does this for real: it
+delegates a disk-usage check to `codex`, a top-CPU-processes check to `copilot`,
+then hands *both real outputs* to `claude-code` and asks it to synthesize an
+operational report — each step genuinely depends on the previous agent's result,
+not a canned reply. By hand, that's three `delegate` calls chained through shell
+variables:
+
+```bash
+DISK=$(target/debug/agentbridge delegate \
+  "Run a disk usage check on this machine (e.g. df -h) and report the real output." \
+  --to codex --agent-id avatar --endpoint "$SLIM_ENDPOINT")
+CPU=$(target/debug/agentbridge delegate \
+  "Rank the top 10 processes on this machine by CPU usage (e.g. ps aux) and report the real output." \
+  --to copilot --agent-id avatar --endpoint "$SLIM_ENDPOINT")
+target/debug/agentbridge delegate \
+  "Summarize these two real system-health snippets into a short report, flagging anything concerning:\n\n$DISK\n\n$CPU" \
+  --to claude-code --agent-id avatar --endpoint "$SLIM_ENDPOINT"
+```
+
+`claude-code`'s response is a real report — e.g. flagging a disk volume nearing
+capacity or a process with unexpectedly high CPU — built from the other two
+agents' real command output.
+
 This is a genuinely live `claude`/`copilot` process handling the prompt — swap the
 message for any real coding task to see it delegated end to end. `codex`'s success
 depends on your local `codex` CLI/model configuration (an unsupported default model

--- a/docs/demos/did-agent-group.md
+++ b/docs/demos/did-agent-group.md
@@ -9,8 +9,13 @@ tell which human an agent belongs to.
 It uses only `shadictl` shell commands. You can run it two ways:
 
 - **One command (recommended):** `bash docs/demos/run-demo.sh` orchestrates the whole
-  flow — node, moderator, four agents, invites, and an A2A roll-call broadcast — and
-  prints the result. Best for a quick, reliable demo.
+  flow — node, moderator, four agents, invites, an A2A roll-call broadcast, and real
+  task delegation to claude-code/codex/copilot — and prints the result. Best for a
+  quick, reliable demo. It prints its log dir immediately and echoes a one-line
+  status per phase as it runs; in a second terminal, `bash docs/demos/watch-demo.sh`
+  tails every per-agent log live (including ones from later phases, as they're
+  created) so you can watch progress in real time instead of waiting for the final
+  summary.
 - **By hand:** drive the `shadictl` shell across a terminal per agent (steps 1–6
   below). Best for exploring; note `/slim join` blocks, so mind the choreography and
   use generous `--timeout` values.

--- a/docs/demos/run-demo.sh
+++ b/docs/demos/run-demo.sh
@@ -6,7 +6,10 @@
 #   codex / copilot / cursor-agent (each a DID derived from one human key) — this
 #   shows off the DID/moderator role UX. Then all five members run
 #   `/slim a2a-collaborate` — an A2A operation backed by SLIM's group channel — to
-#   broadcast an intro and collect everyone else's (a roll-call full mesh).
+#   broadcast an intro and collect everyone else's (a roll-call full mesh). Finally,
+#   claude-code/codex/copilot register as `agentbridge` adapters backed by the real
+#   installed CLI binaries, and the moderator delegates an actual task to each over
+#   the same SLIM node — real messages reaching real coding-agent processes.
 #
 # Run from the repo root:  bash docs/demos/run-demo.sh
 set -uo pipefail
@@ -14,6 +17,8 @@ cd "$(dirname "$0")/../.."   # repo root
 
 BIN=target/debug/shadictl
 [ -x "$BIN" ] || { echo "building shadictl…"; cargo build -p agntcy-shadi-cli || exit 1; }
+AB=target/debug/agentbridge
+[ -x "$AB" ] || { echo "building agentbridge…"; cargo build -p agntcy-agentbridge-cli || exit 1; }
 
 # Fresh, isolated run dir + endpoint; clear any stale shells holding the port.
 export SHADI_TMP_DIR="$(mktemp -d /tmp/shadi-did-demo.XXXXXX)"
@@ -74,8 +79,32 @@ for a in "${ALL_AGENTS[@]}"; do
 done
 for p in "${COLLAB_PIDS[@]}"; do wait "$p"; done
 
+# --- Part 3: delegate a real task to the real coding-agent CLIs (agentbridge) ---
+# claude-code, codex, copilot register as live A2A/SLIM adapters backed by the
+# actual installed CLI binary — the same DID identity from Part 1 carries over
+# automatically (agentbridge checks the same SHADI_SLIM_AUTH=did env). cursor-agent
+# has no `agentbridge register` listener yet, so it's skipped here.
+# A failed delegate below usually means that CLI isn't installed/authenticated on
+# this machine, not a SHADI bug — the script continues regardless.
+
+REGISTER_PIDS=()
+for a in claude-code codex copilot; do
+  env SHADI_AGENT_ID="$a" "$AB" register --tool "$a" --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
+    >"$LOG/$a-agent.log" 2>&1 &
+  REGISTER_PIDS+=($!)
+done
+sleep 3
+
+for a in claude-code codex copilot; do
+  env SHADI_AGENT_ID=avatar "$AB" delegate "Reply with exactly the single word: PONG" --to "$a" \
+    --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/$a-delegate.log" 2>&1
+done
+
+for p in "${REGISTER_PIDS[@]}"; do kill -INT "$p" 2>/dev/null; wait "$p" 2>/dev/null; done
+
 kill "$NODE_PID" 2>/dev/null
 pkill -f "target/debug/shadictl" 2>/dev/null
+pkill -f "target/debug/agentbridge" 2>/dev/null
 
 strip() { sed 's/\x1b\[[0-9;]*m//g'; }
 echo
@@ -86,6 +115,12 @@ for a in claude-code codex copilot cursor-agent; do
   echo "================ $a ================"
   strip <"$LOG/$a.log" | grep -iE "joined|role:|did:|human:"
   strip <"$LOG/$a-collaborate.log" | grep -iE "^broadcast|^  "
+done
+echo
+echo "================ agentbridge: real task delegation ================"
+for a in claude-code codex copilot; do
+  echo "-- $a --"
+  strip <"$LOG/$a-delegate.log" | grep -A1 -iE "^Response from"
 done
 echo
 echo "logs: $LOG"

--- a/docs/demos/run-demo.sh
+++ b/docs/demos/run-demo.sh
@@ -8,8 +8,9 @@
 #   `/slim a2a-collaborate` — an A2A operation backed by SLIM's group channel — to
 #   broadcast an intro and collect everyone else's (a roll-call full mesh). Finally,
 #   claude-code/codex/copilot register as `agentbridge` adapters backed by the real
-#   installed CLI binaries, and the moderator delegates an actual task to each over
-#   the same SLIM node — real messages reaching real coding-agent processes.
+#   installed CLI binaries, and the moderator chains a real task across them: codex
+#   reports real disk usage, copilot ranks real processes by CPU, and claude-code
+#   synthesizes both into an operational report — real work, not a canned reply.
 #
 # Run from the repo root:  bash docs/demos/run-demo.sh
 set -uo pipefail
@@ -90,11 +91,14 @@ done
 for p in "${COLLAB_PIDS[@]}"; do wait "$p"; done
 step "Part 2 done."
 
-# --- Part 3: delegate a real task to the real coding-agent CLIs (agentbridge) ---
+# --- Part 3: chain a real task across the real coding-agent CLIs (agentbridge) ---
 # claude-code, codex, copilot register as live A2A/SLIM adapters backed by the
 # actual installed CLI binary — the same DID identity from Part 1 carries over
 # automatically (agentbridge checks the same SHADI_SLIM_AUTH=did env). cursor-agent
 # has no `agentbridge register` listener yet, so it's skipped here.
+# codex checks real disk usage, copilot ranks real processes by CPU, and
+# claude-code is given both real outputs and asked to synthesize a report — each
+# step depends on the previous agent's real result, not a canned reply.
 # A failed delegate below usually means that CLI isn't installed/authenticated on
 # this machine, not a SHADI bug — the script continues regardless.
 
@@ -107,18 +111,38 @@ for a in claude-code codex copilot; do
 done
 sleep 3
 
-for a in claude-code codex copilot; do
-  step "Part 3: delegating a real task to $a (this really runs the $a CLI, can take up to ~30s)..."
-  env SHADI_AGENT_ID=avatar "$AB" delegate "Reply with exactly the single word: PONG" --to "$a" \
-    --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/$a-delegate.log" 2>&1
-done
+step "Part 3: delegating a disk-usage check to codex (real CLI call, can take ~30s)..."
+env SHADI_AGENT_ID=avatar "$AB" delegate \
+  "Run a disk usage check on this machine (e.g. df -h) and report the real output. Return only the command output, no commentary." \
+  --to codex --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/codex-delegate.log" 2>&1
+DISK_REPORT=$(sed 's/\x1b\[[0-9;]*m//g' "$LOG/codex-delegate.log" | sed -n '/^Response from/,$p' | tail -n +2)
+
+step "Part 3: delegating a top-CPU-processes check to copilot (real CLI call, can take ~30s)..."
+env SHADI_AGENT_ID=avatar "$AB" delegate \
+  "Rank the top 10 processes on this machine by CPU usage (e.g. ps aux sorted by %CPU) and report the real output. Return only the command output, no commentary." \
+  --to copilot --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/copilot-delegate.log" 2>&1
+CPU_REPORT=$(sed 's/\x1b\[[0-9;]*m//g' "$LOG/copilot-delegate.log" | sed -n '/^Response from/,$p' | tail -n +2)
+
+step "Part 3: delegating report synthesis to claude-code (real CLI call, can take ~30s)..."
+REPORT_PROMPT="You are given two real system-health snippets gathered by other agents on this machine. Write a short operational report (a few sentences plus key numbers) summarizing disk usage and CPU load, and flag anything that looks concerning.
+
+=== Disk usage (from codex) ===
+$DISK_REPORT
+
+=== Top CPU processes (from copilot) ===
+$CPU_REPORT"
+env SHADI_AGENT_ID=avatar "$AB" delegate "$REPORT_PROMPT" --to claude-code \
+  --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/claude-code-delegate.log" 2>&1
 step "Part 3 done."
 
 for p in "${REGISTER_PIDS[@]}"; do kill -INT "$p" 2>/dev/null; wait "$p" 2>/dev/null; done
 
+# Every process this script spawned is already tracked and reaped above (SHELL_PIDS,
+# COLLAB_PIDS, REGISTER_PIDS, NODE_PID) — deliberately NOT using a blanket
+# `pkill -f target/debug/shadictl|agentbridge` here, since that would also kill any
+# other run-demo.sh instance running concurrently on this machine.
 kill "$NODE_PID" 2>/dev/null
-pkill -f "target/debug/shadictl" 2>/dev/null
-pkill -f "target/debug/agentbridge" 2>/dev/null
+wait "$NODE_PID" 2>/dev/null
 
 strip() { sed 's/\x1b\[[0-9;]*m//g'; }
 echo
@@ -131,10 +155,14 @@ for a in claude-code codex copilot cursor-agent; do
   strip <"$LOG/$a-collaborate.log" | grep -iE "^broadcast|^  "
 done
 echo
-echo "================ agentbridge: real task delegation ================"
-for a in claude-code codex copilot; do
-  echo "-- $a --"
-  strip <"$LOG/$a-delegate.log" | grep -A1 -iE "^Response from"
-done
+echo "================ agentbridge: chained real task delegation ================"
+echo "-- codex: disk usage --"
+strip <"$LOG/codex-delegate.log" | sed -n '/^Response from/,$p'
+echo
+echo "-- copilot: top CPU processes --"
+strip <"$LOG/copilot-delegate.log" | sed -n '/^Response from/,$p'
+echo
+echo "-- claude-code: synthesized report --"
+strip <"$LOG/claude-code-delegate.log" | sed -n '/^Response from/,$p'
 echo
 echo "logs: $LOG"

--- a/docs/demos/run-demo.sh
+++ b/docs/demos/run-demo.sh
@@ -33,12 +33,20 @@ CH="agntcy/shadi/dev-room"
 LOG="$SHADI_TMP_DIR/logs"; mkdir -p "$LOG"
 ALL_AGENTS=(avatar claude-code codex copilot cursor-agent)
 
+step() { echo "[$(date +%H:%M:%S)] $*"; }
+
+step "logs: $LOG"
+step "watch live progress in another terminal:  bash docs/demos/watch-demo.sh"
+
 # One SLIM node spans both parts below; only killed at the very end.
+step "starting SLIM node..."
 "$BIN" slim start-node >"$LOG/node.log" 2>&1 &
 NODE_PID=$!
 sleep 2
 
 # --- Part 1: DID/moderator role UX (create/invite/join) -------------------
+
+step "Part 1: agents joining, moderator creating channel + inviting..."
 
 # Four coding-agent CLIs join the channel and report their role.
 SHELL_PIDS=()
@@ -63,9 +71,11 @@ SHELL_PIDS+=($!)
 
 for p in "${SHELL_PIDS[@]}"; do wait "$p"; done
 pkill -f "$BIN shell" 2>/dev/null
+step "Part 1 done."
 
 # --- Part 2: roll call over A2A's Collaborate op (SLIM group channel underneath) ---
 
+step "Part 2: roll call — every member broadcasting via /slim a2a-collaborate..."
 sleep 1
 COLLAB_PIDS=()
 for a in "${ALL_AGENTS[@]}"; do
@@ -78,6 +88,7 @@ for a in "${ALL_AGENTS[@]}"; do
   COLLAB_PIDS+=($!)
 done
 for p in "${COLLAB_PIDS[@]}"; do wait "$p"; done
+step "Part 2 done."
 
 # --- Part 3: delegate a real task to the real coding-agent CLIs (agentbridge) ---
 # claude-code, codex, copilot register as live A2A/SLIM adapters backed by the
@@ -87,6 +98,7 @@ for p in "${COLLAB_PIDS[@]}"; do wait "$p"; done
 # A failed delegate below usually means that CLI isn't installed/authenticated on
 # this machine, not a SHADI bug — the script continues regardless.
 
+step "Part 3: registering claude-code/codex/copilot as real agentbridge adapters..."
 REGISTER_PIDS=()
 for a in claude-code codex copilot; do
   env SHADI_AGENT_ID="$a" "$AB" register --tool "$a" --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
@@ -96,9 +108,11 @@ done
 sleep 3
 
 for a in claude-code codex copilot; do
+  step "Part 3: delegating a real task to $a (this really runs the $a CLI, can take up to ~30s)..."
   env SHADI_AGENT_ID=avatar "$AB" delegate "Reply with exactly the single word: PONG" --to "$a" \
     --agent-id avatar --endpoint "$SLIM_ENDPOINT" >"$LOG/$a-delegate.log" 2>&1
 done
+step "Part 3 done."
 
 for p in "${REGISTER_PIDS[@]}"; do kill -INT "$p" 2>/dev/null; wait "$p" 2>/dev/null; done
 

--- a/docs/demos/watch-demo.sh
+++ b/docs/demos/watch-demo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Tail live progress/logs for a run-demo.sh in progress.
+#
+# Run this in a second terminal while run-demo.sh is running (see
+# did-agent-group.md). It finds the most recently started demo run dir and
+# tails every per-agent log, labeled by filename — including files that
+# haven't been created yet (later phases), which `tail -F` picks up as soon
+# as run-demo.sh creates them.
+#
+# Usage:  bash docs/demos/watch-demo.sh
+set -uo pipefail
+
+DIR="$(ls -dt /tmp/shadi-did-demo.*/logs 2>/dev/null | head -1)"
+if [ -z "$DIR" ]; then
+  echo "No run-demo.sh run found yet — start one with 'bash docs/demos/run-demo.sh' first." >&2
+  exit 1
+fi
+
+AGENTS=(avatar claude-code codex copilot cursor-agent)
+FILES=("$DIR/node.log")
+for a in "${AGENTS[@]}"; do FILES+=("$DIR/$a.log" "$DIR/$a-collaborate.log"); done
+for a in claude-code codex copilot; do FILES+=("$DIR/$a-agent.log" "$DIR/$a-delegate.log"); done
+
+echo "Watching: $DIR (Ctrl-C to stop watching; does not affect the running demo)"
+echo
+tail -n +1 -F "${FILES[@]}" 2>/dev/null


### PR DESCRIPTION
## Real coding-agent CLIs in the loop

Adds step 7 to `did-agent-group.md`: `agentbridge register --tool claude-code|codex|copilot --slim-endpoint ...` starts a live SLIM/A2A listener backed by the actual installed CLI binary, using the same DID identity as the rest of the demo (agentbridge already checks `SHADI_SLIM_AUTH=did` the same way `shadictl` does — no new wiring needed). The moderator then `agentbridge delegate`s a real task to each over the same SLIM node, and the CLI's real output comes back over A2A.

`cursor-agent` has no `agentbridge register` listener yet, so it's not part of this step.

Also updates `run-demo.sh` with a "Part 3" doing this end to end for all three.

## Test

- Live smoke tests: registered claude-code/codex/copilot individually, delegated a trivial prompt to each, confirmed the real CLI's response came back over SLIM/A2A (both under shared-secret and the demo's native DID auth).
- Full `run-demo.sh` run (multiple times): all 5 members join/invite/roll-call as before, then claude-code/codex/copilot each receive and correctly respond to a real delegated task.
- Manual follow-up test (not yet in the script): chained a real task across 3 agents — codex reported real disk usage, copilot ranked real processes by CPU, and claude-code synthesized both into an operational report — confirming the wiring supports genuine task delegation and context sharing, not just a canned prompt.