### PR TITLE
feat(agentbridge): require SHADI sandbox enforcement for remote listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-identity",
  "agntcy-shadi-mas",
+ "agntcy-shadi-sandbox",
  "agntcy-slim-bindings",
  "agntcy-slim-rpc",
  "anyhow",

--- a/crates/agentbridge_cli/Cargo.toml
+++ b/crates/agentbridge_cli/Cargo.toml
@@ -21,6 +21,7 @@ a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.0", path = "../agent_secrets" }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }
+shadi_sandbox = { package = "agntcy-shadi-sandbox", version = "0.1.0", path = "../shadi_sandbox" }
 async-trait = "0.1"
 futures = "0.3"
 anyhow = "1"

--- a/crates/agentbridge_cli/README.md
+++ b/crates/agentbridge_cli/README.md
@@ -19,22 +19,30 @@ cargo install --path crates/agentbridge_cli
 Wrap a CLI tool as an agentbridge adapter and keep it running as a SLIM A2A
 service so remote callers can reach it.
 
+> **Security:** `register --slim-endpoint` refuses to start unless it's running
+> under a SHADI sandbox with network blocked by default — wrap it in `shadictl`,
+> as shown below. See [Environment variables](#environment-variables).
+
 ```bash
 # Wrap any subprocess that speaks the agentbridge JSON protocol
-agentbridge register \
+shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+  agentbridge register \
   --tool generic-stdio \
   --command my-tool \
   --arg --agentbridge-mode \
   --slim-endpoint 127.0.0.1:47357
 
 # Start a Claude Code adapter
-agentbridge register --tool claude-code --slim-endpoint 127.0.0.1:47357
+shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+  agentbridge register --tool claude-code --slim-endpoint 127.0.0.1:47357
 
 # Start a Copilot adapter
-agentbridge register --tool copilot --slim-endpoint 127.0.0.1:47357
+shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+  agentbridge register --tool copilot --slim-endpoint 127.0.0.1:47357
 
 # Start a Codex adapter
-agentbridge register --tool codex --slim-endpoint 127.0.0.1:47357
+shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+  agentbridge register --tool codex --slim-endpoint 127.0.0.1:47357
 
 # Publish an OASF record to the Agent Directory after registering
 agentbridge register --tool claude-code --dir-publish
@@ -168,6 +176,14 @@ stdout:  {"ok":true,"data":"fn parse(...) { ... }"}
 > not supported: a `register` listener forwards incoming A2A tasks to the local
 > CLI tool, so admission must be cryptographic, not a symmetric secret compiled
 > into every demo script.
+>
+> That decides *who* may send a task. It doesn't constrain *what* the task can
+> do once it runs, so `register --slim-endpoint` separately refuses to start
+> unless it's running under a SHADI sandbox with network blocked by default —
+> wrap it in `shadictl --net-block --net-allow <slim-endpoint> --`. Kernel
+> sandboxes (Seatbelt/Landlock/AppContainer) are inherited by child processes,
+> so this confines whatever CLI tool the adapter spawns with no extra code in
+> agentbridge itself.
 
 ## Live SLIM demo (4 terminals)
 

--- a/crates/agentbridge_cli/README.md
+++ b/crates/agentbridge_cli/README.md
@@ -21,11 +21,17 @@ service so remote callers can reach it.
 
 > **Security:** `register --slim-endpoint` refuses to start unless it's running
 > under a SHADI sandbox with network blocked by default — wrap it in `shadictl`,
-> as shown below. See [Environment variables](#environment-variables).
+> as shown below, and `--read` the directory holding the SLIM mTLS client
+> certificate (`$SHADI_TMP_DIR/shadi-slim-mtls` in the demos) so the listener
+> can still read its own cert under the sandbox. On macOS, resolve
+> `$SHADI_TMP_DIR` to its real path first (`cd "$SHADI_TMP_DIR" && pwd -P`) —
+> `/tmp` is a symlink to `/private/tmp`, and Seatbelt's sandbox rules don't
+> match a path reached through the symlink if the rule was generated for the
+> canonicalized form. See [Environment variables](#environment-variables).
 
 ```bash
 # Wrap any subprocess that speaks the agentbridge JSON protocol
-shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+shadictl --net-block --net-allow 127.0.0.1:47357 --read "$SHADI_TMP_DIR" -- \
   agentbridge register \
   --tool generic-stdio \
   --command my-tool \
@@ -33,15 +39,15 @@ shadictl --net-block --net-allow 127.0.0.1:47357 -- \
   --slim-endpoint 127.0.0.1:47357
 
 # Start a Claude Code adapter
-shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+shadictl --net-block --net-allow 127.0.0.1:47357 --read "$SHADI_TMP_DIR" -- \
   agentbridge register --tool claude-code --slim-endpoint 127.0.0.1:47357
 
 # Start a Copilot adapter
-shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+shadictl --net-block --net-allow 127.0.0.1:47357 --read "$SHADI_TMP_DIR" -- \
   agentbridge register --tool copilot --slim-endpoint 127.0.0.1:47357
 
 # Start a Codex adapter
-shadictl --net-block --net-allow 127.0.0.1:47357 -- \
+shadictl --net-block --net-allow 127.0.0.1:47357 --read "$SHADI_TMP_DIR" -- \
   agentbridge register --tool codex --slim-endpoint 127.0.0.1:47357
 
 # Publish an OASF record to the Agent Directory after registering

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -450,6 +450,28 @@ fn default_skills() -> Vec<AgentSkill> {
     .collect()
 }
 
+/// Require that this process is running under a SHADI sandbox with network
+/// blocked by default before it may expose a remote-reachable listener.
+///
+/// Seatbelt (macOS), Landlock (Linux), and AppContainer + Job Objects
+/// (Windows) sandboxes are all kernel-enforced and inherited by descendant
+/// processes, so wrapping `agentbridge register` in `shadictl`'s sandbox is
+/// enough to constrain whatever CLI tool an adapter spawns to run a task —
+/// no sandboxing code is needed in agentbridge itself. See
+/// [`shadi_sandbox::sandbox_enforced_from_env`].
+fn require_sandbox_enforced(agent_id: &str, endpoint: &str) -> Result<(), String> {
+    if shadi_sandbox::sandbox_enforced_from_env() {
+        return Ok(());
+    }
+    Err(format!(
+        "agentbridge register --slim-endpoint requires running under a SHADI sandbox with \
+         network blocked by default — a remote-reachable listener must not execute tasks \
+         unsandboxed. Launch as:\n\n  \
+         shadictl --net-block --net-allow {endpoint} -- agentbridge register --tool {agent_id} \
+         --slim-endpoint {endpoint} ...\n"
+    ))
+}
+
 /// Start a SLIM A2A listener that forwards incoming tasks to `adapter`.
 ///
 /// Listens indefinitely under `agntcy/shadi/<agent_id>-a2a` until Ctrl-C.
@@ -463,7 +485,12 @@ fn run_slim_listener(
 ) -> Result<(), String> {
     let agent_name = format!("agntcy/shadi/{agent_id}-a2a");
 
-    // Security posture: incoming A2A tasks are executed by the local CLI tool.
+    require_sandbox_enforced(agent_id, endpoint)?;
+
+    // Security posture: incoming A2A tasks are executed by the local CLI tool,
+    // constrained by whatever SHADI sandbox policy wraps this process (required
+    // above). Sandboxing bounds what a task CAN do; SLIM_MEMBER_DIDS still
+    // decides WHO may send one — only expose this listener to trusted SLIM peers.
     eprintln!(
         "⚠️  Incoming A2A tasks on {agent_name} are executed by the local '{agent_id}' \
          CLI tool. Only expose this listener to trusted SLIM peers."
@@ -667,6 +694,32 @@ fn publish_card_to_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn require_sandbox_enforced_rejects_unsandboxed_and_permissive() {
+        // These env vars are touched by no other test in this crate, so a single
+        // sequential test needs no cross-test lock.
+        std::env::remove_var(shadi_sandbox::SANDBOX_ACTIVE_ENV);
+        std::env::remove_var(shadi_sandbox::SANDBOX_NET_BLOCKED_ENV);
+        let err = require_sandbox_enforced("copilot", "127.0.0.1:47357")
+            .expect_err("must reject when not running under any sandbox");
+        assert!(err.contains("shadictl --net-block"));
+        assert!(err.contains("--tool copilot"));
+        assert!(err.contains("127.0.0.1:47357"));
+
+        std::env::set_var(shadi_sandbox::SANDBOX_ACTIVE_ENV, "1");
+        std::env::set_var(shadi_sandbox::SANDBOX_NET_BLOCKED_ENV, "0");
+        assert!(
+            require_sandbox_enforced("copilot", "127.0.0.1:47357").is_err(),
+            "an active but network-permissive sandbox must still be rejected"
+        );
+
+        std::env::set_var(shadi_sandbox::SANDBOX_NET_BLOCKED_ENV, "1");
+        assert!(require_sandbox_enforced("copilot", "127.0.0.1:47357").is_ok());
+
+        std::env::remove_var(shadi_sandbox::SANDBOX_ACTIVE_ENV);
+        std::env::remove_var(shadi_sandbox::SANDBOX_NET_BLOCKED_ENV);
+    }
 
     #[test]
     fn preview_truncates_to_first_nonblank_line() {

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -16,6 +16,37 @@ use std::process::{Command, ExitStatus};
 use std::io;
 use tracing::{field, info_span};
 
+/// Set on a sandboxed child's environment by [`spawn_sandboxed`], `"1"` iff
+/// the process is running under a SHADI sandbox at all.
+///
+/// Env vars are inherited by descendants automatically, so a grandchild
+/// spawned by the sandboxed process (e.g. a coding-tool subprocess launched
+/// by an agentbridge adapter) can observe this too — but it does not, on its
+/// own, mean anything is actually restricted. Use [`sandbox_enforced_from_env`]
+/// to check for a *meaningfully* restrictive policy, not just an active one.
+pub const SANDBOX_ACTIVE_ENV: &str = "SHADI_SANDBOX_ACTIVE";
+
+/// Set on a sandboxed child's environment by [`spawn_sandboxed`], `"1"` iff
+/// the enclosing policy blocks network by default ([`SandboxPolicy::net_blocked`]).
+pub const SANDBOX_NET_BLOCKED_ENV: &str = "SHADI_SANDBOX_NET_BLOCKED";
+
+/// Whether the current process is running under a SHADI sandbox that blocks
+/// network by default (exceptions carved out via `net_allow` are fine — the
+/// point is default-deny, not zero connectivity).
+///
+/// Seatbelt (macOS), Landlock (Linux), and AppContainer + Job Objects
+/// (Windows) sandboxes are all kernel-enforced and inherited by descendant
+/// processes, so any subprocess spawned by a sandboxed process — including a
+/// coding-tool subprocess an agentbridge adapter launches — is bound by the
+/// same policy automatically. A remote-reachable listener (or any other
+/// operation that executes attacker-influenceable input) should call this
+/// before starting and refuse to run if it returns `false`, rather than
+/// re-implementing policy enforcement itself.
+pub fn sandbox_enforced_from_env() -> bool {
+    std::env::var(SANDBOX_ACTIVE_ENV).as_deref() == Ok("1")
+        && std::env::var(SANDBOX_NET_BLOCKED_ENV).as_deref() == Ok("1")
+}
+
 pub fn spawn_sandboxed(command: &mut Command, policy: &SandboxPolicy) -> Result<SandboxedChild, SandboxError> {
     let program = command.get_program().to_string_lossy().to_string();
     let args = command
@@ -39,6 +70,12 @@ pub fn spawn_sandboxed(command: &mut Command, policy: &SandboxPolicy) -> Result<
         network.mode = %network_mode,
     );
     let _guard = span.enter();
+
+    command.env(SANDBOX_ACTIVE_ENV, "1");
+    command.env(
+        SANDBOX_NET_BLOCKED_ENV,
+        if policy.net_blocked() { "1" } else { "0" },
+    );
 
     platform::spawn_sandboxed(command, policy)
 }
@@ -225,6 +262,57 @@ mod tests {
         let policy = SandboxPolicy::new().allow_read_path("/usr/bin");
         let mut child = spawn_sandboxed(&mut command, &policy).expect("spawn");
         let _ = child.wait().expect("wait");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_sandboxed_propagates_sandbox_env_vars_to_child() {
+        use std::process::Stdio;
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(format!("echo ${SANDBOX_ACTIVE_ENV} ${SANDBOX_NET_BLOCKED_ENV}"))
+            .stdout(Stdio::piped());
+        let policy = SandboxPolicy::new()
+            .allow_read_path("/bin")
+            .allow_read_path("/usr/bin")
+            .block_network(true);
+        let mut child = spawn_sandboxed(&mut command, &policy).expect("spawn");
+        let stdout = child.take_stdout().expect("stdout piped");
+        let output = std::io::read_to_string(stdout).expect("read child stdout");
+        child.wait().expect("wait");
+        assert_eq!(output.trim(), "1 1");
+    }
+
+    #[test]
+    fn sandbox_enforced_from_env_requires_both_active_and_net_blocked() {
+        // These env vars are touched by no other test in this crate, so a single
+        // sequential test needs no cross-test lock.
+        std::env::remove_var(SANDBOX_ACTIVE_ENV);
+        std::env::remove_var(SANDBOX_NET_BLOCKED_ENV);
+        assert!(!sandbox_enforced_from_env(), "no sandbox env vars set");
+
+        std::env::set_var(SANDBOX_ACTIVE_ENV, "1");
+        assert!(
+            !sandbox_enforced_from_env(),
+            "active but permissive (network not blocked) must not count as enforced"
+        );
+
+        std::env::set_var(SANDBOX_NET_BLOCKED_ENV, "0");
+        assert!(!sandbox_enforced_from_env());
+
+        std::env::set_var(SANDBOX_NET_BLOCKED_ENV, "1");
+        assert!(sandbox_enforced_from_env());
+
+        std::env::remove_var(SANDBOX_ACTIVE_ENV);
+        assert!(
+            !sandbox_enforced_from_env(),
+            "net-blocked flag alone without the active flag must not count as enforced"
+        );
+
+        std::env::remove_var(SANDBOX_ACTIVE_ENV);
+        std::env::remove_var(SANDBOX_NET_BLOCKED_ENV);
     }
 
     #[cfg(unix)]

--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -315,10 +315,14 @@ Controls:
   (Linux), and AppContainer + Job Objects (Windows) sandboxes are all
   kernel-enforced and inherited by child processes, so wrapping `agentbridge
   register` in [`shadictl`](sandbox.md) — `shadictl --net-block --net-allow
-  <slim-endpoint> -- agentbridge register ...` — is enough to confine whatever
-  CLI tool the adapter spawns to run a task. agentbridge has no sandboxing code
-  of its own; it leans entirely on the same enforcement `shadictl` already
-  provides.
+  <slim-endpoint> --read <mtls-cert-dir> -- agentbridge register ...` — is
+  enough to confine whatever CLI tool the adapter spawns to run a task.
+  agentbridge has no sandboxing code of its own; it leans entirely on the same
+  enforcement `shadictl` already provides. The `--read` grant needs the SLIM
+  mTLS client certificate directory so the listener itself can still connect;
+  on macOS, resolve it to its real path first (`/tmp` is a symlink to
+  `/private/tmp`, and Seatbelt's rules don't match a path reached through the
+  symlink if generated for the canonicalized form).
 - The listener prints a warning on start-up naming the tool that will execute
   incoming tasks.
 - Only expose the listener to trusted SLIM peers (`SLIM_MEMBER_DIDS` decides

--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -309,10 +309,20 @@ so it can act non-interactively.
 
 Controls:
 
+- **Enforced**: `register --slim-endpoint` refuses to start unless the process is
+  running under a SHADI sandbox with network blocked by default
+  (`shadi_sandbox::sandbox_enforced_from_env`). Seatbelt (macOS), Landlock
+  (Linux), and AppContainer + Job Objects (Windows) sandboxes are all
+  kernel-enforced and inherited by child processes, so wrapping `agentbridge
+  register` in [`shadictl`](sandbox.md) — `shadictl --net-block --net-allow
+  <slim-endpoint> -- agentbridge register ...` — is enough to confine whatever
+  CLI tool the adapter spawns to run a task. agentbridge has no sandboxing code
+  of its own; it leans entirely on the same enforcement `shadictl` already
+  provides.
 - The listener prints a warning on start-up naming the tool that will execute
   incoming tasks.
-- Only expose the listener to trusted SLIM peers. Run agents inside the SHADI
-  [sandbox](sandbox.md) so tool execution is confined by OS policy.
+- Only expose the listener to trusted SLIM peers (`SLIM_MEMBER_DIDS` decides
+  *who* may send a task; the sandbox decides *what* it can do once it runs).
 - Keep the SLIM node on loopback (`127.0.0.1`) for local demos; only bind a
   routable address when the peer set is trusted and authenticated.
 

--- a/docs/content/demos/demo-env-dir.sh
+++ b/docs/content/demos/demo-env-dir.sh
@@ -19,6 +19,12 @@ export SHADI_SLIM_AUTH=did                         # select DID-JWT admission
 export SLIM_HUMAN_SEED="shadi-dir-demo-human-root-secret"
 
 export SHADI_TMP_DIR="${SHADI_TMP_DIR:-/tmp/shadi-dir-demo}"
+mkdir -p "$SHADI_TMP_DIR"
+# Resolve to the real path (macOS /tmp is a symlink to /private/tmp) so it
+# matches exactly what shadictl's sandbox --read/--write policy resolves to —
+# Seatbelt's subpath rules don't match a path accessed through the /tmp
+# symlink if the rule was generated for the canonicalized /private/tmp form.
+export SHADI_TMP_DIR="$(cd "$SHADI_TMP_DIR" && pwd -P)"
 export SLIM_ENDPOINT="${SLIM_ENDPOINT:-127.0.0.1:47660}"
 
 # One transport cert is fine for the demo — identity is the DID, not the TLS CN.

--- a/docs/content/demos/demo-env.sh
+++ b/docs/content/demos/demo-env.sh
@@ -11,6 +11,12 @@ export SLIM_HUMAN_SEED="shadi-demo-human-root-secret"
 export SLIM_HUMAN_DID="did:key:z6MkhVTmZLk7g6zRXm8DF2u2Y5b2WCkC75n16xuoJDN1X4Bp"
 
 export SHADI_TMP_DIR="${SHADI_TMP_DIR:-/tmp/shadi-did-demo}"
+mkdir -p "$SHADI_TMP_DIR"
+# Resolve to the real path (macOS /tmp is a symlink to /private/tmp) so it
+# matches exactly what shadictl's sandbox --read/--write policy resolves to —
+# Seatbelt's subpath rules don't match a path accessed through the /tmp
+# symlink if the rule was generated for the canonicalized /private/tmp form.
+export SHADI_TMP_DIR="$(cd "$SHADI_TMP_DIR" && pwd -P)"
 export SLIM_ENDPOINT="${SLIM_ENDPOINT:-127.0.0.1:47560}"
 
 # One transport cert is fine for the demo — identity is the DID, not the TLS CN.

--- a/docs/content/demos/did-agent-group.md
+++ b/docs/content/demos/did-agent-group.md
@@ -196,10 +196,15 @@ checks `SHADI_SLIM_AUTH=did` the same way `shadictl` does, no separate setup).
 of this step (it still participates in the roll call above).
 
 **Each agent terminal (e.g. claude-code)** — registers a live adapter backed by the
-real CLI, reachable at `agntcy/shadi/claude-code-a2a`:
+real CLI, reachable at `agntcy/shadi/claude-code-a2a`. `agentbridge register
+--slim-endpoint` refuses to start unless it's running under a SHADI sandbox with
+network blocked by default — Seatbelt/Landlock/AppContainer policies are inherited
+by child processes, so wrapping it in `shadictl` is enough to constrain whatever CLI
+tool the adapter spawns to run a task, with no extra code:
 
 ```bash
-SHADI_AGENT_ID=claude-code target/debug/agentbridge register --tool claude-code \
+SHADI_AGENT_ID=claude-code target/debug/shadictl --net-block --net-allow "$SLIM_ENDPOINT" -- \
+  target/debug/agentbridge register --tool claude-code \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT"
 ```
 ```text

--- a/docs/content/demos/did-agent-group.md
+++ b/docs/content/demos/did-agent-group.md
@@ -203,7 +203,8 @@ by child processes, so wrapping it in `shadictl` is enough to constrain whatever
 tool the adapter spawns to run a task, with no extra code:
 
 ```bash
-SHADI_AGENT_ID=claude-code target/debug/shadictl --net-block --net-allow "$SLIM_ENDPOINT" -- \
+SHADI_AGENT_ID=claude-code target/debug/shadictl --net-block --net-allow "$SLIM_ENDPOINT" \
+  --read "$SHADI_TMP_DIR" -- \
   target/debug/agentbridge register --tool claude-code \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT"
 ```

--- a/docs/content/demos/dir-group-discovery.md
+++ b/docs/content/demos/dir-group-discovery.md
@@ -124,7 +124,8 @@ whatever CLI tool the adapter spawns to run a task, with no extra code:
 source docs/content/demos/demo-env-dir.sh
 export SLIM_MEMBER_DIDS="did:key:z6MkwE1Y6L4KLgaQMACssnKN9LSEGTJpgdJxATgvRJAgkF76"
 SHADI_AGENT_ID=copilot target/debug/shadictl --net-block \
-  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" -- \
+  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" \
+  --read "$SHADI_TMP_DIR" -- \
   target/debug/agentbridge register --tool copilot \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
   --dir-publish --dir-server "$SHADI_DIR_SERVER"
@@ -249,7 +250,8 @@ without recreating anything.
 source docs/content/demos/demo-env-dir.sh
 export SLIM_MEMBER_DIDS="did:key:z6MkwE1Y6L4KLgaQMACssnKN9LSEGTJpgdJxATgvRJAgkF76"
 SHADI_AGENT_ID=claude-code target/debug/shadictl --net-block \
-  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" -- \
+  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" \
+  --read "$SHADI_TMP_DIR" -- \
   target/debug/agentbridge register --tool claude-code \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
   --dir-publish --dir-server "$SHADI_DIR_SERVER"

--- a/docs/content/demos/dir-group-discovery.md
+++ b/docs/content/demos/dir-group-discovery.md
@@ -115,12 +115,17 @@ printf '/slim whoami\n/exit\n' | SHADI_AGENT_ID=avatar target/debug/shadictl she
 ```
 
 **Terminal copilot** and **Terminal codex** — register a real listener and
-publish its AgentCard to the local DIR node:
+publish its AgentCard to the local DIR node. `agentbridge register
+--slim-endpoint` refuses to start unless it's running under a SHADI sandbox with
+network blocked by default — wrapping it in `shadictl` is enough to constrain
+whatever CLI tool the adapter spawns to run a task, with no extra code:
 
 ```bash
 source docs/content/demos/demo-env-dir.sh
 export SLIM_MEMBER_DIDS="did:key:z6MkwE1Y6L4KLgaQMACssnKN9LSEGTJpgdJxATgvRJAgkF76"
-SHADI_AGENT_ID=copilot target/debug/agentbridge register --tool copilot \
+SHADI_AGENT_ID=copilot target/debug/shadictl --net-block \
+  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" -- \
+  target/debug/agentbridge register --tool copilot \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
   --dir-publish --dir-server "$SHADI_DIR_SERVER"
 ```
@@ -243,7 +248,9 @@ without recreating anything.
 ```bash
 source docs/content/demos/demo-env-dir.sh
 export SLIM_MEMBER_DIDS="did:key:z6MkwE1Y6L4KLgaQMACssnKN9LSEGTJpgdJxATgvRJAgkF76"
-SHADI_AGENT_ID=claude-code target/debug/agentbridge register --tool claude-code \
+SHADI_AGENT_ID=claude-code target/debug/shadictl --net-block \
+  --net-allow "$SLIM_ENDPOINT" --net-allow "$SHADI_DIR_SERVER" -- \
+  target/debug/agentbridge register --tool claude-code \
   --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
   --dir-publish --dir-server "$SHADI_DIR_SERVER"
 ```

--- a/docs/content/demos/run-demo.sh
+++ b/docs/content/demos/run-demo.sh
@@ -22,7 +22,12 @@ AB=target/debug/agentbridge
 [ -x "$AB" ] || { echo "building agentbridge…"; cargo build -p agntcy-agentbridge-cli || exit 1; }
 
 # Fresh, isolated run dir + endpoint; clear any stale shells holding the port.
-export SHADI_TMP_DIR="$(mktemp -d /tmp/shadi-did-demo.XXXXXX)"
+# Resolve to the real path (macOS /tmp is a symlink to /private/tmp) so it
+# matches exactly what shadictl's sandbox --read/--write policy resolves to —
+# Seatbelt's subpath rules don't match a path accessed through the /tmp
+# symlink if the rule was generated for the canonicalized /private/tmp form.
+SHADI_TMP_DIR_RAW="$(mktemp -d /tmp/shadi-did-demo.XXXXXX)"
+export SHADI_TMP_DIR="$(cd "$SHADI_TMP_DIR_RAW" && pwd -P)"
 export SLIM_ENDPOINT="127.0.0.1:47590"
 pkill -f "$BIN shell" 2>/dev/null; sleep 1
 # shellcheck source=/dev/null
@@ -99,8 +104,14 @@ step "Part 2 done."
 # codex checks real disk usage, copilot ranks real processes by CPU, and
 # claude-code is given both real outputs and asked to synthesize a report — each
 # step depends on the previous agent's real result, not a canned reply.
-# A failed delegate below usually means that CLI isn't installed/authenticated on
-# this machine, not a SHADI bug — the script continues regardless.
+# A failed delegate below usually means the CLI isn't installed/authenticated
+# on this machine, or that the sandbox --net-block/--read policy above is
+# narrower than what that CLI itself needs (its own API endpoints, install
+# path, or credential/config directory aren't in --net-allow/--read) — not a
+# SHADI bug. The policy here only grants what agentbridge's own SLIM listener
+# needs; add tool-specific --read/--net-allow entries if you want the wrapped
+# CLI's own network/filesystem calls to succeed too. The script continues
+# regardless.
 
 step "Part 3: registering claude-code/codex/copilot as real agentbridge adapters..."
 REGISTER_PIDS=()
@@ -109,7 +120,8 @@ for a in claude-code codex copilot; do
   # sandbox with network blocked by default — Seatbelt/Landlock/AppContainer
   # policies are inherited by child processes, so wrapping it in shadictl is
   # enough to confine whatever CLI tool the adapter spawns to run a task.
-  env SHADI_AGENT_ID="$a" "$BIN" --net-block --net-allow "$SLIM_ENDPOINT" -- \
+  env SHADI_AGENT_ID="$a" "$BIN" --net-block --net-allow "$SLIM_ENDPOINT" \
+    --read "$SHADI_TMP_DIR" -- \
     "$AB" register --tool "$a" --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
     >"$LOG/$a-agent.log" 2>&1 &
   REGISTER_PIDS+=($!)

--- a/docs/content/demos/run-demo.sh
+++ b/docs/content/demos/run-demo.sh
@@ -105,7 +105,12 @@ step "Part 2 done."
 step "Part 3: registering claude-code/codex/copilot as real agentbridge adapters..."
 REGISTER_PIDS=()
 for a in claude-code codex copilot; do
-  env SHADI_AGENT_ID="$a" "$AB" register --tool "$a" --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
+  # register --slim-endpoint refuses to start unless it's running under a SHADI
+  # sandbox with network blocked by default — Seatbelt/Landlock/AppContainer
+  # policies are inherited by child processes, so wrapping it in shadictl is
+  # enough to confine whatever CLI tool the adapter spawns to run a task.
+  env SHADI_AGENT_ID="$a" "$BIN" --net-block --net-allow "$SLIM_ENDPOINT" -- \
+    "$AB" register --tool "$a" --command "$(pwd)" --slim-endpoint "$SLIM_ENDPOINT" \
     >"$LOG/$a-agent.log" 2>&1 &
   REGISTER_PIDS+=($!)
 done

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -194,11 +194,18 @@ Controls:
   allow-list — shared secrets are not accepted for agentbridge listeners
   (`shadi_identity::require_did_auth_from_env` rejects anything else). See the
   [Secure Agent Group Demo](demos/did-agent-group.md) for the full admission
-  model.
+  model. This decides *who* may send a task.
 - Transport is mutually authenticated with SLIMRPC over TLS; keep the CA bundle
   private to trusted peers.
-- Run bridged tools inside the SHADI [sandbox](sandbox.md) so tool execution is
-  confined by OS policy. See [AgentBridge → Security model](agentbridge.md#security-model).
+- **Enforced**: `register --slim-endpoint` refuses to start unless it is running
+  under a SHADI [sandbox](sandbox.md) with network blocked by default
+  (`shadi_sandbox::sandbox_enforced_from_env`). Seatbelt/Landlock/AppContainer
+  sandboxes are kernel-enforced and inherited by child processes, so wrapping
+  `agentbridge register` in `shadictl` confines whatever CLI tool the adapter
+  spawns to run a task — agentbridge has no sandboxing logic of its own, it
+  leans entirely on `shadictl`'s existing enforcement. This decides *what* a
+  task can do once it runs. See
+  [AgentBridge → Security model](agentbridge.md#security-model).
 
 ## Threat model
 


### PR DESCRIPTION
## Summary

`agentbridge register --slim-endpoint` forwards every incoming A2A task straight to the wrapped CLI tool's subprocess. DID auth (`SLIM_MEMBER_DIDS`) gates *who* can send a task; nothing gated *what* it can do once it ran — agentbridge has no dependency on `shadi_sandbox` at all, and none of its 5 adapters route their subprocess spawn through any policy.

## Fix: leverage shadictl's existing sandbox natively, don't duplicate it

Seatbelt (macOS), Landlock (Linux), and AppContainer + Job Objects (Windows) are all kernel-enforced and **inherited by child processes**. That means agentbridge doesn't need any sandboxing code of its own — if `agentbridge register` runs wrapped inside `shadictl`'s sandbox, whatever CLI tool an adapter spawns to execute a task is already constrained, for free.

- `shadi_sandbox::spawn_sandboxed` now stamps `SHADI_SANDBOX_ACTIVE` / `SHADI_SANDBOX_NET_BLOCKED` onto the sandboxed child's env (inherited by grandchildren automatically).
- New `shadi_sandbox::sandbox_enforced_from_env()` — `true` iff both are set, i.e. an *active and network-default-deny* sandbox, not just any sandbox (a permissive `--profile connected` doesn't count).
- `agentbridge register --slim-endpoint` now hard-fails at startup unless that returns `true`:
  ```
  agentbridge register --slim-endpoint requires running under a SHADI sandbox with
  network blocked by default — a remote-reachable listener must not execute tasks
  unsandboxed. Launch as:

    shadictl --net-block --net-allow <endpoint> -- agentbridge register --tool <tool> ...
  ```
- Updated demo scripts/docs (`run-demo.sh`, `did-agent-group.md`, `dir-group-discovery.md`, `agentbridge.md`, `security.md`, the CLI README) that previously invoked `register --slim-endpoint` unwrapped.

## Test plan
- [x] `cargo test -p agntcy-shadi-sandbox -p agntcy-agentbridge-cli` — new tests for `sandbox_enforced_from_env` (including a real macOS `spawn_sandboxed` + env-propagation integration test) and `require_sandbox_enforced`
- [x] `cargo build --workspace`
- [x] `mkdocs build --strict`
- [x] Verified `shadictl`'s existing `signal_hook`-based interrupt handling kills+waits its sandboxed child before exiting, so `run-demo.sh`'s `kill -INT; wait` cleanup still works after wrapping