### PR TITLE
docs: update agentbridge READMEs for general-purpose framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SHADI is for teams that want agents to work with real tools and real credentials
 ## What You Get
 
 - [`shadictl`](https://agntcy.github.io/shadi/cli/#shadictl-shadi): the main CLI for policy, sandbox execution, identity, secrets, memory, and shell control.
+- [`agentbridge`](https://agntcy.github.io/shadi/agentbridge/): a general-purpose agent interconnect over A2A — coding CLIs (Claude Code, Copilot, Codex, Cursor Agent) are the flagship use case.
 - [`shadi_sandbox`](https://agntcy.github.io/shadi/architecture/#2-sandbox-layer): OS-enforced sandbox policy.
 - [`agent_secrets`](https://agntcy.github.io/shadi/architecture/#1-secrets-layer): keychain-backed secret storage and verification gates.
 - [`shadi_memory`](https://agntcy.github.io/shadi/architecture/#3-memory-layer): SQLCipher-backed local memory.

--- a/crates/agentbridge/README.md
+++ b/crates/agentbridge/README.md
@@ -1,10 +1,15 @@
 # agentbridge
 
-`agentbridge` is the CLI coding-agent adapter library. It bridges individual
-coding tools (Claude Code, GitHub Copilot, OpenAI Codex, or any CLI that speaks
-the agentbridge JSON protocol) into the `shadi_mas` coordination runtime so they
-can exchange context, delegate tasks, and coordinate autonomously toward a shared
-programming goal.
+`agentbridge` is a general-purpose agent adapter library. It bridges any agent
+that speaks the `CliAdapter` trait or the agentbridge JSON subprocess protocol
+into the `shadi_mas` coordination runtime so they can exchange context, delegate
+tasks, and coordinate autonomously toward a shared goal.
+
+Today's built-in adapters target CLI coding tools (Claude Code, GitHub
+Copilot, OpenAI Codex, Cursor Agent) since interconnecting coding assistants
+was the motivating use case this was first built for, and they remain the
+flagship example below — but nothing in `CliAdapter` or the coordination
+runtime is specific to coding tools.
 
 ## How it fits into SHADI
 

--- a/crates/agentbridge_cli/README.md
+++ b/crates/agentbridge_cli/README.md
@@ -1,10 +1,10 @@
 # agentbridge CLI
 
-`agentbridge` is the command-line interface for the agentbridge coding-agent
-interconnect. It registers CLI coding tools (Claude Code, Copilot, Codex, Cursor
-Agent, or any subprocess that speaks the agentbridge JSON protocol) as live A2A
-services, lists them via DIR discovery, hands off context between them, and
-coordinates them autonomously toward a shared programming goal.
+`agentbridge` is the command-line interface for the agentbridge general-purpose
+agent interconnect. It registers agents (CLI coding tools like Claude Code,
+Copilot, Codex, Cursor Agent, or any subprocess that speaks the agentbridge
+JSON protocol) as live A2A services, lists them via DIR discovery, hands off
+context between them, and coordinates them autonomously toward a shared goal.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Update crates/agentbridge and crates/agentbridge_cli READMEs to match the general-purpose A2A framing from #102 (they were missed in that PR)
- Add agentbridge to the root README's feature list — it's a released, shipped component but wasn't mentioned there

## Test plan
- [x] Docs-only change