### PR TITLE
feat(desktop): define the Tauri IPC command contract

### DIFF
--- a/apps/shadi_desktop/docs/ipc-contract.md
+++ b/apps/shadi_desktop/docs/ipc-contract.md
@@ -1,0 +1,82 @@
+# Tauri IPC command contract
+
+Closes [agntcy/shadi#114](https://github.com/agntcy/shadi/issues/114).
+
+This is the frontend/backend contract every panel issue (`#115`-`#121`) builds
+against. It exists so frontend and backend work can proceed in parallel
+without churn: the request/response shapes below should not need to change
+when a panel replaces its module's stubs with real calls into the
+corresponding SHADI crate.
+
+**Scope**: signatures and types only. Every command in `src-tauri/src/commands/`
+currently returns `not_implemented(<panel-issue>)` — see that module's own
+doc comment. Implementing them is each panel issue's job, not this one's.
+
+## Conventions
+
+- **Errors are `String`.** Tauri requires command errors to be serializable;
+  a plain message is enough at this layer — no error-code taxonomy yet. If a
+  panel's implementation needs richer error handling (e.g. distinguishing
+  "not found" from "permission denied" in the UI), add a typed error enum
+  in that panel's own PR rather than widening this contract speculatively.
+- **One module per panel**, named to match: `sandbox.rs` (#115), `policy.rs`
+  (#116), `identity.rs` (#117, secrets included), `slim.rs` (#118), `dir.rs`
+  (#119), `agentbridge.rs` (#120), `trace_memory.rs` (#121, both included
+  since they share one CLI-side gate — see below).
+- **Async by default.** Every command is `async fn`, even though the stubs
+  don't await anything — real implementations will call into blocking SHADI
+  APIs (subprocess I/O, keychain access, SLIM connections) and should do that
+  work via `tauri::async_runtime::spawn_blocking` rather than block Tauri's
+  async executor.
+- **Sessions are identified by socket path**, not an opaque handle. The
+  sandbox/policy commands all take a `socket_path: String` — the same
+  identifier `shadictl shell`'s `/attach` and `/sessions` already use — so a
+  panel can hold a list of sessions from `sandbox_list_sessions` and pass one
+  straight back into `policy_query`/`sandbox_status` without a separate
+  "open a handle" step.
+- **Secret values never round-trip further than they have to.** `secret_get`
+  returns the raw value (the panel needs it to display it), but
+  `secret_list_keychain` returns key names only, and `memory_search`/
+  `memory_list` return entry metadata without `payload` — only `memory_get`
+  populates that field. Panels must not log or persist values returned by
+  these commands outside of React state. See
+  [`docs/content/security.md`](https://github.com/agntcy/shadi/blob/main/docs/content/security.md)
+  for the secret-delivery model this must not weaken.
+- **Streaming uses Tauri events, not long-lived return values.**
+  `agentbridge_coordinate` is the one command whose real implementation runs
+  for multiple rounds. Rather than returning a `Vec` of every round only at
+  the end, it emits `CoordinateRoundEvent` on the `coordinate:round` event
+  (see `COORDINATE_ROUND_EVENT` in `agentbridge.rs`) as each round completes,
+  and the command's return value is only the final result. The frontend must
+  call `listen("coordinate:round", ...)` *before* invoking the command, or it
+  will miss early rounds.
+- **Tagged unions over mutually-exclusive optional fields.** The CLI models
+  "secret ref xor file path" as two `Option<T>` args with `conflicts_with`/
+  `required_unless_present` clap attributes — that's a clap ergonomics
+  pattern, not a good IPC shape. `HumanKeySource` in `identity.rs` is a
+  `#[serde(tag = "kind")]` enum instead, so invalid combinations aren't
+  representable at all.
+
+## Command index
+
+| Module | Commands | CLI/shell equivalent |
+|---|---|---|
+| `sandbox.rs` | `sandbox_launch`, `sandbox_list_sessions`, `sandbox_attach`, `sandbox_detach`, `sandbox_kill`, `sandbox_status` | `shadictl <flags> -- <cmd>`, shell `/sessions` `/attach` `/detach` `/kill` `/status` |
+| `policy.rs` | `policy_query`, `policy_patch`, `policy_explain`, `policy_diff`, `policy_profiles` | shell `/policy query\|patch\|explain\|diff`, `--profile` |
+| `identity.rs` | `identity_did_from_gpg`, `identity_did_from_github`, `identity_derive_agent`, `identity_verify_agent`, `secret_get`, `secret_put_key`, `secret_list_keychain`, `secret_backend_status` | `shadictl did-from-gpg\|did-from-github\|derive-agent-identity\|verify-agent-identity\|get-secret\|put-key`, `--list-keychain` |
+| `slim.rs` | `slim_node_start`, `slim_node_status`, `slim_group_create`, `slim_group_invite`, `slim_group_join`, `slim_controller_list_connections`, `slim_controller_list_routes` | shell `/slim start-node\|create-group\|invite\|join\|controller` |
+| `dir.rs` | `dir_search`, `dir_pull`, `dir_info`, `dir_register` | `shadictl dir search\|pull\|info`, `agentbridge register --dir-publish` |
+| `agentbridge.rs` | `agentbridge_list_adapters`, `agentbridge_handoff`, `agentbridge_delegate`, `agentbridge_coordinate` | `agentbridge list\|handoff\|delegate\|coordinate` |
+| `trace_memory.rs` | `trace_list`, `trace_summary`, `memory_get`, `memory_search`, `memory_list` | `shadictl trace list\|summary`, `shadictl memory get\|search\|list` |
+
+Full request/response types are in each module — they're the source of
+truth; this table is a map, not a copy.
+
+## What's deliberately not here
+
+- **The embedded terminal (#122)** doesn't need any of these commands — it
+  spawns `shadictl shell` as a real subprocess/PTY and talks to it over
+  stdin/stdout, not Tauri IPC.
+- **Onboarding (#123)** composes `identity_derive_agent` and
+  `secret_backend_status` from this contract; it doesn't need new commands
+  of its own.

--- a/apps/shadi_desktop/src-tauri/Cargo.lock
+++ b/apps/shadi_desktop/src-tauri/Cargo.lock
@@ -3004,6 +3004,8 @@ dependencies = [
 name = "shadi_desktop"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",

--- a/apps/shadi_desktop/src-tauri/Cargo.toml
+++ b/apps/shadi_desktop/src-tauri/Cargo.toml
@@ -30,4 +30,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 

--- a/apps/shadi_desktop/src-tauri/src/commands/agentbridge.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/agentbridge.rs
@@ -1,0 +1,112 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! agentbridge control panel (agntcy/shadi#120) — replaces `agentbridge
+//! list|handoff|delegate|coordinate`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 120;
+
+/// Tauri event name `agentbridge_coordinate` emits a [`CoordinateRoundEvent`]
+/// on, once per round, while a coordination run is in flight. The frontend
+/// subscribes with `listen("coordinate:round", ...)` before invoking the
+/// command — this is what makes round-by-round progress visible instead of
+/// only a final result (the highest-value piece of this panel, per #120).
+///
+/// Unused until #120 wires a real `app.emit(...)` call — part of the
+/// contract, not dead code left behind by accident.
+#[allow(dead_code)]
+pub const COORDINATE_ROUND_EVENT: &str = "coordinate:round";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdapterInfo {
+    pub agent_id: String,
+    pub tool: String,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextPacketSummary {
+    pub id: String,
+    pub source_agent: String,
+    pub conversation_messages: usize,
+    pub artifacts: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegateResult {
+    pub response: String,
+    pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoordinateRequest {
+    pub goal: String,
+    /// `claude-code` | `copilot` | `codex` | `cursor-agent` |
+    /// `generic-stdio:<cmd>` | `slim:<agent-id>[@<host:port>]`, matching
+    /// `agentbridge coordinate --agents`.
+    pub agent_specs: Vec<String>,
+    pub quorum: usize,
+    pub max_rounds: u64,
+    pub require_human: bool,
+}
+
+/// Emitted on [`COORDINATE_ROUND_EVENT`] as a coordination run progresses.
+/// Unused until #120 wires a real `app.emit(...)` call.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoordinateRoundEvent {
+    pub round: u64,
+    pub agent: String,
+    /// "proposal" | "vote".
+    pub kind: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoordinateResult {
+    pub winning_agent: String,
+    pub artifact: String,
+}
+
+/// List registered adapters, via DIR discovery or the local SLIM node only
+/// (`agentbridge list [--local]`).
+#[tauri::command]
+pub async fn agentbridge_list_adapters(local_only: bool) -> Result<Vec<AdapterInfo>, String> {
+    let _ = local_only;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Snapshot context from `from` and inject it into `to` (`agentbridge handoff`).
+#[tauri::command]
+pub async fn agentbridge_handoff(from: String, to: String) -> Result<ContextPacketSummary, String> {
+    let _ = (from, to);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Send a single prompt to a remote adapter over A2A/SLIM (`agentbridge delegate`).
+#[tauri::command]
+pub async fn agentbridge_delegate(
+    prompt: String,
+    to: String,
+    agent_id: String,
+    endpoint: String,
+) -> Result<DelegateResult, String> {
+    let _ = (prompt, to, agent_id, endpoint);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Run `MasRuntime<DevelopmentEngine>` across a set of agents toward a goal
+/// (`agentbridge coordinate`). Emits [`COORDINATE_ROUND_EVENT`] as rounds
+/// complete; returns only the final winning artifact.
+#[tauri::command]
+pub async fn agentbridge_coordinate(
+    app: tauri::AppHandle,
+    request: CoordinateRequest,
+) -> Result<CoordinateResult, String> {
+    let _ = (app, request);
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/dir.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/dir.rs
@@ -1,0 +1,48 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Agent Directory (agntcy/shadi#119) — replaces `shadictl dir
+//! search|pull|info` and `agentbridge register --dir-publish`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 119;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DirRecordSummary {
+    pub cid: String,
+    pub name: String,
+    pub did: Option<String>,
+    pub skills: Vec<String>,
+}
+
+/// Search the directory for agent records by skill (`shadictl dir search`).
+#[tauri::command]
+pub async fn dir_search(skill: String, dir_server: String, limit: usize) -> Result<Vec<DirRecordSummary>, String> {
+    let _ = (skill, dir_server, limit);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Fetch and cache an OASF agent record (`shadictl dir pull`).
+#[tauri::command]
+pub async fn dir_pull(cid: String, dir_server: String) -> Result<DirRecordSummary, String> {
+    let _ = (cid, dir_server);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Display metadata about a locally cached record (`shadictl dir info`).
+#[tauri::command]
+pub async fn dir_info(cid: String) -> Result<DirRecordSummary, String> {
+    let _ = cid;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Publish a real, connectable AgentCard to the directory
+/// (`agentbridge register --dir-publish`). Returns the record's CID.
+#[tauri::command]
+pub async fn dir_register(agent_card_json: String, dir_server: String) -> Result<String, String> {
+    let _ = (agent_card_json, dir_server);
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/identity.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/identity.rs
@@ -1,0 +1,124 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity and secrets (agntcy/shadi#117) — replaces `shadictl`'s
+//! `did-from-gpg`, `did-from-github`, `derive-agent-identity`,
+//! `verify-agent-identity`, `get-secret`, `put-key`, `--list-keychain`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 117;
+
+/// Where human key material comes from. The CLI models this as two
+/// mutually-exclusive `Option` flags (`--secret` xor `--in <file>`); a tagged
+/// union is a cleaner IPC shape for the same choice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HumanKeySource {
+    /// Reference into the SHADI secret store.
+    SecretRef { key: String },
+    /// A GPG key file on disk.
+    File { path: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DidDocument {
+    pub did: String,
+    pub document_json: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentIdentity {
+    pub agent_name: String,
+    pub did: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyAgentIdentityResult {
+    pub matches: bool,
+    pub expected_did: String,
+    pub stored_did: Option<String>,
+    /// `None` if `require_human_binding` wasn't requested.
+    pub human_binding_ok: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeychainEntry {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SecretBackend {
+    Keychain,
+    OnePassword { vault: String },
+}
+
+/// Create a `did:key` document from a GPG key (`did-from-gpg`).
+#[tauri::command]
+pub async fn identity_did_from_gpg(source: HumanKeySource) -> Result<DidDocument, String> {
+    let _ = source;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Create a `did:key` document from a GitHub user's GPG key (`did-from-github`).
+#[tauri::command]
+pub async fn identity_did_from_github(username: String) -> Result<DidDocument, String> {
+    let _ = username;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Derive one or more local agent identities from a human source
+/// (`derive-agent-identity`).
+#[tauri::command]
+pub async fn identity_derive_agent(
+    source: HumanKeySource,
+    agent_names: Vec<String>,
+    human_did_key: Option<String>,
+) -> Result<Vec<AgentIdentity>, String> {
+    let _ = (source, agent_names, human_did_key);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Recompute the expected agent key/DID and compare to stored values
+/// (`verify-agent-identity`).
+#[tauri::command]
+pub async fn identity_verify_agent(
+    source: HumanKeySource,
+    agent_name: String,
+    require_human_binding: bool,
+) -> Result<VerifyAgentIdentityResult, String> {
+    let _ = (source, agent_name, require_human_binding);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Read a secret from the SHADI secret store (`get-secret`). Returns the
+/// secret value — the panel must not log or persist this outside memory.
+#[tauri::command]
+pub async fn secret_get(key: String) -> Result<String, String> {
+    let _ = key;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Store an OpenPGP key in the SHADI secret store (`put-key`).
+#[tauri::command]
+pub async fn secret_put_key(key: String, openpgp_key_path: String) -> Result<(), String> {
+    let _ = (key, openpgp_key_path);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// List keys under a prefix (`--list-keychain` / `--list-prefix`). Returns
+/// key names only — never values.
+#[tauri::command]
+pub async fn secret_list_keychain(prefix: Option<String>) -> Result<Vec<KeychainEntry>, String> {
+    let _ = prefix;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Which secret backend is active (`SHADI_SECRET_BACKEND`).
+#[tauri::command]
+pub async fn secret_backend_status() -> Result<SecretBackend, String> {
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/mod.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/mod.rs
@@ -1,0 +1,27 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Tauri IPC command contract — see ../../docs/ipc-contract.md.
+//!
+//! Every command here is a stub (agntcy/shadi#114): it defines the request
+//! and response shapes the frontend can rely on, but returns
+//! [`not_implemented`] instead of doing real work. Each panel issue
+//! (agntcy/shadi#115-#121) replaces its own module's stubs with real calls
+//! into the corresponding SHADI crate — the signatures below should not need
+//! to change when that happens.
+
+pub mod agentbridge;
+pub mod dir;
+pub mod identity;
+pub mod policy;
+pub mod sandbox;
+pub mod slim;
+pub mod trace_memory;
+
+/// Placeholder error for every stub command. `issue` is the panel issue that
+/// will replace this stub with a real implementation.
+pub(crate) fn not_implemented<T>(issue: u32) -> Result<T, String> {
+    Err(format!(
+        "not implemented yet — see agntcy/shadi#{issue}"
+    ))
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/policy.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/policy.rs
@@ -1,0 +1,73 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Policy inspector and editor (agntcy/shadi#116) — replaces `shadictl
+//! shell`'s `/policy query|patch|explain|diff` and the `--profile` presets.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 116;
+
+/// Serde-friendly mirror of `shadi_sandbox::SandboxPolicy` — the desktop app
+/// doesn't link `shadi_sandbox` yet (that lands with #116's implementation),
+/// so this is an independent shape with the same fields, not a re-export.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PolicyConfig {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+    pub net_allow: Vec<String>,
+    /// "strict" | "balanced" | "connected", matching `shadictl --profile`.
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyExplanation {
+    pub effective: PolicyConfig,
+    /// Human-readable provenance per field, e.g. "profile:strict", "cli:--allow /tmp".
+    pub sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDiff {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub changed: Vec<String>,
+}
+
+/// Show the effective policy of the attached session (`/policy query`).
+#[tauri::command]
+pub async fn policy_query(socket_path: String) -> Result<PolicyConfig, String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Patch the policy of the attached session live (`/policy patch`).
+#[tauri::command]
+pub async fn policy_patch(socket_path: String, patch: PolicyConfig) -> Result<PolicyConfig, String> {
+    let _ = (socket_path, patch);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Resolved policy plus source inputs (`/policy explain`).
+#[tauri::command]
+pub async fn policy_explain(socket_path: String) -> Result<PolicyExplanation, String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Diff effective policy against a baseline profile (`/policy diff`).
+#[tauri::command]
+pub async fn policy_diff(socket_path: String, baseline_profile: String) -> Result<PolicyDiff, String> {
+    let _ = (socket_path, baseline_profile);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// The named profile presets `shadictl --profile` accepts.
+#[tauri::command]
+pub async fn policy_profiles() -> Result<Vec<String>, String> {
+    Ok(vec!["strict".into(), "balanced".into(), "connected".into()])
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
@@ -1,0 +1,77 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sandbox session management (agntcy/shadi#115) — replaces `shadictl shell`'s
+//! `/status`, `/attach`, `/detach`, `/kill`, `/sessions`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+use super::policy::PolicyConfig;
+
+const PANEL_ISSUE: u32 = 115;
+
+/// A discovered or attached SHADI sandbox control socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxSession {
+    pub name: String,
+    pub socket_path: String,
+    pub pid: Option<u32>,
+}
+
+/// Live status of an attached session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxStatus {
+    pub session: SandboxSession,
+    pub running: bool,
+    pub uptime_secs: Option<u64>,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaunchSandboxRequest {
+    pub command: Vec<String>,
+    pub policy: PolicyConfig,
+    pub session_name: Option<String>,
+}
+
+/// Launch a new sandboxed process (mirrors `shadictl <flags> -- <command>`).
+#[tauri::command]
+pub async fn sandbox_launch(request: LaunchSandboxRequest) -> Result<SandboxSession, String> {
+    let _ = request;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Discover running SHADI sandbox control sockets (`/sessions`).
+#[tauri::command]
+pub async fn sandbox_list_sessions() -> Result<Vec<SandboxSession>, String> {
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Attach to a running session by name or socket path (`/attach`).
+#[tauri::command]
+pub async fn sandbox_attach(socket_path: String) -> Result<SandboxStatus, String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Detach from the current session without terminating it (`/detach`).
+#[tauri::command]
+pub async fn sandbox_detach(socket_path: String) -> Result<(), String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Terminate the attached sandboxed process (`/kill`).
+#[tauri::command]
+pub async fn sandbox_kill(socket_path: String) -> Result<(), String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Live status of an attached session (`/status`).
+#[tauri::command]
+pub async fn sandbox_status(socket_path: String) -> Result<SandboxStatus, String> {
+    let _ = socket_path;
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -1,0 +1,100 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! SLIM operations (agntcy/shadi#118) — replaces `shadictl shell`'s
+//! `/slim start-node|create-group|invite|join|controller`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 118;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlimNodeStatus {
+    pub running: bool,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlimGroupMember {
+    pub name: String,
+    pub did: String,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlimGroupInfo {
+    pub channel: String,
+    /// "moderator" | "participant".
+    pub role: String,
+    pub members: Vec<SlimGroupMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlimConnection {
+    pub id: String,
+    pub endpoint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlimRoute {
+    pub destination: String,
+    pub via: String,
+}
+
+/// Start a local native SLIM node with SHADI mTLS defaults (`/slim start-node`).
+#[tauri::command]
+pub async fn slim_node_start() -> Result<SlimNodeStatus, String> {
+    not_implemented(PANEL_ISSUE)
+}
+
+#[tauri::command]
+pub async fn slim_node_status() -> Result<SlimNodeStatus, String> {
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Create a group with members resolved from Agent Directory discovery
+/// and/or named explicitly (`/slim create-group`, `member_specs` in the
+/// `skill:<skill>` | `did:<did>` | `explicit:<name>=<did>[@<endpoint>]` shape
+/// documented in `shadictl slim create-group --help`).
+#[tauri::command]
+pub async fn slim_group_create(
+    channel: String,
+    member_specs: Vec<String>,
+    dir_server: String,
+) -> Result<SlimGroupInfo, String> {
+    let _ = (channel, member_specs, dir_server);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Invite a participant into the active group session (`/slim invite`,
+/// `/slim invite-from`).
+#[tauri::command]
+pub async fn slim_group_invite(channel: String, member_spec: String) -> Result<SlimGroupInfo, String> {
+    let _ = (channel, member_spec);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Join an already-running channel as a participant (`/slim join`).
+#[tauri::command]
+pub async fn slim_group_join(channel: String) -> Result<SlimGroupInfo, String> {
+    let _ = channel;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// List connections known to a controller endpoint (`/slim controller
+/// list-connections`).
+#[tauri::command]
+pub async fn slim_controller_list_connections(endpoint: String) -> Result<Vec<SlimConnection>, String> {
+    let _ = endpoint;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// List routes known to a controller endpoint (`/slim controller
+/// list-routes`).
+#[tauri::command]
+pub async fn slim_controller_list_routes(endpoint: String) -> Result<Vec<SlimRoute>, String> {
+    let _ = endpoint;
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/commands/trace_memory.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/trace_memory.rs
@@ -1,0 +1,78 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trace and memory viewer (agntcy/shadi#121) — replaces `shadictl trace
+//! list|summary` and `shadictl memory get|search|list`.
+
+use serde::{Deserialize, Serialize};
+
+use super::not_implemented;
+
+const PANEL_ISSUE: u32 = 121;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceEntry {
+    pub name: String,
+    pub command: Option<String>,
+    pub exit_code: Option<i32>,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceSummaryEntry {
+    pub span_name: String,
+    pub count: usize,
+    pub avg_duration_ms: f64,
+}
+
+/// Read-only view of a memory entry. `payload` is only populated by
+/// [`memory_get`] — [`memory_search`]/[`memory_list`] return metadata only,
+/// matching the CLI's own behavior, so listing entries doesn't require the
+/// same secret-verification gate as reading one's actual content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryEntry {
+    pub scope: String,
+    pub entry_key: String,
+    pub payload: Option<String>,
+}
+
+/// List recent trace log entries (`shadictl trace list`).
+#[tauri::command]
+pub async fn trace_list(
+    limit: usize,
+    name: Option<String>,
+    command: Option<String>,
+    exit_code: Option<i32>,
+) -> Result<Vec<TraceEntry>, String> {
+    let _ = (limit, name, command, exit_code);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Summarize trace logs by span name (`shadictl trace summary`).
+#[tauri::command]
+pub async fn trace_summary(limit: usize) -> Result<Vec<TraceSummaryEntry>, String> {
+    let _ = limit;
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Read one memory entry, gated behind the same secret-verification path the
+/// CLI's `memory get` uses (`shadictl memory get`).
+#[tauri::command]
+pub async fn memory_get(scope: String, entry_key: String) -> Result<MemoryEntry, String> {
+    let _ = (scope, entry_key);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// Search memory entries by query (`shadictl memory search`).
+#[tauri::command]
+pub async fn memory_search(scope: Option<String>, query: String, limit: usize) -> Result<Vec<MemoryEntry>, String> {
+    let _ = (scope, query, limit);
+    not_implemented(PANEL_ISSUE)
+}
+
+/// List memory entries (`shadictl memory list`).
+#[tauri::command]
+pub async fn memory_list(scope: Option<String>, limit: usize) -> Result<Vec<MemoryEntry>, String> {
+    let _ = (scope, limit);
+    not_implemented(PANEL_ISSUE)
+}

--- a/apps/shadi_desktop/src-tauri/src/lib.rs
+++ b/apps/shadi_desktop/src-tauri/src/lib.rs
@@ -4,14 +4,57 @@
 //! SHADI Desktop — a native control-plane app for shadictl, agentbridge, and
 //! the SHADI shell. See agntcy/shadi#112 for the epic and panel breakdown.
 //!
-//! This is scaffolding only (agntcy/shadi#113): an empty window with no
-//! feature panels yet. The Tauri IPC command contract (agntcy/shadi#114)
-//! lands before any panel starts calling into the core SHADI crates.
+//! The Tauri IPC command contract (agntcy/shadi#114) is defined in
+//! `commands/` — see `../docs/ipc-contract.md`. Every command there is
+//! currently a stub; no feature panels exist yet.
+
+mod commands;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .invoke_handler(tauri::generate_handler![
+            commands::sandbox::sandbox_launch,
+            commands::sandbox::sandbox_list_sessions,
+            commands::sandbox::sandbox_attach,
+            commands::sandbox::sandbox_detach,
+            commands::sandbox::sandbox_kill,
+            commands::sandbox::sandbox_status,
+            commands::policy::policy_query,
+            commands::policy::policy_patch,
+            commands::policy::policy_explain,
+            commands::policy::policy_diff,
+            commands::policy::policy_profiles,
+            commands::identity::identity_did_from_gpg,
+            commands::identity::identity_did_from_github,
+            commands::identity::identity_derive_agent,
+            commands::identity::identity_verify_agent,
+            commands::identity::secret_get,
+            commands::identity::secret_put_key,
+            commands::identity::secret_list_keychain,
+            commands::identity::secret_backend_status,
+            commands::slim::slim_node_start,
+            commands::slim::slim_node_status,
+            commands::slim::slim_group_create,
+            commands::slim::slim_group_invite,
+            commands::slim::slim_group_join,
+            commands::slim::slim_controller_list_connections,
+            commands::slim::slim_controller_list_routes,
+            commands::dir::dir_search,
+            commands::dir::dir_pull,
+            commands::dir::dir_info,
+            commands::dir::dir_register,
+            commands::agentbridge::agentbridge_list_adapters,
+            commands::agentbridge::agentbridge_handoff,
+            commands::agentbridge::agentbridge_delegate,
+            commands::agentbridge::agentbridge_coordinate,
+            commands::trace_memory::trace_list,
+            commands::trace_memory::trace_summary,
+            commands::trace_memory::memory_get,
+            commands::trace_memory::memory_search,
+            commands::trace_memory::memory_list,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary

Closes #114.

Defines the 34 stub commands every panel issue (#115-#121) builds against, one module per panel (sandbox/policy/identity/slim/dir/agentbridge/trace_memory), all wired into the Tauri builder. Each returns `not_implemented(<panel-issue>)` — implementing them is each panel's own job, not this one's. Full design notes in `apps/shadi_desktop/docs/ipc-contract.md`.

Highlights:
- Sessions identified by `socket_path`, matching `shadictl shell`'s own `/attach`/`/sessions` identifier.
- Secret values never round-trip further than needed: `secret_list_keychain` returns key names only; `memory_search`/`memory_list` omit `payload` (only `memory_get` populates it).
- `agentbridge_coordinate` streams round-by-round progress via a Tauri event (`coordinate:round`) instead of only returning a final result.
- `HumanKeySource` is a tagged union, not the CLI's two `conflicts_with` `Option` fields for the same secret-ref-xor-file choice — makes invalid combinations unrepresentable.

## Test plan
- [x] `cargo build --workspace` (root, unaffected)
- [x] `cargo build --locked` in `apps/shadi_desktop/src-tauri` (its own independent workspace)
- [x] `pnpm build` in `apps/shadi_desktop` (frontend unaffected, sanity-checked)
- [x] `mkdocs build --strict`