### PR TITLE
chore(ci): bump binary-build runners to latest images

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -107,13 +107,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-15
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-15-intel
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-2022
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
     env:
       PYO3_PYTHON: python
@@ -290,13 +290,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-15
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-15-intel
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-2022
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
     env:
       PYO3_PYTHON: python

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -20,13 +20,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-15
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-15-intel
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-2022
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
     name: ${{ matrix.name }}
     env:


### PR DESCRIPTION
## Summary
- Bump `macos-15`->`macos-26`, `macos-15-intel`->`macos-26-intel`, `windows-2022`->`windows-2025` in `shadictl-binaries.yml` and `release-rust.yml` (both had explicit, now 1-2-major-versions-behind pins; `ci.yml` already tracks the `-latest` tags)
- Note: same CPU/hardware class either way, so this doesn't fix the macOS Intel runner speed gap flagged earlier — OS/toolchain currency only

## Do not merge yet
Holding this open until the in-flight WinGet publish process (agntcy/shadi's shadictl + agentbridge manifests, currently in Microsoft's review queue) is done, to avoid changing the build environment mid-release.

## Test plan
- [x] `actionlint` clean