### PR TITLE
fix(release): exclude agentbridge_demo from crates.io publish

### DIFF
--- a/examples/agentbridge_demo/Cargo.toml
+++ b/examples/agentbridge_demo/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [[bin]]
 name = "agentbridge_demo"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,3 +8,8 @@ publish_timeout = "30m"
 name = "shadi_demo_bot"
 publish = false
 release = false
+
+[[package]]
+name = "agentbridge_demo"
+publish = false
+release = false


### PR DESCRIPTION
## Summary
- `agentbridge_demo` is a demo binary example (same category as `shadi_demo_bot`, already excluded) that was missing a `description` field crates.io requires, and wasn't excluded from publishing. It was the second crate to abort the currently in-progress release mid-run.
- Add `publish = false` to its manifest and exclude it in `release-plz.toml`, matching `shadi_demo_bot`.

## Test plan
- [ ] Merge, confirm the release resumes and both CLIs + remaining crates publish