### PR TITLE
feat(release): distribute agentbridge like shadictl

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -6,14 +6,24 @@ on:
       - published
   workflow_dispatch:
     inputs:
+      cli:
+        description: Which CLI to render a formula for (shadictl or agentbridge)
+        required: false
+        type: string
+        default: shadictl
       tag:
-        description: CLI release tag to render into Formula/shadictl.rb
+        description: CLI release tag to render into Formula/<cli>.rb
         required: true
         type: string
 
 jobs:
   refresh-homebrew-formula:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'agntcy-shadi-cli-v') }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.event.release.tag_name, 'agntcy-shadi-cli-v') ||
+        startsWith(github.event.release.tag_name, 'agntcy-agentbridge-cli-v')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -41,35 +51,47 @@ jobs:
 
           case "$tag" in
             agntcy-shadi-cli-v*)
+              cli="shadictl"
               version="${tag#agntcy-shadi-cli-v}"
               ;;
+            agntcy-agentbridge-cli-v*)
+              cli="agentbridge"
+              version="${tag#agntcy-agentbridge-cli-v}"
+              ;;
             *)
-              echo "::error::expected an agntcy-shadi-cli-v* tag, got $tag"
+              echo "::error::expected an agntcy-shadi-cli-v* or agntcy-agentbridge-cli-v* tag, got $tag"
               exit 1
               ;;
           esac
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "cli=$cli" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Render Homebrew formula
-        run: python3 scripts/render_homebrew_formula.py --tag "${{ steps.release.outputs.tag }}" --output Formula/shadictl.rb
+        run: |
+          python3 scripts/render_homebrew_formula.py \
+            --cli "${{ steps.release.outputs.cli }}" \
+            --tag "${{ steps.release.outputs.tag }}" \
+            --output "Formula/${{ steps.release.outputs.cli }}.rb"
 
       - name: Open formula refresh PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLI: ${{ steps.release.outputs.cli }}
+          FORMULA_PATH: Formula/${{ steps.release.outputs.cli }}.rb
         run: |
-          if git diff --quiet -- Formula/shadictl.rb; then
+          if git diff --quiet -- "$FORMULA_PATH"; then
             echo "Formula already up to date for ${{ steps.release.outputs.tag }}"
             exit 0
           fi
 
-          branch="automation/homebrew-shadictl-${{ steps.release.outputs.version }}"
+          branch="automation/homebrew-$CLI-${{ steps.release.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
-          git add Formula/shadictl.rb
-          git commit -m "release: update Homebrew formula for shadictl v${{ steps.release.outputs.version }}"
+          git add "$FORMULA_PATH"
+          git commit -m "release: update Homebrew formula for $CLI v${{ steps.release.outputs.version }}"
           git push --force --set-upstream origin "$branch"
 
           pr_number=$(gh pr list --repo agntcy/shadi --head "$branch" --base main --state open --json number --jq 'first(.[].number) // ""')
@@ -79,7 +101,7 @@ jobs:
           fi
 
           cat > /tmp/homebrew-formula-pr-body.md <<EOF
-          Update Formula/shadictl.rb for ${{ steps.release.outputs.tag }}.
+          Update $FORMULA_PATH for ${{ steps.release.outputs.tag }}.
 
           - refreshes the source tarball SHA256
           - keeps the Homebrew install path aligned with the latest CLI release
@@ -91,5 +113,5 @@ jobs:
             --repo agntcy/shadi \
             --base main \
             --head "$branch" \
-            --title "release: update Homebrew formula for shadictl v${{ steps.release.outputs.version }}" \
+            --title "release: update Homebrew formula for $CLI v${{ steps.release.outputs.version }}" \
             --body-file /tmp/homebrew-formula-pr-body.md

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -165,6 +165,7 @@ jobs:
         shell: bash
         run: |
           python scripts/resolve_shadictl_release_metadata.py \
+            --cli shadictl \
             --event-name release \
             --release-tag "${{ needs.resolve-shadictl-release.outputs.release_tag }}" \
             --target "${{ matrix.target }}" \
@@ -181,6 +182,7 @@ jobs:
             --binary "${{ steps.metadata.outputs.binary_path }}" \
             --target "${{ matrix.target }}" \
             --version "${{ steps.metadata.outputs.version }}" \
+            --name "${{ steps.metadata.outputs.binary_name }}" \
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
 
@@ -237,6 +239,191 @@ jobs:
           gh workflow run homebrew-formula.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
