### PR TITLE
chore(release-plz): revert temporary force-release flip

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-release_always = true
+release_always = false
 publish = true
 publish_no_verify = true
 publish_timeout = "30m"


### PR DESCRIPTION
## Summary
- Revert `release_always` to `false` now that the stuck release (both CLIs + remaining crates) published successfully via #92/#103/#105
- Avoids the race condition release-plz's docs warn about when `release_always=true` combines with squash-merge

## Test plan
- [x] N/A — config-only change