### PR TITLE
chore(release-plz): temporarily force release on next push

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-release_always = false
+release_always = true
 publish = true
 publish_no_verify = true
 publish_timeout = "30m"


### PR DESCRIPTION
## Summary
- Flip `release_always` to `true` for one push so the stuck release (agent-secrets 0.2.0 published, everything after it including both CLIs never did) resumes publishing
- Will revert to `false` in a follow-up PR once the remaining crates publish

## Test plan
- [ ] Merge, confirm shadictl/agentbridge_cli and remaining crates publish, then revert