+            -f tag="$RELEASE_TAG"
+
+  resolve-agentbridge-release:
+    name: Resolve agentbridge release
+    needs: release-crates
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-agentbridge-cli"') }}
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+    steps:
+      - name: Resolve CLI release tag
+        id: release
+        shell: bash
+        env:
+          RELEASES: ${{ needs.release-crates.outputs.releases }}
+        run: |
+          release_tag=$(python - <<'PY'
+          import json
+          import os
+
+          releases = json.loads(os.environ["RELEASES"])
+          for release in releases:
+              if release["package_name"] == "agntcy-agentbridge-cli":
+                  print(release["tag"])
+                  break
+          else:
+              raise SystemExit("agntcy-agentbridge-cli release not found in release-plz outputs")
+          PY
+          )
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+  release-agentbridge-binaries:
+    name: Release agentbridge binaries (${{ matrix.name }})
+    needs:
+      - release-crates
+      - resolve-agentbridge-release
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-agentbridge-cli"') }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-2022
+            target: x86_64-pc-windows-msvc
+    env:
+      PYO3_PYTHON: python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.88.0
+          targets: ${{ matrix.target }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config nettle-dev libssl-dev
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nettle pkg-config
+
+      - name: Set OpenSSL env vars (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
+          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $opensslDir) {
+            choco install openssl -y --no-progress
+            $opensslDir = "C:\Program Files\OpenSSL-Win64"
+          }
+          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
+          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python scripts/resolve_shadictl_release_metadata.py \
+            --cli agentbridge \
+            --event-name release \
+            --release-tag "${{ needs.resolve-agentbridge-release.outputs.release_tag }}" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build agentbridge
+        run: cargo build -p agntcy-agentbridge-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_shadictl_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --name "${{ steps.metadata.outputs.binary_name }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ steps.metadata.outputs.release_tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+  release-agentbridge-winget:
+    name: Publish agentbridge WinGet manifests
+    needs:
+      - release-crates
+      - resolve-agentbridge-release
+      - release-agentbridge-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-agentbridge-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-agentbridge-release.outputs.release_tag }}
+    steps:
+      - name: Trigger WinGet manifest workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run winget-manifests.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f cli=agentbridge \
+            -f release_tag="$RELEASE_TAG"
+
+  release-agentbridge-homebrew:
+    name: Publish agentbridge Homebrew formula
+    needs:
+      - release-crates
+      - resolve-agentbridge-release
+      - release-agentbridge-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-agentbridge-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-agentbridge-release.outputs.release_tag }}
+    steps:
+      - name: Trigger Homebrew formula workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run homebrew-formula.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f cli=agentbridge \
             -f tag="$RELEASE_TAG"
 
   release-crates-pr:

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -1,4 +1,4 @@
-name: Build shadictl Release Artifacts
+name: Build CLI Release Artifacts
 
 on:
   pull_request:
@@ -74,11 +74,12 @@ jobs:
           "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Resolve release metadata
+      - name: Resolve shadictl release metadata
         id: metadata
         shell: bash
         run: |
           python scripts/resolve_shadictl_release_metadata.py \
+            --cli shadictl \
             --event-name "${{ github.event_name }}" \
             --release-tag "" \
             --target "${{ matrix.target }}" \
@@ -87,7 +88,7 @@ jobs:
       - name: Build shadictl
         run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}
 
-      - name: Package release archive
+      - name: Package shadictl release archive
         id: package
         shell: bash
         run: |
@@ -95,5 +96,32 @@ jobs:
             --binary "${{ steps.metadata.outputs.binary_path }}" \
             --target "${{ matrix.target }}" \
             --version "${{ steps.metadata.outputs.version }}" \
+            --name "${{ steps.metadata.outputs.binary_name }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Resolve agentbridge release metadata
+        id: metadata-agentbridge
+        shell: bash
+        run: |
+          python scripts/resolve_shadictl_release_metadata.py \
+            --cli agentbridge \
+            --event-name "${{ github.event_name }}" \
+            --release-tag "" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build agentbridge
+        run: cargo build -p agntcy-agentbridge-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package agentbridge release archive
+        id: package-agentbridge
+        shell: bash
+        run: |
+          python scripts/package_shadictl_release.py \
+            --binary "${{ steps.metadata-agentbridge.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata-agentbridge.outputs.version }}" \
+            --name "${{ steps.metadata-agentbridge.outputs.binary_name }}" \
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -3,6 +3,11 @@ name: Publish WinGet Manifests
 on:
   workflow_call:
     inputs:
