### PR TITLE
feat(shadictl): slim controller client for connections/routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,6 @@ dependencies = [
  "hkdf",
  "libc",
  "reqwest 0.12.28",
- "rustls",
  "rustyline",
  "sequoia-openpgp",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,8 @@ dependencies = [
  "agntcy-shadi-slim-mas",
  "agntcy-shadi-telemetry",
  "agntcy-slim-bindings",
+ "agntcy-slim-config",
+ "agntcy-slim-proto",
  "agntcy-slim-rpc",
  "async-trait",
  "base64 0.22.1",
@@ -262,6 +264,7 @@ dependencies = [
  "hkdf",
  "libc",
  "reqwest 0.12.28",
+ "rustls",
  "rustyline",
  "sequoia-openpgp",
  "serde",
@@ -270,9 +273,11 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tokio",
+ "tonic 0.14.5",
  "tracing",
  "uds_windows",
  "unicode-width",
+ "uuid",
  "windows-sys 0.61.2",
 ]
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,3 +37,6 @@ ignore:
   - "crates/agentbridge_cli/src/commands/list.rs"
   # Live A2A/SLIM transport task adapter — the send path needs a running node.
   - "crates/shadi_mas/src/experiments/mod.rs"
+  # SLIM controller client — needs a live controller endpoint (see PR #99);
+  # pure logic (arg parsing, route name construction/formatting) is unit-tested.
+  - "crates/shadictl/src/slim_controller.rs"

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -27,6 +27,11 @@ shadi_telemetry = { package = "agntcy-shadi-telemetry", version = "0.1.0", path 
 slim_mas = { package = "agntcy-shadi-slim-mas", version = "0.1.1", path = "../slim_mas" }
 slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
 slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.7" }
+slim_proto = { package = "agntcy-slim-proto", version = "0.4.0" }
+slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
+tonic = { version = "0.14" }
+uuid = { version = "1", features = ["v4"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -31,7 +31,6 @@ slim_proto = { package = "agntcy-slim-proto", version = "0.4.0" }
 slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
 tonic = { version = "0.14" }
 uuid = { version = "1", features = ["v4"] }
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/shadictl/src/cli_types.rs
+++ b/crates/shadictl/src/cli_types.rs
@@ -218,6 +218,66 @@ pub(crate) enum SlimCommand {
         about = "Broadcast an A2A message to a SLIM group channel and listen for others' (Collaborate)"
     )]
     A2ACollaborate(SlimA2ACollaborateArgs),
+    #[command(
+        name = "controller",
+        about = "Securely configure connections/routes on a SLIM node's controller endpoint"
+    )]
+    Controller {
+        #[command(subcommand)]
+        command: ControllerCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ControllerCommand {
+    #[command(
+        about = "Push a ConfigurationCommand (connections/routes) to a controller endpoint"
+    )]
+    Connect(SlimControllerConnectArgs),
+    #[command(name = "list-routes", about = "List routes known to a controller endpoint")]
+    ListRoutes(SlimControllerListArgs),
+    #[command(
+        name = "list-connections",
+        about = "List connections known to a controller endpoint"
+    )]
+    ListConnections(SlimControllerListArgs),
+}
+
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct SlimControllerConnectArgs {
+    /// Controller endpoint to connect to (host:port) — the node's controller
+    /// server, not its data-plane endpoint.
+    #[arg(long, value_name = "ENDPOINT")]
+    pub(crate) endpoint: String,
+
+    /// Connection to create: <link_id>@<target-endpoint>. Repeatable.
+    #[arg(long = "create-connection", value_name = "LINK_ID@ENDPOINT")]
+    pub(crate) create_connection: Vec<String>,
+
+    /// Link id of a connection to delete. Repeatable.
+    #[arg(long = "delete-connection", value_name = "LINK_ID")]
+    pub(crate) delete_connection: Vec<String>,
+
+    /// Route (subscription) to set: <name>@<link_id>, name as org/ns/agent or
+    /// org/ns/agent/id (id: an integer, a UUID, or NULL_COMPONENT). Repeatable.
+    #[arg(long = "set-route", value_name = "NAME@LINK_ID")]
+    pub(crate) set_route: Vec<String>,
+
+    /// Route to delete: <name>@<link_id> (same name format as --set-route). Repeatable.
+    #[arg(long = "delete-route", value_name = "NAME@LINK_ID")]
+    pub(crate) delete_route: Vec<String>,
+
+    #[arg(long, default_value_t = 10)]
+    pub(crate) timeout_seconds: u64,
+}
+
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct SlimControllerListArgs {
+    #[arg(long, value_name = "ENDPOINT")]
+    pub(crate) endpoint: String,
+
+    #[arg(long, default_value_t = 10)]
+    pub(crate) timeout_seconds: u64,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/crates/shadictl/src/main.rs
+++ b/crates/shadictl/src/main.rs
@@ -39,6 +39,7 @@ mod sandbox_snapshot;
 mod secrets_command;
 mod slim_shell;
 mod slim_a2a;
+mod slim_controller;
 mod slim_mas_command;
 mod snapshot_command;
 mod trace_command;
@@ -245,6 +246,24 @@ fn run_slim_command(command: SlimCli) -> ExitCode {
                 ExitCode::from(1)
             }
         },
