### PR TITLE
docs(security): point to the GitHub Security Advisories space

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,5 +21,7 @@ Participation in security issue coordination processes is at the discretion of t
 ## Security advisories
 
 The project team is committed to transparency in the security issue disclosure
-process. The SHADI team announces security issues via [project GitHub Release notes](https://github.com/agntcy/shadi/releases)
+process. The SHADI team tracks and publishes security advisories in the
+project's [GitHub Security Advisories space](https://github.com/agntcy/shadi/security/advisories),
+and announces them via [project GitHub Release notes](https://github.com/agntcy/shadi/releases)
 and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -3,6 +3,14 @@
 This library targets confidentiality for agent secrets at rest and in memory.
 It does not assume a hostile OS for v1.
 
+!!! info "Reporting a vulnerability"
+
+    Report security issues privately to [security@agntcy.org](mailto:security@agntcy.org),
+    not via the public issue tracker. The project tracks and publishes
+    advisories in the [GitHub Security Advisories space](https://github.com/agntcy/shadi/security/advisories) —
+    see [SECURITY.md](https://github.com/agntcy/shadi/blob/main/SECURITY.md) for
+    the full disclosure and coordination process.
+
 OpenPGP key handling is performed in-process via `sequoia-openpgp` rather than
 shelling out to `gpg`.
 


### PR DESCRIPTION
## Summary
- SECURITY.md only linked the generic GitHub help page on advisories; point at https://github.com/agntcy/shadi/security/advisories instead
- Add a short reporting pointer to the docs site's Security Notes page, which had no mention of vulnerability reporting at all

## Test plan
- [x] `mkdocs build --strict` clean