+      cli:
+        description: Which CLI to render WinGet manifests for (shadictl or agentbridge)
+        required: false
+        type: string
+        default: shadictl
       release_tag:
         description: CLI release tag to render into WinGet manifests
         required: true
@@ -14,6 +19,11 @@ on:
         required: false
   workflow_dispatch:
     inputs:
+      cli:
+        description: Which CLI to render WinGet manifests for (shadictl or agentbridge)
+        required: false
+        type: string
+        default: shadictl
       release_tag:
         description: CLI release tag to render into WinGet manifests
         required: true
@@ -25,6 +35,7 @@ jobs:
     permissions:
       contents: read
     env:
+      CLI: ${{ inputs.cli }}
       RELEASE_TAG: ${{ inputs.release_tag }}
       APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
     steps:
@@ -42,6 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           python scripts/render_winget_manifests.py \
+            --cli "$CLI" \
             --tag "$RELEASE_TAG" \
             --output-dir dist/winget \
             --github-output "$GITHUB_OUTPUT"
@@ -99,7 +111,7 @@ jobs:
           rm -rf /tmp/winget-pkgs
           GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1
 
-          branch="automation/winget-shadictl-$PACKAGE_VERSION"
+          branch="automation/winget-$CLI-$PACKAGE_VERSION"
 
           cd /tmp/winget-pkgs
           if git remote get-url upstream >/dev/null 2>&1; then
@@ -123,7 +135,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "release: add WinGet manifest for shadictl v$PACKAGE_VERSION"
+          git commit -m "release: add WinGet manifest for $CLI v$PACKAGE_VERSION"
           git push --force --set-upstream origin "$branch"
 
           pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')