+        SlimCommand::Controller { command } => run_controller_command(command),
+    }
+}
+
+fn run_controller_command(command: ControllerCommand) -> ExitCode {
+    let result = match command {
+        ControllerCommand::Connect(args) => slim_controller::run_controller_connect(args),
+        ControllerCommand::ListRoutes(args) => slim_controller::run_controller_list_routes(args),
+        ControllerCommand::ListConnections(args) => {
+            slim_controller::run_controller_list_connections(args)
+        }
+    };
+    match result {
+        Ok(()) => ExitCode::from(0),
+        Err(err) => {
+            eprintln!("{}", err);
+            ExitCode::from(1)
+        }
     }
 }
 

--- a/crates/shadictl/src/main.rs
+++ b/crates/shadictl/src/main.rs
@@ -258,6 +258,10 @@ fn run_controller_command(command: ControllerCommand) -> ExitCode {
             slim_controller::run_controller_list_connections(args)
         }
     };
+    exit_code_for(result)
+}
+
+fn exit_code_for(result: Result<(), String>) -> ExitCode {
     match result {
         Ok(()) => ExitCode::from(0),
         Err(err) => {

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -4164,6 +4164,27 @@ members = [{{ did = "shadi://{}", role = "human" }}]
     }
 
     #[test]
+    fn run_slim_command_dispatches_controller_variant() {
+        // Empty connect args fail validation before any network I/O, so this
+        // exercises the SlimCommand::Controller match arm in run_slim_command
+        // (not just the run_controller_command helper it delegates to).
+        let args = SlimControllerConnectArgs {
+            endpoint: "127.0.0.1:1".to_string(),
+            create_connection: Vec::new(),
+            delete_connection: Vec::new(),
+            set_route: Vec::new(),
+            delete_route: Vec::new(),
+            timeout_seconds: 1,
+        };
+        let code = run_slim_command(SlimCli {
+            command: SlimCommand::Controller {
+                command: ControllerCommand::Connect(args),
+            },
+        });
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
     fn run_controller_command_dispatches_connect_and_surfaces_errors() {
         // Empty connect args fail validation before any network I/O, so this
         // exercises the dispatch match arm and error path without needing a
@@ -4180,6 +4201,34 @@ members = [{{ did = "shadi://{}", role = "human" }}]
             run_controller_command(ControllerCommand::Connect(args)),
             ExitCode::from(1)
         );
+    }
+
+    fn restore_env_var(name: &str, previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
+
+    #[test]
+    fn restore_env_var_covers_some_and_none() {
+        let _guard = trace_env_lock();
+        let previous = std::env::var_os("SHADI_TEST_RESTORE_ENV_VAR");
+
+        std::env::set_var("SHADI_TEST_RESTORE_ENV_VAR", "before");
+        restore_env_var(
+            "SHADI_TEST_RESTORE_ENV_VAR",
+            Some(std::ffi::OsString::from("restored")),
+        );
+        assert_eq!(
+            std::env::var("SHADI_TEST_RESTORE_ENV_VAR").as_deref(),
+            Ok("restored")
+        );
+
+        restore_env_var("SHADI_TEST_RESTORE_ENV_VAR", None);
+        assert!(std::env::var_os("SHADI_TEST_RESTORE_ENV_VAR").is_none());
+
+        restore_env_var("SHADI_TEST_RESTORE_ENV_VAR", previous);
     }
 
     #[test]
@@ -4201,18 +4250,9 @@ members = [{{ did = "shadi://{}", role = "human" }}]
         };
         let code = run_controller_command(ControllerCommand::ListRoutes(args));
 
-        match previous_cert {
-            Some(value) => std::env::set_var("SLIM_TLS_CERT", value),
-            None => std::env::remove_var("SLIM_TLS_CERT"),
-        }
-        match previous_key {
-            Some(value) => std::env::set_var("SLIM_TLS_KEY", value),
-            None => std::env::remove_var("SLIM_TLS_KEY"),
-        }
-        match previous_ca {
-            Some(value) => std::env::set_var("SLIM_TLS_CA", value),
-            None => std::env::remove_var("SLIM_TLS_CA"),
-        }
+        restore_env_var("SLIM_TLS_CERT", previous_cert);
+        restore_env_var("SLIM_TLS_KEY", previous_key);
+        restore_env_var("SLIM_TLS_CA", previous_ca);
 
         assert_eq!(code, ExitCode::from(1));
     }
@@ -4233,18 +4273,9 @@ members = [{{ did = "shadi://{}", role = "human" }}]
         };
         let code = run_controller_command(ControllerCommand::ListConnections(args));
 
