### PR TITLE
fix(shadi_identity): add crate description for crates.io publish

### DIFF
--- a/crates/shadi_identity/Cargo.toml
+++ b/crates/shadi_identity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-shadi-identity"
 version = "0.1.0"
 edition = "2021"
+description = "Ed25519 did:key agent identity primitives for SHADI."
 license.workspace = true
 repository.workspace = true
 


### PR DESCRIPTION
## Summary
- `agntcy-shadi-identity` was missing a `description` field, which crates.io requires. This blocked the release-plz publish job mid-run (after `agent-secrets 0.2.0` had already published), so the CLI crates never got released.

## Test plan
- [x] `cargo metadata` succeeds; every other crate already sets its own `description`