--- a/README.md
+++ b/README.md
@@ -40,24 +40,29 @@ curl -fsSL https://agntcy.github.io/shadi/install.sh | bash
 For pinned versions, custom install paths, and installer environment overrides,
 see [Install the CLI](https://agntcy.github.io/shadi/install/).
 
-On macOS, you can install the latest released `shadictl` formula with Homebrew:
+On macOS, you can install the latest released `shadictl` or `agentbridge`
+formula with Homebrew:
 
 ```bash
 brew tap agntcy/shadi https://github.com/agntcy/shadi
 brew install agntcy/shadi/shadictl
+brew install agntcy/shadi/agentbridge
 ```
 
 On Windows, once the matching WinGet manifest has landed in the default source,
-you can install or upgrade `shadictl` with:
+you can install or upgrade either CLI with:
 
 ```powershell
 winget install --id AGNTCY.shadictl -e
+winget install --id AGNTCY.agentbridge -e
 winget upgrade --id AGNTCY.shadictl -e
+winget upgrade --id AGNTCY.agentbridge -e
 ```
 
-The Homebrew formula builds from the published `agntcy-shadi-cli` release tag.
-Published `agntcy-shadi-cli` releases also include prebuilt archives for Linux
-(`x86_64` and `aarch64`), macOS (`arm64` and `x86_64`), and Windows (`x86_64`).
+Each Homebrew formula builds from its own published release tag
+(`agntcy-shadi-cli` for `shadictl`, `agntcy-agentbridge-cli` for `agentbridge`).
+Both releases also include prebuilt archives for Linux (`x86_64` and
+`aarch64`), macOS (`arm64` and `x86_64`), and Windows (`x86_64`).
 For unreleased changes or any other host, use the source build flow below.
 
 ## Quick Start

--- a/crates/agentbridge/Cargo.toml
+++ b/crates/agentbridge/Cargo.toml
@@ -3,7 +3,7 @@ name = "agntcy-agentbridge"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
-description = "CLI coding-agent interconnect built on shadi_mas."
+description = "General-purpose agent interconnect over A2A, built on shadi_mas."
 license.workspace = true
 repository.workspace = true
 

--- a/crates/agentbridge_cli/Cargo.toml
+++ b/crates/agentbridge_cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "agntcy-agentbridge-cli"
 version = "0.1.0"
 edition = "2021"
 rust-version.workspace = true
-description = "CLI binary for the agentbridge coding-agent interconnect."
+description = "CLI binary for the agentbridge general-purpose agent interconnect."
 license.workspace = true
 repository.workspace = true
 

--- a/scripts/package_shadictl_release.py
+++ b/scripts/package_shadictl_release.py
@@ -39,6 +39,11 @@ def parse_args() -> argparse.Namespace:
         help="CLI version used in the release archive name.",
     )
     parser.add_argument(
+        "--name",
+        default="shadictl",
+        help="Binary/archive name to package (default: shadictl).",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=DEFAULT_OUTPUT_DIR,
@@ -105,7 +110,7 @@ def main() -> None:
         if not support_path.is_file():
             raise SystemExit(f"expected support file at {support_path}")
 
-    archive_stem = f"shadictl-v{args.version}-{args.target}"
+    archive_stem = f"{args.name}-v{args.version}-{args.target}"
     output_dir = args.output_dir.resolve()
     staging_dir = output_dir / archive_stem
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -114,7 +119,7 @@ def main() -> None:
         shutil.rmtree(staging_dir)
     staging_dir.mkdir()
 
-    binary_name = "shadictl.exe" if args.target.endswith("windows-msvc") else "shadictl"
+    binary_name = f"{args.name}.exe" if args.target.endswith("windows-msvc") else args.name
     shutil.copy2(binary, staging_dir / binary_name)
     shutil.copy2(args.license, staging_dir / args.license.name)
     shutil.copy2(args.readme, staging_dir / args.readme.name)

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -15,9 +15,28 @@ import urllib.request
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
-CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
-DEFAULT_OUTPUT = ROOT / "Formula" / "shadictl.rb"
-TAG_PATTERN = re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+
+CLI_CONFIGS = {
+    "shadictl": {
+        "manifest": ROOT / "crates" / "shadictl" / "Cargo.toml",
+        "tag_pattern": re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$"),
+        "default_output": ROOT / "Formula" / "shadictl.rb",
+        "class_name": "Shadictl",
+        "crate_path": "crates/shadictl",
+        "binary_name": "shadictl",
+    },
+    "agentbridge": {
+        "manifest": ROOT / "crates" / "agentbridge_cli" / "Cargo.toml",
+        "tag_pattern": re.compile(
+            r"^agntcy-agentbridge-cli-v(?P<version>[0-9A-Za-z.+-]+)$"
+        ),
+        "default_output": ROOT / "Formula" / "agentbridge.rb",
+        "class_name": "Agentbridge",
+        "crate_path": "crates/agentbridge_cli",
+        "binary_name": "agentbridge",
+    },
+}
+
 FORMULA_HEADER = textwrap.dedent(
     """\
     # Copyright AGNTCY Contributors (https://github.com/agntcy)
@@ -29,18 +48,24 @@ FORMULA_HEADER = textwrap.dedent(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Render the Homebrew formula for the released shadictl CLI tag."
+        description="Render the Homebrew formula for a released CLI tag."
+    )
+    parser.add_argument(
+        "--cli",
+        choices=sorted(CLI_CONFIGS),
+        default="shadictl",
+        help="Which CLI to render a formula for (default: shadictl).",
     )
     parser.add_argument(
         "--tag",
         required=True,
-        help="Release tag in the form agntcy-shadi-cli-v<version>",
+        help="Release tag, e.g. agntcy-shadi-cli-v<version> or agntcy-agentbridge-cli-v<version>",
     )
     parser.add_argument(
         "--output",
         type=Path,
-        default=DEFAULT_OUTPUT,
-        help=f"Formula output path (default: {DEFAULT_OUTPUT})",
+        default=None,
+        help="Formula output path (default: Formula/<cli>.rb)",
     )
     return parser.parse_args()
 
@@ -75,13 +100,14 @@ def ruby_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
-def render_formula(tag: str) -> str:
-    match = TAG_PATTERN.match(tag)
+def render_formula(cli: str, tag: str) -> str:
+    config = CLI_CONFIGS[cli]
+    match = config["tag_pattern"].match(tag)
     if not match:
-        raise SystemExit(f"expected agntcy-shadi-cli-v<version> tag, got: {tag}")
+        raise SystemExit(f"expected {config['tag_pattern'].pattern} tag, got: {tag}")
 
     workspace = load_toml(WORKSPACE_MANIFEST)
-    cli_manifest = load_toml(CLI_MANIFEST)
+    cli_manifest = load_toml(config["manifest"])
     workspace_package = workspace["workspace"]["package"]
     package = cli_manifest["package"]
 
@@ -91,10 +117,13 @@ def render_formula(tag: str) -> str:
     source_url = f"{homepage}/archive/refs/tags/{tag}.tar.gz"
     source_sha256 = fetch_sha256(source_url)
     git_url = homepage if homepage.endswith(".git") else f"{homepage}.git"
+    class_name = config["class_name"]
+    crate_path = config["crate_path"]
+    binary_name = config["binary_name"]
 
     formula_body = textwrap.dedent(
         f"""\
-        class Shadictl < Formula
+        class {class_name} < Formula
           desc \"{ruby_string(description)}\"
           homepage \"{ruby_string(homepage)}\"
           url \"{ruby_string(source_url)}\"
@@ -112,11 +141,11 @@ def render_formula(tag: str) -> str:
             ENV[\"OPENSSL_DIR\"] = Formula[\"openssl@3\"].opt_prefix
             ENV[\"PYO3_PYTHON\"] = Formula[\"python@3.12\"].opt_bin/\"python3.12\"
 
-            system \"cargo\", \"install\", \"--locked\", \"--path\", \"crates/shadictl\", *std_cargo_args
+            system \"cargo\", \"install\", \"--locked\", \"--path\", \"{crate_path}\", *std_cargo_args
           end
 
           test do
-            assert_match \"shadictl\", shell_output("#{{bin}}/shadictl --help")
+            assert_match \"{binary_name}\", shell_output("#{{bin}}/{binary_name} --help")
           end
         end
         """
@@ -127,9 +156,10 @@ def render_formula(tag: str) -> str:
 
 def main() -> int:
     args = parse_args()
-    formula = render_formula(args.tag)
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(formula, encoding="utf-8")
+    output = args.output or CLI_CONFIGS[args.cli]["default_output"]
+    formula = render_formula(args.cli, args.tag)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(formula, encoding="utf-8")
     return 0
 
 

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -20,22 +20,38 @@ from urllib.error import HTTPError
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
-CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
 DEFAULT_OUTPUT_DIR = ROOT / "dist" / "winget"
 
 MANIFEST_VERSION = "1.12.0"
-PACKAGE_IDENTIFIER = "AGNTCY.shadictl"
 PACKAGE_LOCALE = "en-US"
 PUBLISHER = "AGNTCY"
-PACKAGE_NAME = "shadictl"
-MONIKER = "shadictl"
 WINDOWS_ARCHITECTURE = "x64"
 WINDOWS_TARGET = "x86_64-pc-windows-msvc"
 DOCS_URL = "https://agntcy.github.io/shadi"
-TAG_PATTERN = re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
 REPOSITORY_PATTERN = re.compile(
     r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
 )
+
+CLI_CONFIGS = {
+    "shadictl": {
+        "manifest": ROOT / "crates" / "shadictl" / "Cargo.toml",
+        "tag_pattern": re.compile(r"^agntcy-shadi-cli-v(?P<version>[0-9A-Za-z.+-]+)$"),
+        "package_identifier": "AGNTCY.shadictl",
+        "package_name": "shadictl",
+        "moniker": "shadictl",
+        "binary_name": "shadictl",
+    },
+    "agentbridge": {
+        "manifest": ROOT / "crates" / "agentbridge_cli" / "Cargo.toml",
+        "tag_pattern": re.compile(
+            r"^agntcy-agentbridge-cli-v(?P<version>[0-9A-Za-z.+-]+)$"
+        ),
+        "package_identifier": "AGNTCY.agentbridge",
+        "package_name": "agentbridge",
+        "moniker": "agentbridge",
+        "binary_name": "agentbridge",
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -50,12 +66,18 @@ class ReleaseAssets:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Render WinGet manifests for a released shadictl CLI tag."
+        description="Render WinGet manifests for a released CLI tag."
+    )
+    parser.add_argument(
+        "--cli",
+        choices=sorted(CLI_CONFIGS),
+        default="shadictl",
+        help="Which CLI to render WinGet manifests for (default: shadictl).",
     )
     parser.add_argument(
         "--tag",
         required=True,
-        help="Release tag in the form agntcy-shadi-cli-v<version>",
+        help="Release tag, e.g. agntcy-shadi-cli-v<version> or agntcy-agentbridge-cli-v<version>",
     )
     parser.add_argument(
         "--output-dir",
@@ -142,20 +164,22 @@ def parse_repository_slug(repository_url: str) -> str:
     return f"{match.group('owner')}/{match.group('repo')}"
 
 
-def parse_release_tag(tag: str) -> str:
-    match = TAG_PATTERN.match(tag)
+def parse_release_tag(tag: str, tag_pattern: re.Pattern[str]) -> str:
+    match = tag_pattern.match(tag)
     if not match:
-        raise SystemExit(f"expected agntcy-shadi-cli-v<version> tag, got: {tag}")
+        raise SystemExit(f"expected {tag_pattern.pattern} tag, got: {tag}")
     return match.group("version")
 
 
-def resolve_release_assets(tag: str, repository_slug: str) -> ReleaseAssets:
-    version = parse_release_tag(tag)
+def resolve_release_assets(
+    tag: str, repository_slug: str, tag_pattern: re.Pattern[str], binary_name: str
+) -> ReleaseAssets:
+    version = parse_release_tag(tag, tag_pattern)
     release = fetch_json(
         f"https://api.github.com/repos/{repository_slug}/releases/tags/{tag}"
     )
 
-    installer_name = f"shadictl-v{version}-{WINDOWS_TARGET}.zip"
+    installer_name = f"{binary_name}-v{version}-{WINDOWS_TARGET}.zip"
     checksum_name = f"{installer_name}.sha256"
 
     installer_url = None
@@ -196,12 +220,12 @@ def resolve_release_assets(tag: str, repository_slug: str) -> ReleaseAssets:
     )
 
 
-def render_version_manifest(version: str) -> str:
+def render_version_manifest(package_identifier: str, version: str) -> str:
     return textwrap.dedent(
         f"""\
         # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.{MANIFEST_VERSION}.schema.json
 
-        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageIdentifier: {package_identifier}
         PackageVersion: {version}
         DefaultLocale: {PACKAGE_LOCALE}
         ManifestType: version
@@ -212,6 +236,9 @@ def render_version_manifest(version: str) -> str:
 
 def render_default_locale_manifest(
     *,
+    package_identifier: str,
+    package_name: str,
+    moniker: str,
     tag: str,
     version: str,
     description: str,
@@ -232,19 +259,19 @@ def render_default_locale_manifest(
         f"""\
         # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.{MANIFEST_VERSION}.schema.json
 
-        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageIdentifier: {package_identifier}
         PackageVersion: {version}
         PackageLocale: {PACKAGE_LOCALE}
         Publisher: {PUBLISHER}
         PublisherUrl: https://github.com/agntcy
         PublisherSupportUrl: {repository_url}/issues
         Author: AGNTCY Contributors
-        PackageName: {PACKAGE_NAME}
+        PackageName: {package_name}
         PackageUrl: {repository_url}
         License: {license_id}
         LicenseUrl: {repository_url}/blob/{tag}/LICENSE.md
         ShortDescription: {description}
-        Moniker: {MONIKER}
+        Moniker: {moniker}
         {tags}
         Documentations:
         - DocumentLabel: Documentation
@@ -256,20 +283,22 @@ def render_default_locale_manifest(
     )
 
 
-def render_installer_manifest(release_assets: ReleaseAssets) -> str:
+def render_installer_manifest(
+    *, package_identifier: str, moniker: str, binary_name: str, release_assets: ReleaseAssets
+) -> str:
     relative_file_path = (
-        f"shadictl-v{release_assets.version}-{WINDOWS_TARGET}\\shadictl.exe"
+        f"{binary_name}-v{release_assets.version}-{WINDOWS_TARGET}\\{binary_name}.exe"
     )
     return textwrap.dedent(
         f"""\
         # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.{MANIFEST_VERSION}.schema.json
 
-        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageIdentifier: {package_identifier}
         PackageVersion: {release_assets.version}
         InstallerType: zip
         NestedInstallerType: portable
         Commands:
-        - {MONIKER}
+        - {moniker}
         ReleaseDate: {release_assets.release_date}
         Installers:
         - Architecture: {WINDOWS_ARCHITECTURE}
@@ -277,7 +306,7 @@ def render_installer_manifest(release_assets: ReleaseAssets) -> str:
           InstallerSha256: {release_assets.installer_sha256}
           NestedInstallerFiles:
           - RelativeFilePath: {relative_file_path}
-            PortableCommandAlias: {MONIKER}
+            PortableCommandAlias: {moniker}
         ManifestType: installer
         ManifestVersion: {MANIFEST_VERSION}
         """
@@ -297,9 +326,11 @@ def write_github_output(path: Path, values: dict[str, str]) -> None:
 
 def main() -> int:
     args = parse_args()
+    config = CLI_CONFIGS[args.cli]
+    package_identifier = config["package_identifier"]
 
     workspace = load_toml(WORKSPACE_MANIFEST)
-    cli_manifest = load_toml(CLI_MANIFEST)
+    cli_manifest = load_toml(config["manifest"])
     workspace_package = workspace["workspace"]["package"]
     package = cli_manifest["package"]
 
@@ -308,20 +339,25 @@ def main() -> int:
     description = package["description"]
     license_id = resolve_workspace_value(package, workspace_package, "license")
 
-    release_assets = resolve_release_assets(args.tag, repository_slug)
+    release_assets = resolve_release_assets(
+        args.tag, repository_slug, config["tag_pattern"], config["binary_name"]
+    )
 
     output_dir = args.output_dir.resolve()
-    manifests_dir = manifest_directory(output_dir, PACKAGE_IDENTIFIER, release_assets.version)
+    manifests_dir = manifest_directory(output_dir, package_identifier, release_assets.version)
     if manifests_dir.exists():
         shutil.rmtree(manifests_dir)
     manifests_dir.mkdir(parents=True, exist_ok=True)
 
-    (manifests_dir / f"{PACKAGE_IDENTIFIER}.yaml").write_text(
-        render_version_manifest(release_assets.version),
+    (manifests_dir / f"{package_identifier}.yaml").write_text(
+        render_version_manifest(package_identifier, release_assets.version),
         encoding="utf-8",
     )
-    (manifests_dir / f"{PACKAGE_IDENTIFIER}.locale.{PACKAGE_LOCALE}.yaml").write_text(
+    (manifests_dir / f"{package_identifier}.locale.{PACKAGE_LOCALE}.yaml").write_text(
         render_default_locale_manifest(
+            package_identifier=package_identifier,
+            package_name=config["package_name"],
+            moniker=config["moniker"],
             tag=release_assets.tag,
             version=release_assets.version,
             description=description,
@@ -330,15 +366,20 @@ def main() -> int:
         ),
         encoding="utf-8",
     )
-    (manifests_dir / f"{PACKAGE_IDENTIFIER}.installer.yaml").write_text(
-        render_installer_manifest(release_assets),
+    (manifests_dir / f"{package_identifier}.installer.yaml").write_text(
+        render_installer_manifest(
+            package_identifier=package_identifier,
+            moniker=config["moniker"],
+            binary_name=config["binary_name"],
+            release_assets=release_assets,
+        ),
         encoding="utf-8",
     )
 
     outputs = {
         "manifest_dir": str(manifests_dir),
         "manifest_rel_dir": manifests_dir.relative_to(output_dir).as_posix(),
-        "package_identifier": PACKAGE_IDENTIFIER,
+        "package_identifier": package_identifier,
         "package_version": release_assets.version,
         "release_url": release_assets.release_url,
     }

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -245,6 +245,11 @@ def render_default_locale_manifest(
     repository_url: str,
     license_id: str,
 ) -> str:
+    # textwrap.dedent() strips the *common* leading whitespace across every
+    # line. Interpolating a multi-line block whose own lines start at column 0
+    # (as YAML block-sequence items must) breaks that common-prefix
+    # computation and leaves every other line indented. Dedent the template
+    # with a single-line placeholder first, then splice the tags block in.
     tags = "\n".join(
         [
             "Tags:",
@@ -255,7 +260,7 @@ def render_default_locale_manifest(
             "- slim",
         ]
     )
-    return textwrap.dedent(
+    template = textwrap.dedent(
         f"""\
         # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.{MANIFEST_VERSION}.schema.json
 
@@ -272,7 +277,7 @@ def render_default_locale_manifest(
         LicenseUrl: {repository_url}/blob/{tag}/LICENSE.md
         ShortDescription: {description}
         Moniker: {moniker}
-        {tags}
+        __TAGS__
         Documentations:
         - DocumentLabel: Documentation
           DocumentUrl: {DOCS_URL}
@@ -281,6 +286,7 @@ def render_default_locale_manifest(
         ManifestVersion: {MANIFEST_VERSION}
         """
     )
+    return template.replace("__TAGS__", tags)
 
 
 def render_installer_manifest(

--- a/scripts/resolve_shadictl_release_metadata.py
+++ b/scripts/resolve_shadictl_release_metadata.py
@@ -10,12 +10,30 @@ import tomllib
 
 
 ROOT = Path(__file__).resolve().parent.parent
-CLI_MANIFEST = ROOT / "crates" / "shadictl" / "Cargo.toml"
+
+CLI_CONFIGS = {
+    "shadictl": {
+        "manifest": ROOT / "crates" / "shadictl" / "Cargo.toml",
+        "tag_prefix": "agntcy-shadi-cli-v",
+        "binary_name": "shadictl",
+    },
+    "agentbridge": {
+        "manifest": ROOT / "crates" / "agentbridge_cli" / "Cargo.toml",
+        "tag_prefix": "agntcy-agentbridge-cli-v",
+        "binary_name": "agentbridge",
+    },
+}
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Resolve shadictl release metadata for the GitHub Actions workflow."
+        description="Resolve CLI release metadata for the GitHub Actions workflow."
+    )
+    parser.add_argument(
+        "--cli",
+        choices=sorted(CLI_CONFIGS),
+        default="shadictl",
+        help="Which CLI to resolve release metadata for (default: shadictl).",
     )
     parser.add_argument(
         "--event-name",
@@ -30,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--target",
         required=True,
-        help="Rust target triple used to build shadictl.",
+        help="Rust target triple used to build the CLI.",
     )
     parser.add_argument(
         "--github-output",
@@ -41,31 +59,32 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_version() -> str:
-    with CLI_MANIFEST.open("rb") as handle:
-        manifest = tomllib.load(handle)
-    return manifest["package"]["version"]
+def load_version(manifest: Path) -> str:
+    with manifest.open("rb") as handle:
+        manifest_data = tomllib.load(handle)
+    return manifest_data["package"]["version"]
 
 
-def resolve_release_tag(event_name: str, release_tag: str, version: str) -> str:
+def resolve_release_tag(
+    event_name: str, release_tag: str, version: str, manifest: Path, tag_prefix: str
+) -> str:
     if event_name != "release":
         return ""
 
-    prefix = "agntcy-shadi-cli-v"
-    if not release_tag.startswith(prefix):
-        raise SystemExit(f"expected {prefix}<version>, got {release_tag}")
+    if not release_tag.startswith(tag_prefix):
+        raise SystemExit(f"expected {tag_prefix}<version>, got {release_tag}")
 
-    tag_version = release_tag[len(prefix):]
+    tag_version = release_tag[len(tag_prefix):]
     if tag_version != version:
         raise SystemExit(
-            f"release tag version {tag_version} does not match crates/shadictl/Cargo.toml version {version}"
+            f"release tag version {tag_version} does not match {manifest} version {version}"
         )
 
     return release_tag
 
 
-def resolve_binary_path(target: str) -> str:
-    binary_path = f"target/{target}/release/shadictl"
+def resolve_binary_path(target: str, binary_name: str) -> str:
+    binary_path = f"target/{target}/release/{binary_name}"
     if target.endswith("windows-msvc"):
         return f"{binary_path}.exe"
     return binary_path
@@ -73,14 +92,18 @@ def resolve_binary_path(target: str) -> str:
 
 def main() -> None:
     args = parse_args()
+    config = CLI_CONFIGS[args.cli]
 
-    version = load_version()
-    release_tag = resolve_release_tag(args.event_name, args.release_tag, version)
+    version = load_version(config["manifest"])
+    release_tag = resolve_release_tag(
+        args.event_name, args.release_tag, version, config["manifest"], config["tag_prefix"]
+    )
 
     outputs = {
         "version": version,
         "release_tag": release_tag,
-        "binary_path": resolve_binary_path(args.target),
+        "binary_path": resolve_binary_path(args.target, config["binary_name"]),
+        "binary_name": config["binary_name"],
     }
 
     with args.github_output.open("a", encoding="utf-8") as handle:


### PR DESCRIPTION
## Summary
- `agentbridge_cli` published to crates.io in the last release but got none of shadictl's binary distribution (no GitHub Release archives, no Homebrew formula, no WinGet manifest)
- Generalize the 4 release scripts (`resolve_shadictl_release_metadata.py`, `package_shadictl_release.py`, `render_homebrew_formula.py`, `render_winget_manifests.py`) to take a `--cli` param instead of hardcoding shadictl
- Mirror shadictl's release job set in `release-rust.yml` for agentbridge (resolve/binaries/winget/homebrew), gated independently on `agntcy-agentbridge-cli` being in the release
- `winget-manifests.yml` / `homebrew-formula.yml` now accept a `cli` input; `shadictl-binaries.yml` (PR validation) builds+packages both CLIs per platform job, without doubling the runner matrix
- Fix stale pre-reframing `description` fields on `agentbridge`/`agentbridge_cli` Cargo.toml that would have leaked into the new Homebrew `desc` / WinGet `ShortDescription`
- Update README's install instructions for both CLIs

## Test plan
- [x] All 4 scripts compile and pass `--cli agentbridge` / `--cli shadictl` functional smoke tests (including a live render against the real `agntcy-agentbridge-cli-v0.1.0` and `agntcy-shadi-cli-v0.1.2` releases)
- [x] `actionlint` clean on all 4 touched workflow files
- [x] `cargo metadata` succeeds after the Cargo.toml description edits