### PR TITLE
docs: frame agentbridge as general-purpose A2A interconnect

### DIFF
--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -1,15 +1,27 @@
-# agentbridge — Autonomous CLI Coding-Agent Interconnect
+# agentbridge — General-Purpose Agent Interconnect over A2A
 
-agentbridge is the layer of SHADI that connects CLI coding tools — Claude Code,
-GitHub Copilot CLI, OpenAI Codex CLI, Cursor Agent, or any tool that speaks the
-agentbridge subprocess protocol — so they can exchange context, delegate tasks to
-each other, and coordinate autonomously until a programming goal is achieved.
+agentbridge is the layer of SHADI that bridges agents over the
+[A2A protocol](slim_a2a.md) — via SLIM transport, DID identity, DIR
+discovery, and `shadi_mas` for autonomous multi-round coordination — so they
+can exchange context, delegate tasks to each other, and coordinate
+autonomously toward a shared goal. Nothing in that mechanism is specific to
+any one kind of agent: any agent that speaks A2A, or the simpler agentbridge
+subprocess protocol (`GenericStdioAdapter`), can be bridged this way.
+
+Today's built-in adapters happen to target CLI coding tools — Claude Code,
+GitHub Copilot CLI, OpenAI Codex CLI, Cursor Agent — because interconnecting
+coding assistants was the motivating use case this was first built for, and
+they remain the flagship, most-exercised example throughout this page and the
+demos. The `CliAdapter` trait, the A2A/SLIM transport, and the coordination
+runtime underneath them don't know or care that they're wrapping coding
+tools; a bridge for any other class of agent looks the same.
 
 ## Motivation
 
-Every major coding assistant operates in isolation. When a developer switches
-tools (e.g., from Claude Code to Copilot), all conversation history, open files,
-and accumulated context is lost. There is no standard way to:
+The concrete problem that motivated agentbridge: every major coding assistant
+operates in isolation. When a developer switches tools (e.g., from Claude Code
+to Copilot), all conversation history, open files, and accumulated context is
+lost. There was no standard way to:
 
 - hand off an in-progress session from one tool to another,
 - ask one agent to generate a specific artifact for another agent's task, or
@@ -17,7 +29,8 @@ and accumulated context is lost. There is no standard way to:
 
 agentbridge solves this using the existing SHADI infrastructure: A2A for task
 delegation, SLIM for transport, DIR for discovery, and `shadi_mas` for
-autonomous multi-round coordination.
+autonomous multi-round coordination — the same general-purpose stack that
+would bridge any other kind of agent, applied here to coding tools first.
 
 ## Quick start
 

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -196,4 +196,4 @@ The CLI combines profile defaults, policy file settings, and explicit flags:
 - Review the full threat model, secret-delivery rationale, and residual risks in [Security Notes](security.md).
 - Put this into practice with [Sandbox and Policies](sandbox.md) and the [CLI Reference](cli.md).
 - Integrate into an agent or app via the [API Guide](api_integration.md).
-- See the multi-agent coordination layer and CLI coding-agent interconnect in [AgentBridge](agentbridge.md).
+- See the multi-agent coordination layer and general-purpose A2A agent interconnect in [AgentBridge](agentbridge.md).

--- a/docs/content/design.md
+++ b/docs/content/design.md
@@ -10,7 +10,7 @@ The workspace contains these crates:
 - shadi_a2a: A2A-over-SLIM wrapper, including secure group (Collaborate) messaging
 - slim_mas: SLIM multi-agent group config and DID allow-list evaluation (a library, consumed by `shadictl slim-mas`, not itself a CLI)
 - shadi_mas: autonomous multi-round agent coordination runtime (proposal/vote/finalize), consumed by `agentbridge coordinate`
-- agentbridge / agentbridge_cli: CLI coding-agent interconnect (register, handoff, delegate, coordinate)
+- agentbridge / agentbridge_cli: general-purpose A2A agent interconnect (register, handoff, delegate, coordinate); ships with CLI coding-tool adapters (Claude Code, Copilot, Codex, Cursor Agent) as its flagship use case
 - agent_transport_slim: transport adapter for SLIM/A2A and stdio bridge for SHADI-managed sessions
 - shadi_telemetry: OpenTelemetry tracing/metrics initialization
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -44,9 +44,10 @@ SHADI presents the runtime as four product layers:
 - Python bindings for secrets, memory, and sandboxed execution.
 - CLI workflows for policy, identity, key management, and sandbox execution.
 - Example agents and demos, including a SecOps workflow against real GitHub signals.
-- **agentbridge**: interconnect Claude Code, Copilot, Codex, Cursor Agent, and
-  other CLI coding tools via A2A, SLIM, and DIR with autonomous coordination
-  toward a shared goal.
+- **agentbridge**: general-purpose agent interconnect over A2A, SLIM, and DIR
+  with autonomous coordination toward a shared goal — ships today with
+  adapters for Claude Code, Copilot, Codex, Cursor Agent, and other CLI
+  coding tools.
 - **Secure agent groups**: moderator-invited SLIM channels admitted against a
   per-agent DID allow-list, with many-to-many A2A Collaborate broadcast
   messaging between every member.
@@ -58,7 +59,7 @@ SHADI presents the runtime as four product layers:
 - Need the system model? Read [Architecture](architecture.md) and [Security Notes](security.md).
 - Integrating into an agent or app? Start with the [API Guide](api_integration.md).
 - Looking for flags and commands? See the [CLI Reference](cli.md).
-- Connecting CLI coding tools autonomously? Start with [AgentBridge](agentbridge.md).
+- Interconnecting agents over A2A autonomously? Start with [AgentBridge](agentbridge.md).
 
 ## By Role
 
@@ -71,7 +72,7 @@ SHADI presents the runtime as four product layers:
 - [Architecture](architecture.md)
 - [API Guide](api_integration.md)
 - [SLIM and A2A](slim_a2a.md)
-- [agentbridge — CLI coding-agent interconnect](agentbridge.md)
+- [agentbridge — general-purpose A2A agent interconnect](agentbridge.md)
 
 **Security Engineering**
 - [Security Notes](security.md)

--- a/docs/content/slim_a2a.md
+++ b/docs/content/slim_a2a.md
@@ -82,5 +82,5 @@ agentbridge — see the [Secure Agent Group Demo](demos/did-agent-group.md).
 
 - Walk through a full multi-agent example in the [Secure Agent Group Demo](demos/did-agent-group.md).
 - See how a group's membership can be discovered instead of hand-named in the [Agent Directory Discovery Demo](demos/dir-group-discovery.md).
-- See how CLI coding agents use this transport in [AgentBridge](agentbridge.md).
+- See how agentbridge uses this transport to interconnect agents — coding CLIs today, any A2A-speaking agent in general — in [AgentBridge](agentbridge.md).
 - Look up exact flags in the [CLI Reference](cli.md).


### PR DESCRIPTION
## Summary
- Reframe agentbridge as a general-purpose A2A agent interconnect; coding CLIs are the flagship use case, not an inherent limit
- Update architecture/design/overview/slim_a2a to match

## Test plan
- [x] `mkdocs build --strict` clean