### PR TITLE
feat(desktop): connect agentbridge discovery to SLIM room membership

### DIFF
--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -303,17 +303,29 @@ pub async fn slim_group_create(
 ///
 /// A `skill:`/`did:`/`explicit:` spec is resolved through the Directory and
 /// admitted with its DID; a bare `org/ns/app` name is invited directly.
+///
+/// `kind` overrides the human/agent default. Callers that already know what
+/// they are admitting should always pass it: adding a Directory-discovered
+/// agent by its known `{name, did, endpoint}` uses an `explicit:` spec, whose
+/// prefix-based default would otherwise mislabel it as human.
 #[tauri::command]
 pub async fn slim_group_invite(
     state: tauri::State<'_, SlimState>,
     channel: String,
     member_spec: String,
     dir_server: Option<String>,
+    kind: Option<String>,
 ) -> Result<SlimGroupInfo, String> {
-    let resolved = if is_member_spec(&member_spec) {
-        let dir_server = dir_server.ok_or_else(|| {
-            format!("member spec '{member_spec}' needs a Directory server to resolve against")
-        })?;
+    let mut resolved = if is_member_spec(&member_spec) {
+        // Only Directory-backed specs need a server; `explicit:` carries its
+        // own DID and resolves locally.
+        let dir_server = if spec_needs_directory(&member_spec) {
+            dir_server.ok_or_else(|| {
+                format!("member spec '{member_spec}' needs a Directory server to resolve against")
+            })?
+        } else {
+            dir_server.unwrap_or_default()
+        };
         resolve_candidates(std::slice::from_ref(&member_spec), &dir_server)?
     } else {
         vec![(
@@ -328,6 +340,11 @@ pub async fn slim_group_invite(
     };
     if resolved.is_empty() {
         return Err(format!("member spec '{member_spec}' resolved to no candidates"));
+    }
+    if let Some(kind) = kind {
+        for (member, _) in &mut resolved {
+            member.kind = kind.clone();
+        }
     }
     admit_dids_to_trust_set(
         resolved
@@ -589,6 +606,13 @@ fn describe_proto_name(name: &ProtoName) -> String {
 fn is_member_spec(spec: &str) -> bool {
     spec.starts_with("skill:") || spec.starts_with("did:") || spec.starts_with("explicit:")
 }
+
+/// Whether a spec has to be resolved against the Agent Directory. `explicit:`
+/// already names `{name, did, endpoint}`, so it resolves without a server.
+fn spec_needs_directory(spec: &str) -> bool {
+    spec.starts_with("skill:") || spec.starts_with("did:")
+}
+
 
 /// Resolve `--members`-style specs into members. Directory-discovered
 /// candidates are agents; an `explicit:` entry names a member by hand and is
@@ -873,6 +897,50 @@ mod tests {
         assert!(is_member_spec("did:key:z6Mk"));
         assert!(is_member_spec("explicit:alice=did:key:z6Mk"));
         assert!(!is_member_spec("agntcy/shadi/reviewer"));
+    }
+
+    #[test]
+    fn only_directory_backed_specs_need_a_server() {
+        assert!(spec_needs_directory("skill:agent_orchestration/x"));
+        assert!(spec_needs_directory("did:key:z6Mk"));
+        // `explicit:` already carries the DID — requiring a DIR server for it
+        // would block admitting an already-discovered candidate.
+        assert!(!spec_needs_directory("explicit:alice=did:key:z6Mk"));
+        assert!(!spec_needs_directory("agntcy/shadi/reviewer"));
+    }
+
+    /// Guards the wire format the frontend's `explicitMemberSpec`
+    /// (`src/shared/rooms.tsx`) emits when admitting a discovered adapter: it
+    /// must resolve locally, DID and endpoint intact, with no Directory server.
+    /// Keep these literals in step with that function.
+    #[test]
+    fn frontend_explicit_spec_format_resolves_without_a_directory() {
+        use agentbridge::member_source::{parse_member_spec, DirLookupOptions};
+
+        let dir = DirLookupOptions {
+            server_addr: String::new(),
+            gh_token: None,
+            limit: 1,
+        };
+
+        let with_endpoint = "explicit:agntcy/shadi/reviewer=did:key:z6MkTest@127.0.0.1:47357";
+        let resolved = parse_member_spec(with_endpoint, &dir)
+            .expect("spec parses")
+            .resolve()
+            .expect("explicit source resolves locally");
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "agntcy/shadi/reviewer");
+        assert_eq!(resolved[0].did, "did:key:z6MkTest");
+        assert_eq!(resolved[0].slim_endpoint.as_deref(), Some("127.0.0.1:47357"));
+
+        // Endpoint is omitted entirely when unknown, not left as a bare `@`.
+        let no_endpoint = "explicit:agntcy/shadi/reviewer=did:key:z6MkTest";
+        let resolved = parse_member_spec(no_endpoint, &dir)
+            .expect("spec parses")
+            .resolve()
+            .expect("explicit source resolves locally");
+        assert_eq!(resolved[0].did, "did:key:z6MkTest");
+        assert!(resolved[0].slim_endpoint.is_none());
     }
 
     #[test]

--- a/apps/shadi_desktop/src/App.tsx
+++ b/apps/shadi_desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import "./App.css";
 import { AgentBridgePanel } from "./panels/AgentBridgePanel";
 import { SlimRoomsPanel } from "./panels/SlimRoomsPanel";
+import { RoomsProvider } from "./shared/rooms";
 
 const TABS = [
   { id: "rooms", label: "Rooms", render: () => <SlimRoomsPanel /> },
@@ -13,21 +14,26 @@ function App() {
   const tab = TABS.find((t) => t.id === active) ?? TABS[0];
 
   return (
-    <main className="container">
-      <h1>SHADI Desktop</h1>
-      <nav className="tabs">
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            className={t.id === active ? "tab tab-active" : "tab"}
-            onClick={() => setActive(t.id)}
-          >
-            {t.label}
-          </button>
-        ))}
-      </nav>
-      {tab.render()}
-    </main>
+    // Rooms are shared across both panels (#135), so the provider wraps both
+    // and survives tab switches — a room admitted in one tab is immediately
+    // visible in the other.
+    <RoomsProvider>
+      <main className="container">
+        <h1>SHADI Desktop</h1>
+        <nav className="tabs">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              className={t.id === active ? "tab tab-active" : "tab"}
+              onClick={() => setActive(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+        {tab.render()}
+      </main>
+    </RoomsProvider>
   );
 }
 

--- a/apps/shadi_desktop/src/panels/AgentBridgePanel.css
+++ b/apps/shadi_desktop/src/panels/AgentBridgePanel.css
@@ -67,6 +67,37 @@
   font-size: 0.9rem;
 }
 
+.ab-hint {
+  opacity: 0.65;
+  font-size: 0.8rem;
+}
+
+.ab-note {
+  margin-top: -0.25rem;
+  margin-bottom: 0.6rem;
+}
+
+.ab-ok {
+  color: #3fb950;
+  font-size: 0.8rem;
+}
+
+.ab-select {
+  padding: 0.3rem 0.4rem;
+  border-radius: 6px;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background: transparent;
+  color: inherit;
+  max-width: 14rem;
+}
+
+.ab-did {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  word-break: break-all;
+  max-width: 16rem;
+}
+
 .ab-table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
+++ b/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
@@ -44,12 +44,14 @@ function ErrorText({ message }: { message: string | null }) {
   return <p className="ab-error">{message}</p>;
 }
 
-/// Admits a discovered adapter into a room without retyping its DID or
-/// endpoint (agntcy/shadi#135). `agentbridge_list_adapters` already returns
-/// `{agent_id, tool: did, endpoint}`, so this builds the `explicit:` spec from
-/// what's in hand — no second Directory round-trip — and passes
-/// `kind: "agent"` so the invite isn't mislabelled human by the spec-prefix
-/// default.
+/**
+ * Admits a discovered adapter into a room without retyping its DID or
+ * endpoint (agntcy/shadi#135). `agentbridge_list_adapters` already returns
+ * `{agent_id, tool: did, endpoint}`, so this builds the `explicit:` spec from
+ * what's in hand — no second Directory round-trip — and passes
+ * `kind: "agent"` so the invite isn't mislabelled human by the spec-prefix
+ * default.
+ */
 function AddToRoom({ adapter }: { adapter: AdapterInfo }) {
   const { rooms, refresh } = useRooms();
   const [busy, setBusy] = useState(false);
@@ -366,9 +368,11 @@ function CoordinateVisualizer() {
     roundsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [rounds]);
 
-  /// Replace the free-typed specs with this room's agent members
-  /// (agntcy/shadi#135). Humans are skipped — they participate through their
-  /// own harness, not as a coordination tool endpoint.
+  /**
+   * Replace the free-typed specs with this room's agent members
+   * (agntcy/shadi#135). Humans are skipped — they participate through their
+   * own harness, not as a coordination tool endpoint.
+   */
   function applyRoomRoster(channel: string) {
     const room = rooms.find((r) => r.channel === channel);
     if (!room) return;

--- a/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
+++ b/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { explicitMemberSpec, slimAgentSpec, useRooms } from "../shared/rooms";
+import type { SlimGroupInfo } from "../shared/rooms";
 import "./AgentBridgePanel.css";
 
 interface AdapterInfo {
@@ -40,6 +42,71 @@ interface CoordinateResult {
 function ErrorText({ message }: { message: string | null }) {
   if (!message) return null;
   return <p className="ab-error">{message}</p>;
+}
+
+/// Admits a discovered adapter into a room without retyping its DID or
+/// endpoint (agntcy/shadi#135). `agentbridge_list_adapters` already returns
+/// `{agent_id, tool: did, endpoint}`, so this builds the `explicit:` spec from
+/// what's in hand — no second Directory round-trip — and passes
+/// `kind: "agent"` so the invite isn't mislabelled human by the spec-prefix
+/// default.
+function AddToRoom({ adapter }: { adapter: AdapterInfo }) {
+  const { rooms, refresh } = useRooms();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  const moderated = rooms.filter((r) => r.role === "moderator");
+
+  async function add(channel: string) {
+    setBusy(true);
+    setError(null);
+    setDone(null);
+    try {
+      await invoke<SlimGroupInfo>("slim_group_invite", {
+        channel,
+        memberSpec: explicitMemberSpec(
+          adapter.agent_id,
+          adapter.tool,
+          adapter.endpoint,
+        ),
+        dirServer: null,
+        kind: "agent",
+      });
+      setDone(channel);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (moderated.length === 0) {
+    return <span className="ab-hint">no moderated room</span>;
+  }
+
+  return (
+    <>
+      <select
+        className="ab-select"
+        disabled={busy}
+        value=""
+        onChange={(e) => {
+          if (e.target.value) add(e.target.value);
+        }}
+      >
+        <option value="">{busy ? "Adding…" : "Add to…"}</option>
+        {moderated.map((r) => (
+          <option key={r.channel} value={r.channel}>
+            {r.channel}
+          </option>
+        ))}
+      </select>
+      {done && <span className="ab-ok"> ✓ {done}</span>}
+      {error && <span className="ab-error"> {error}</span>}
+    </>
+  );
 }
 
 function AdapterList() {
@@ -107,19 +174,23 @@ function AdapterList() {
               <th>Agent ID</th>
               <th>Tool / DID</th>
               <th>Endpoint</th>
+              <th>Add to room</th>
             </tr>
           </thead>
           <tbody>
             {adapters.map((a) => (
               <tr key={a.agent_id}>
                 <td>{a.agent_id}</td>
-                <td>{a.tool}</td>
+                <td className="ab-did">{a.tool}</td>
                 <td>{a.endpoint ?? "—"}</td>
+                <td>
+                  <AddToRoom adapter={a} />
+                </td>
               </tr>
             ))}
             {adapters.length === 0 && (
               <tr>
-                <td colSpan={3}>No adapters found.</td>
+                <td colSpan={4}>No adapters found.</td>
               </tr>
             )}
           </tbody>
@@ -227,6 +298,10 @@ function DelegateForm() {
   return (
     <section className="ab-card">
       <h2>Delegate</h2>
+      <p className="ab-hint ab-note">
+        Sends one prompt to one peer and shows the reply — a manual probe, not
+        the room's ongoing conversation.
+      </p>
       <textarea
         className="ab-textarea"
         placeholder="Prompt"
@@ -285,10 +360,29 @@ function CoordinateVisualizer() {
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const roundsEndRef = useRef<HTMLDivElement | null>(null);
+  const { rooms } = useRooms();
 
   useEffect(() => {
     roundsEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [rounds]);
+
+  /// Replace the free-typed specs with this room's agent members
+  /// (agntcy/shadi#135). Humans are skipped — they participate through their
+  /// own harness, not as a coordination tool endpoint.
+  function applyRoomRoster(channel: string) {
+    const room = rooms.find((r) => r.channel === channel);
+    if (!room) return;
+    const specs = room.members
+      .filter((m) => m.kind !== "human")
+      .map(slimAgentSpec);
+    if (specs.length === 0) {
+      setError(`room ${channel} has no agent members to coordinate`);
+      return;
+    }
+    setError(null);
+    setAgentSpecs(specs.join(", "));
+    setQuorum(Math.min(quorum, specs.length));
+  }
 
   async function onCoordinate() {
     setRunning(true);
@@ -333,6 +427,11 @@ function CoordinateVisualizer() {
   return (
     <section className="ab-card">
       <h2>Coordinate</h2>
+      <p className="ab-hint ab-note">
+        A manual, operator-triggered run for test-driving a set of agents. The
+        sustained exchange between room members happens over SLIM via each
+        member's own harness, continuously — not by re-clicking here.
+      </p>
       <textarea
         className="ab-textarea"
         placeholder="Goal"
@@ -346,6 +445,23 @@ function CoordinateVisualizer() {
           value={agentSpecs}
           onChange={(e) => setAgentSpecs(e.target.value)}
         />
+        {rooms.length > 0 && (
+          <select
+            className="ab-select"
+            value=""
+            onChange={(e) => {
+              if (e.target.value) applyRoomRoster(e.target.value);
+            }}
+          >
+            <option value="">Use room roster…</option>
+            {rooms.map((r) => (
+              <option key={r.channel} value={r.channel}>
+                {r.channel} ({r.members.filter((m) => m.kind !== "human").length}{" "}
+                agents)
+              </option>
+            ))}
+          </select>
+        )}
       </div>
       <div className="ab-row">
         <label>

--- a/apps/shadi_desktop/src/panels/SlimRoomsPanel.tsx
+++ b/apps/shadi_desktop/src/panels/SlimRoomsPanel.tsx
@@ -1,23 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useRooms } from "../shared/rooms";
+import type { SlimGroupInfo } from "../shared/rooms";
 import "./SlimRoomsPanel.css";
 
 interface SlimNodeStatus {
   running: boolean;
   endpoint: string | null;
-}
-
-interface SlimGroupMember {
-  name: string;
-  did: string;
-  endpoint: string | null;
-  kind: string;
-}
-
-interface SlimGroupInfo {
-  channel: string;
-  role: string;
-  members: SlimGroupMember[];
 }
 
 interface SlimConnection {
@@ -222,7 +211,7 @@ function RoomCard({ room, onChanged }: { room: SlimGroupInfo; onChanged: () => v
 }
 
 function RoomsSection() {
-  const [rooms, setRooms] = useState<SlimGroupInfo[]>([]);
+  const { rooms, error: roomsError, refresh } = useRooms();
   const [error, setError] = useState<string | null>(null);
   const [channel, setChannel] = useState("");
   const [memberSpecs, setMemberSpecs] = useState("");
@@ -230,18 +219,6 @@ function RoomsSection() {
   const [busy, setBusy] = useState(false);
   const [joinChannel, setJoinChannel] = useState("");
   const [joinTimeout, setJoinTimeout] = useState(30);
-
-  const refresh = useCallback(async () => {
-    try {
-      setRooms(await invoke<SlimGroupInfo[]>("slim_group_list"));
-    } catch (e) {
-      setError(String(e));
-    }
-  }, []);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
 
   async function onCreate() {
     setBusy(true);
@@ -341,7 +318,7 @@ function RoomsSection() {
         </button>
       </div>
 
-      <ErrorText message={error} />
+      <ErrorText message={error ?? roomsError} />
 
       {rooms.length === 0 ? (
         <p className="sl-muted">Not in any room.</p>

--- a/apps/shadi_desktop/src/shared/rooms.tsx
+++ b/apps/shadi_desktop/src/shared/rooms.tsx
@@ -1,0 +1,85 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface SlimGroupMember {
+  name: string;
+  did: string;
+  endpoint: string | null;
+  kind: string;
+}
+
+export interface SlimGroupInfo {
+  channel: string;
+  role: string;
+  members: SlimGroupMember[];
+}
+
+/// Rooms are shared across panels (agntcy/shadi#135): the agentbridge panel
+/// needs them to admit a discovered adapter into a room and to source
+/// coordination agent specs from a roster, while the SLIM panel administers
+/// them. Keeping one copy here avoids the two panels drifting out of sync
+/// after an invite or a removal.
+interface RoomsContextValue {
+  rooms: SlimGroupInfo[];
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const RoomsContext = createContext<RoomsContextValue | null>(null);
+
+export function RoomsProvider({ children }: { children: ReactNode }) {
+  const [rooms, setRooms] = useState<SlimGroupInfo[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setRooms(await invoke<SlimGroupInfo[]>("slim_group_list"));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const value = useMemo(
+    () => ({ rooms, error, refresh }),
+    [rooms, error, refresh],
+  );
+  return <RoomsContext.Provider value={value}>{children}</RoomsContext.Provider>;
+}
+
+export function useRooms(): RoomsContextValue {
+  const ctx = useContext(RoomsContext);
+  if (!ctx) throw new Error("useRooms must be used inside a RoomsProvider");
+  return ctx;
+}
+
+/// The `explicit:<name>=<did>[@<endpoint>]` spec that admits an
+/// already-resolved candidate without a second Directory round-trip. Mirrors
+/// `explicit_member_spec` in `commands/slim.rs`.
+export function explicitMemberSpec(
+  name: string,
+  did: string,
+  endpoint: string | null,
+): string {
+  return endpoint ? `explicit:${name}=${did}@${endpoint}` : `explicit:${name}=${did}`;
+}
+
+/// The `slim:<agent-id>[@host:port]` spec `agentbridge coordinate` expects for
+/// a remote member, derived from a room roster entry.
+export function slimAgentSpec(member: SlimGroupMember): string {
+  return member.endpoint
+    ? `slim:${member.name}@${member.endpoint}`
+    : `slim:${member.name}`;
+}

--- a/apps/shadi_desktop/src/shared/rooms.tsx
+++ b/apps/shadi_desktop/src/shared/rooms.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import type { ReactNode } from "react";
@@ -22,11 +23,13 @@ export interface SlimGroupInfo {
   members: SlimGroupMember[];
 }
 
-/// Rooms are shared across panels (agntcy/shadi#135): the agentbridge panel
-/// needs them to admit a discovered adapter into a room and to source
-/// coordination agent specs from a roster, while the SLIM panel administers
-/// them. Keeping one copy here avoids the two panels drifting out of sync
-/// after an invite or a removal.
+/**
+ * Rooms are shared across panels (agntcy/shadi#135): the agentbridge panel
+ * needs them to admit a discovered adapter into a room and to source
+ * coordination agent specs from a roster, while the SLIM panel administers
+ * them. Keeping one copy here avoids the two panels drifting out of sync
+ * after an invite or a removal.
+ */
 interface RoomsContextValue {
   rooms: SlimGroupInfo[];
   error: string | null;
@@ -38,12 +41,22 @@ const RoomsContext = createContext<RoomsContextValue | null>(null);
 export function RoomsProvider({ children }: { children: ReactNode }) {
   const [rooms, setRooms] = useState<SlimGroupInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Refreshes are fired from several places at once — the mount effect, and
+  // each invite/create/join/remove. Adding two adapters in quick succession
+  // starts two overlapping `slim_group_list` calls, so responses have to be
+  // ordered: an older one landing last would drop a just-admitted room from
+  // both panels until something refreshed again.
+  const latestRefresh = useRef(0);
 
   const refresh = useCallback(async () => {
+    const version = ++latestRefresh.current;
     try {
-      setRooms(await invoke<SlimGroupInfo[]>("slim_group_list"));
+      const next = await invoke<SlimGroupInfo[]>("slim_group_list");
+      if (version !== latestRefresh.current) return;
+      setRooms(next);
       setError(null);
     } catch (e) {
+      if (version !== latestRefresh.current) return;
       setError(String(e));
     }
   }, []);
@@ -65,9 +78,14 @@ export function useRooms(): RoomsContextValue {
   return ctx;
 }
 
-/// The `explicit:<name>=<did>[@<endpoint>]` spec that admits an
-/// already-resolved candidate without a second Directory round-trip. Mirrors
-/// `explicit_member_spec` in `commands/slim.rs`.
+/**
+ * The `explicit:<name>=<did>[@<endpoint>]` spec that admits an
+ * already-resolved candidate without a second Directory round-trip.
+ *
+ * This is the only place the format is built; the Rust side just consumes it.
+ * `frontend_explicit_spec_format_resolves_without_a_directory` in
+ * `commands/slim.rs` pins the exact shape — update it alongside this.
+ */
 export function explicitMemberSpec(
   name: string,
   did: string,
@@ -76,8 +94,10 @@ export function explicitMemberSpec(
   return endpoint ? `explicit:${name}=${did}@${endpoint}` : `explicit:${name}=${did}`;
 }
 
-/// The `slim:<agent-id>[@host:port]` spec `agentbridge coordinate` expects for
-/// a remote member, derived from a room roster entry.
+/**
+ * The `slim:<agent-id>[@host:port]` spec `agentbridge coordinate` expects for
+ * a remote member, derived from a room roster entry.
+ */
 export function slimAgentSpec(member: SlimGroupMember): string {
   return member.endpoint
     ? `slim:${member.name}@${member.endpoint}`


### PR DESCRIPTION
Closes #135.

Discovered adapters can be admitted into a moderated room in one click, and `coordinate`'s agent specs can be sourced from a room's roster instead of retyped. Rooms move into a shared provider so an invite in one tab shows up in the other.

Two fixes this surfaced in #118's own code:
- **`slim_group_invite` gains an explicit `kind`.** Admitting a discovered agent uses an `explicit:` spec (its DID is already known, so no second Directory round-trip) — but that prefix defaulted to `human`, which would have mislabelled every agent this feature admits.
- **`explicit:` no longer requires a Directory server.** It carries its own name/DID/endpoint and resolves locally; requiring a server blocked admitting an already-discovered candidate.

Delegate and coordinate now say in the UI that they're manual probes — the room's sustained exchange runs over SLIM via each member's harness, per #112's admin-surface-not-message-relay split.

## Test plan
- [x] `cargo clippy --all-targets` clean; 7 unit tests pass, including one guarding the `explicit:` wire format the frontend emits (resolves with DID + endpoint intact, and omits the endpoint cleanly when unknown)
- [x] `pnpm build` clean; verified in browser — both tabs render, notes present, roster picker correctly hidden when there are no rooms
- [ ] End-to-end: needs a real SLIM node + DIR server, so the data-dependent paths (add-to-room, roster→specs) are unverified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared room state across desktop panels, preserving room data when switching tabs.
  - Enabled adding discovered agents directly to moderated rooms.
  - Added room-roster selection for coordinating with available agents.
  - Added optional member types and improved support for explicit, DID, and endpoint-based invitations.

- **Bug Fixes**
  - Improved room loading, refreshing, and error display across panels.
  - Clarified agent delegation and coordination behavior with helpful interface guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->