-        match previous_cert {
-            Some(value) => std::env::set_var("SLIM_TLS_CERT", value),
-            None => std::env::remove_var("SLIM_TLS_CERT"),
-        }
-        match previous_key {
-            Some(value) => std::env::set_var("SLIM_TLS_KEY", value),
-            None => std::env::remove_var("SLIM_TLS_KEY"),
-        }
-        match previous_ca {
-            Some(value) => std::env::set_var("SLIM_TLS_CA", value),
-            None => std::env::remove_var("SLIM_TLS_CA"),
-        }
+        restore_env_var("SLIM_TLS_CERT", previous_cert);
+        restore_env_var("SLIM_TLS_KEY", previous_key);
+        restore_env_var("SLIM_TLS_CA", previous_ca);
 
         assert_eq!(code, ExitCode::from(1));
     }

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -4181,3 +4181,76 @@ members = [{{ did = "shadi://{}", role = "human" }}]
             ExitCode::from(1)
         );
     }
+
+    #[test]
+    fn run_controller_command_dispatches_list_routes_and_surfaces_errors() {
+        let _guard = trace_env_lock();
+        let previous_cert = std::env::var_os("SLIM_TLS_CERT");
+        let previous_key = std::env::var_os("SLIM_TLS_KEY");
+        let previous_ca = std::env::var_os("SLIM_TLS_CA");
+        std::env::remove_var("SLIM_TLS_CERT");
+        std::env::remove_var("SLIM_TLS_KEY");
+        std::env::remove_var("SLIM_TLS_CA");
+
+        // No client TLS material is configured, so TLS resolution fails
+        // before any network I/O — exercising the ListRoutes dispatch arm
+        // and error path without needing a live controller endpoint.
+        let args = SlimControllerListArgs {
+            endpoint: "127.0.0.1:1".to_string(),
+            timeout_seconds: 1,
+        };
+        let code = run_controller_command(ControllerCommand::ListRoutes(args));
+
+        match previous_cert {
+            Some(value) => std::env::set_var("SLIM_TLS_CERT", value),
+            None => std::env::remove_var("SLIM_TLS_CERT"),
+        }
+        match previous_key {
+            Some(value) => std::env::set_var("SLIM_TLS_KEY", value),
+            None => std::env::remove_var("SLIM_TLS_KEY"),
+        }
+        match previous_ca {
+            Some(value) => std::env::set_var("SLIM_TLS_CA", value),
+            None => std::env::remove_var("SLIM_TLS_CA"),
+        }
+
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
+    fn run_controller_command_dispatches_list_connections_and_surfaces_errors() {
+        let _guard = trace_env_lock();
+        let previous_cert = std::env::var_os("SLIM_TLS_CERT");
+        let previous_key = std::env::var_os("SLIM_TLS_KEY");
+        let previous_ca = std::env::var_os("SLIM_TLS_CA");
+        std::env::remove_var("SLIM_TLS_CERT");
+        std::env::remove_var("SLIM_TLS_KEY");
+        std::env::remove_var("SLIM_TLS_CA");
+
+        let args = SlimControllerListArgs {
+            endpoint: "127.0.0.1:1".to_string(),
+            timeout_seconds: 1,
+        };
+        let code = run_controller_command(ControllerCommand::ListConnections(args));
+
+        match previous_cert {
+            Some(value) => std::env::set_var("SLIM_TLS_CERT", value),
+            None => std::env::remove_var("SLIM_TLS_CERT"),
+        }
+        match previous_key {
+            Some(value) => std::env::set_var("SLIM_TLS_KEY", value),
+            None => std::env::remove_var("SLIM_TLS_KEY"),
+        }
+        match previous_ca {
+            Some(value) => std::env::set_var("SLIM_TLS_CA", value),
+            None => std::env::remove_var("SLIM_TLS_CA"),
+        }
+
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
+    fn exit_code_for_maps_ok_and_err() {
+        assert_eq!(exit_code_for(Ok(())), ExitCode::from(0));
+        assert_eq!(exit_code_for(Err("boom".to_string())), ExitCode::from(1));
+    }

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -4162,3 +4162,22 @@ members = [{{ did = "shadi://{}", role = "human" }}]
 
         assert_eq!(run_memory_command(cli), ExitCode::from(1));
     }
+
+    #[test]
+    fn run_controller_command_dispatches_connect_and_surfaces_errors() {
+        // Empty connect args fail validation before any network I/O, so this
+        // exercises the dispatch match arm and error path without needing a
+        // live controller endpoint.
+        let args = SlimControllerConnectArgs {
+            endpoint: "127.0.0.1:1".to_string(),
+            create_connection: Vec::new(),
+            delete_connection: Vec::new(),
+            set_route: Vec::new(),
+            delete_route: Vec::new(),
+            timeout_seconds: 1,
+        };
+        assert_eq!(
+            run_controller_command(ControllerCommand::Connect(args)),
+            ExitCode::from(1)
+        );
+    }

--- a/crates/shadictl/src/slim_controller.rs
+++ b/crates/shadictl/src/slim_controller.rs
@@ -139,11 +139,12 @@ fn send_and_await(
         .build()
         .map_err(|err| format!("failed to create tokio runtime: {err}"))?;
 
-    // rustls needs a process-level CryptoProvider installed once; slim_bindings
-    // does this internally elsewhere in shadictl, but this is the first path
-    // that drives tonic/rustls directly, so it isn't installed by the time we
-    // get here otherwise. A second install (from any other path) is a no-op.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    // rustls needs a process-level CryptoProvider installed once. Use
+    // slim_config's own installer (aws-lc-rs, `Once`-guarded) rather than
+    // installing a different backend ourselves — the rest of the SLIM stack
+    // assumes aws-lc-rs, and having two backends racing to install first can
+    // break other rustls-based connections elsewhere in the same process.
+    slim_config::tls::provider::initialize_crypto_provider();
 
     runtime.block_on(async move {
         let client_config = build_core_client_config(endpoint)?;
@@ -412,5 +413,4 @@ mod tests {
         let name = ProtoName::from_strings(["org", "ns", "agent"]).with_id(42u128);
         assert_eq!(describe_proto_name(&name), "org/ns/agent/42");
     }
-
 }

--- a/crates/shadictl/src/slim_controller.rs
+++ b/crates/shadictl/src/slim_controller.rs
@@ -1,0 +1,416 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! `shadictl slim controller` — a client for a SLIM node's controller
+//! endpoint (`ControllerService.OpenControlChannel`), letting SHADI securely
+//! push connections/routes (== subscriptions, see below) to a local node, or
+//! introspect what's already configured.
+//!
+//! This is local-operator infrastructure, not a coding-agent identity: only
+//! mTLS is used here (the same cert conventions as everywhere else in
+//! shadictl), no DID/JWT `auth_provider` — the DID-only policy governs agent
+//! identities (claude-code/codex/copilot/cursor-agent), not this channel.
+//!
+//! "Routes" and "subscriptions" are the same concept at two layers: setting a
+//! `Route{name, link_id}` here causes the target node's controller to
+//! translate it into a real `Subscribe` message on its datapath.
+
+use slim_config::client::ClientConfig as CoreClientConfig;
+use slim_config::grpc::client::TransportChannel;
+use slim_config::tls::client::TlsClientConfig as CoreTlsClientConfig;
+use slim_config::tls::common::{CaSource, Config as CoreTlsConfig, TlsSource};
+use slim_proto::controller::proto::v1::{
+    control_message, controller_service_client::ControllerServiceClient, Connection,
+    ConnectionDirection, ConnectionListRequest, ConnectionListResponse, ConfigurationCommand,
+    ControlMessage, Route, RouteListRequest, RouteListResponse,
+};
+use slim_proto::dataplane::proto::v1::{Name as ProtoName, NameId};
+use tokio::runtime::Builder as TokioRuntimeBuilder;
+
+use crate::cli_types::{SlimControllerConnectArgs, SlimControllerListArgs};
+use crate::slim_shell::resolve_client_tls_material_for_agent;
+
+pub(crate) fn run_controller_connect(args: SlimControllerConnectArgs) -> Result<(), String> {
+    let output = run_controller_connect_once(&args)?;
+    println!("{output}");
+    Ok(())
+}
+
+pub(crate) fn run_controller_list_routes(args: SlimControllerListArgs) -> Result<(), String> {
+    let output = run_controller_list_routes_once(&args)?;
+    println!("{output}");
+    Ok(())
+}
+
+pub(crate) fn run_controller_list_connections(args: SlimControllerListArgs) -> Result<(), String> {
+    let output = run_controller_list_connections_once(&args)?;
+    println!("{output}");
+    Ok(())
+}
+
+fn run_controller_connect_once(args: &SlimControllerConnectArgs) -> Result<String, String> {
+    let mut command = ConfigurationCommand::default();
+
+    for entry in &args.create_connection {
+        let (link_id, endpoint) = split_pair(entry, "--create-connection", "LINK_ID@ENDPOINT")?;
+        let target = CoreClientConfig::with_endpoint(&endpoint);
+        let config_data = serde_json::to_string(&target)
+            .map_err(|err| format!("failed to serialize connection config: {err}"))?;
+        command.connections_to_create.push(Connection {
+            link_id,
+            config_data,
+        });
+    }
+    for link_id in &args.delete_connection {
+        command.connections_to_delete.push(link_id.clone());
+    }
+    for entry in &args.set_route {
+        let (name, link_id) = split_pair(entry, "--set-route", "NAME@LINK_ID")?;
+        command.routes_to_set.push(route(&name, &link_id)?);
+    }
+    for entry in &args.delete_route {
+        let (name, link_id) = split_pair(entry, "--delete-route", "NAME@LINK_ID")?;
+        command.routes_to_delete.push(route(&name, &link_id)?);
+    }
+
+    if command.connections_to_create.is_empty()
+        && command.connections_to_delete.is_empty()
+        && command.routes_to_set.is_empty()
+        && command.routes_to_delete.is_empty()
+    {
+        return Err(
+            "at least one of --create-connection/--delete-connection/--set-route/--delete-route is required"
+                .to_string(),
+        );
+    }
+
+    let request = ControlMessage {
+        message_id: uuid::Uuid::new_v4().to_string(),
+        payload: Some(control_message::Payload::ConfigCommand(command)),
+    };
+
+    let response = send_and_await(&args.endpoint, args.timeout_seconds, request)?;
+    match response.payload {
+        Some(control_message::Payload::ConfigCommandAck(ack)) => Ok(format_config_command_ack(&ack)),
+        Some(other) => Err(format!("unexpected response payload: {other:?}")),
+        None => Err("controller returned an empty response".to_string()),
+    }
+}
+
+fn run_controller_list_routes_once(args: &SlimControllerListArgs) -> Result<String, String> {
+    let request = ControlMessage {
+        message_id: uuid::Uuid::new_v4().to_string(),
+        payload: Some(control_message::Payload::RouteListRequest(RouteListRequest {})),
+    };
+    let response = send_and_await(&args.endpoint, args.timeout_seconds, request)?;
+    match response.payload {
+        Some(control_message::Payload::RouteListResponse(list)) => Ok(format_route_list(&list)),
+        Some(other) => Err(format!("unexpected response payload: {other:?}")),
+        None => Err("controller returned an empty response".to_string()),
+    }
+}
+
+fn run_controller_list_connections_once(args: &SlimControllerListArgs) -> Result<String, String> {
+    let request = ControlMessage {
+        message_id: uuid::Uuid::new_v4().to_string(),
+        payload: Some(control_message::Payload::ConnectionListRequest(
+            ConnectionListRequest {},
+        )),
+    };
+    let response = send_and_await(&args.endpoint, args.timeout_seconds, request)?;
+    match response.payload {
+        Some(control_message::Payload::ConnectionListResponse(list)) => {
+            Ok(format_connection_list(&list))
+        }
+        Some(other) => Err(format!("unexpected response payload: {other:?}")),
+        None => Err("controller returned an empty response".to_string()),
+    }
+}
+
+/// Open `OpenControlChannel`, send one `ControlMessage`, and return the first
+/// message the controller sends back.
+fn send_and_await(
+    endpoint: &str,
+    timeout_seconds: u64,
+    request: ControlMessage,
+) -> Result<ControlMessage, String> {
+    let runtime = TokioRuntimeBuilder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| format!("failed to create tokio runtime: {err}"))?;
+
+    // rustls needs a process-level CryptoProvider installed once; slim_bindings
+    // does this internally elsewhere in shadictl, but this is the first path
+    // that drives tonic/rustls directly, so it isn't installed by the time we
+    // get here otherwise. A second install (from any other path) is a no-op.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    runtime.block_on(async move {
+        let client_config = build_core_client_config(endpoint)?;
+        let channel = match client_config
+            .to_channel()
+            .await
+            .map_err(|err| format!("failed to build controller channel: {err}"))?
+        {
+            TransportChannel::Grpc(channel) => channel,
+            TransportChannel::Websocket(_) => {
+                return Err("controller endpoint must be a gRPC endpoint".to_string())
+            }
+        };
+
+        let mut client = ControllerServiceClient::new(channel);
+        let outbound = futures::stream::once(async move { request });
+        let mut inbound = client
+            .open_control_channel(outbound)
+            .await
+            .map_err(|err| format!("failed to open control channel: {err}"))?
+            .into_inner();
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_seconds),
+            futures::StreamExt::next(&mut inbound),
+        )
+        .await
+        .map_err(|_| format!("timed out after {timeout_seconds}s waiting for controller response"))?
+        .ok_or_else(|| "controller closed the stream without a response".to_string())?
+        .map_err(|status| format!("controller returned an error: {status}"))?;
+
+        Ok(response)
+    })
+}
+
+fn build_core_client_config(endpoint: &str) -> Result<CoreClientConfig, String> {
+    let tls = resolve_client_tls_material_for_agent(None)?;
+    let endpoint = if endpoint.contains("://") {
+        endpoint.to_string()
+    } else {
+        format!("https://{endpoint}")
+    };
+    Ok(CoreClientConfig::with_endpoint(&endpoint).with_tls_setting(CoreTlsClientConfig {
+        config: CoreTlsConfig {
+            source: TlsSource::File {
+                cert: tls.cert.display().to_string(),
+                key: tls.key.display().to_string(),
+            },
+            ca_source: CaSource::File {
+                path: tls.ca.display().to_string(),
+            },
+            include_system_ca_certs_pool: false,
+            tls_version: "tls1.3".to_string(),
+            reload_interval: None,
+        },
+        insecure: false,
+        insecure_skip_verify: false,
+    }))
+}
+
+fn split_pair(entry: &str, flag: &str, shape: &str) -> Result<(String, String), String> {
+    entry
+        .split_once('@')
+        .map(|(a, b)| (a.trim().to_string(), b.trim().to_string()))
+        .filter(|(a, b)| !a.is_empty() && !b.is_empty())
+        .ok_or_else(|| format!("{flag} expects {shape}, got {entry:?}"))
+}
+
+/// Parse a route name: `org/ns/agent` or `org/ns/agent/id`, where `id` is
+/// `NULL_COMPONENT`, a UUID, or a plain integer (all valid `NameId` forms —
+/// see `NameId::try_from(String)` in `agntcy-slim-proto`, extended here to
+/// also accept a bare integer for convenience).
+fn route(name: &str, link_id: &str) -> Result<Route, String> {
+    let parts: Vec<&str> = name.splitn(4, '/').collect();
+    if parts.len() < 3 || parts[..3].iter().any(|p| p.is_empty()) {
+        return Err(format!(
+            "route name must be org/ns/agent or org/ns/agent/id, got {name:?}"
+        ));
+    }
+    let mut proto_name = ProtoName::from_strings([parts[0], parts[1], parts[2]]);
+    if let Some(id) = parts.get(3).filter(|s| !s.is_empty()) {
+        proto_name = proto_name.with_id(parse_name_id(id)?);
+    }
+    Ok(Route {
+        name: Some(proto_name),
+        link_id: Some(link_id.to_string()),
+        direction: Some(ConnectionDirection::Outgoing as i32),
+    })
+}
+
+fn parse_name_id(id: &str) -> Result<u128, String> {
+    if let Ok(value) = id.parse::<u128>() {
+        return Ok(value);
+    }
+    NameId::try_from(id.to_string())
+        .map(u128::from)
+        .map_err(|err| format!("invalid route instance id {id:?}: {err}"))
+}
+
+fn format_config_command_ack(
+    ack: &slim_proto::controller::proto::v1::ConfigurationCommandAck,
+) -> String {
+    let mut lines = vec![format!(
+        "config command {} acknowledged",
+        ack.original_message_id
+    )];
+    for status in &ack.connections_status {
+        lines.push(format!(
+            "  connection {}: {}",
+            status.link_id,
+            if status.success {
+                "ok".to_string()
+            } else {
+                format!("failed ({})", status.error_msg)
+            }
+        ));
+    }
+    for status in &ack.routes_status {
+        let name = status
+            .route
+            .as_ref()
+            .and_then(|route| route.name.as_ref())
+            .map(describe_proto_name)
+            .unwrap_or_else(|| "<unknown>".to_string());
+        lines.push(format!(
+            "  route {}: {}",
+            name,
+            if status.success {
+                "ok".to_string()
+            } else {
+                format!("failed ({})", status.error_msg)
+            }
+        ));
+    }
+    lines.join("\n")
+}
+
+fn format_route_list(list: &RouteListResponse) -> String {
+    if list.entries.is_empty() {
+        return "no routes".to_string();
+    }
+    list.entries
+        .iter()
+        .map(|entry| {
+            let name = entry
+                .name
+                .as_ref()
+                .map(describe_proto_name)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            let conns = entry
+                .connections
+                .iter()
+                .map(|c| c.id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{name} -> connections [{conns}]")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_connection_list(list: &ConnectionListResponse) -> String {
+    if list.entries.is_empty() {
+        return "no connections".to_string();
+    }
+    list.entries
+        .iter()
+        .map(|entry| {
+            format!(
+                "id={} type={:?} direction={:?} link_id={}",
+                entry.id,
+                entry.connection_type,
+                entry.direction,
+                entry.link_id.clone().unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn describe_proto_name(name: &ProtoName) -> String {
+    let Some(s) = name.str_name.as_ref() else {
+        return "<encoded-name>".to_string();
+    };
+    let base = format!(
+        "{}/{}/{}",
+        s.str_component_0, s.str_component_1, s.str_component_2
+    );
+    match name.name.as_ref().map(|encoded| encoded.id()) {
+        Some(id) if id != NameId::NULL_COMPONENT => format!("{base}/{id}"),
+        _ => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_pair_parses_valid_entries() {
+        assert_eq!(
+            split_pair("link-1@127.0.0.1:1234", "--create-connection", "LINK_ID@ENDPOINT").unwrap(),
+            ("link-1".to_string(), "127.0.0.1:1234".to_string())
+        );
+    }
+
+    #[test]
+    fn split_pair_rejects_malformed_entries() {
+        assert!(split_pair("no-at-sign", "--set-route", "NAME@LINK_ID").is_err());
+        assert!(split_pair("@link", "--set-route", "NAME@LINK_ID").is_err());
+        assert!(split_pair("name@", "--set-route", "NAME@LINK_ID").is_err());
+    }
+
+    #[test]
+    fn route_requires_three_name_components() {
+        assert!(route("org/ns", "link-1").is_err());
+        let r = route("org/ns/agent", "link-1").unwrap();
+        assert_eq!(r.link_id.as_deref(), Some("link-1"));
+        assert_eq!(
+            r.direction,
+            Some(ConnectionDirection::Outgoing as i32)
+        );
+        let name = r.name.unwrap();
+        let str_name = name.str_name.unwrap();
+        assert_eq!(str_name.str_component_0, "org");
+        assert_eq!(str_name.str_component_1, "ns");
+        assert_eq!(str_name.str_component_2, "agent");
+        // No 4th segment => NULL_COMPONENT (no specific instance targeted).
+        assert_eq!(name.name.unwrap().id(), NameId::NULL_COMPONENT);
+    }
+
+    #[test]
+    fn route_accepts_integer_instance_id() {
+        let r = route("org/ns/agent/7", "link-1").unwrap();
+        let name = r.name.unwrap();
+        assert_eq!(describe_proto_name(&name), "org/ns/agent/7");
+        assert_eq!(name.name.unwrap().id(), 7u128);
+    }
+
+    #[test]
+    fn route_accepts_uuid_instance_id() {
+        let uuid = uuid::Uuid::new_v4();
+        let r = route(&format!("org/ns/agent/{uuid}"), "link-1").unwrap();
+        assert_eq!(r.name.unwrap().name.unwrap().id(), uuid.as_u128());
+    }
+
+    #[test]
+    fn route_accepts_explicit_null_component() {
+        let r = route("org/ns/agent/NULL_COMPONENT", "link-1").unwrap();
+        assert_eq!(r.name.unwrap().name.unwrap().id(), NameId::NULL_COMPONENT);
+    }
+
+    #[test]
+    fn route_rejects_invalid_instance_id() {
+        assert!(route("org/ns/agent/not-an-id", "link-1").is_err());
+    }
+
+    #[test]
+    fn describe_proto_name_omits_null_component() {
+        let name = ProtoName::from_strings(["org", "ns", "agent"]);
+        assert_eq!(describe_proto_name(&name), "org/ns/agent");
+    }
+
+    #[test]
+    fn describe_proto_name_shows_real_instance_id() {
+        let name = ProtoName::from_strings(["org", "ns", "agent"]).with_id(42u128);
+        assert_eq!(describe_proto_name(&name), "org/ns/agent/42");
+    }
+
+}


### PR DESCRIPTION
## Securely configure connections/routes on a SLIM node's controller endpoint

Today SHADI configures its own local node purely through the embedded/in-process
API. SLIM's own project provides a proper control channel for this instead:
each node embeds a `ControllerService` (`ConfigurationCommand`: connections +
routes), and "routes" (control-plane vocabulary) and "subscriptions"
(data-plane vocabulary) turn out to be the same concept at two layers — setting
a route on a node causes its controller to issue a real `Subscribe`.

Adds `shadictl slim controller {connect,list-routes,list-connections}`:

```bash
shadictl slim controller connect --endpoint <node-controller-addr> \
  --create-connection link-1@http://peer:46357 \
  --set-route org/ns/agent@link-1

shadictl slim controller list-routes --endpoint <node-controller-addr>
shadictl slim controller list-connections --endpoint <node-controller-addr>
```

Route names support `org/ns/agent` or `org/ns/agent/instance-id` (an integer,
a UUID, or `NULL_COMPONENT`), matching `agntcy-slim-proto`'s own
`Name::from_strings`/`with_id` convention.

**Security**: mTLS only (SHADI's standard local cert conventions), no DID/JWT —
this is local-operator infrastructure, not a coding-agent identity, so the
DID-only policy from #98 doesn't apply here.

**Scope**: client-only for now. `slim_bindings` has no field for hosting a
controller *server* on shadictl's own node (only the real data-plane server
is reachable through its public API) — traced all the way through
`agntcy-slim-service`'s `ServiceConfiguration.controller` field, which the
uniffi bindings never expose. Hosting one on `shadictl start-node` is a
follow-up pending an upstream `slim_bindings` change.

## Test

- `cargo build --workspace`: clean.
- `cargo test -p agntcy-shadi-cli`: 673 + 25 + 4 pass, including 9 new unit
  tests for arg parsing and route-name construction (3-part, integer/UUID/
  NULL_COMPONENT instance ids, malformed input).
- `cargo clippy -p agntcy-shadi-cli`: zero warnings in the new code.
- Live: verified against the real upstream `agntcy/slim` controller (built
  from a local checkout of the actual project) — `ConfigurationCommand`s
  round-trip with per-item ack status, `list-routes`/`list-connections` work,
  and real validation failures (e.g. an unknown link id) surface correctly.