### PR TITLE
feat(desktop): persist known rooms, and fix the runtime panic that made the panel non-functional

### DIFF
--- a/apps/shadi_desktop/docs/ipc-contract.md
+++ b/apps/shadi_desktop/docs/ipc-contract.md
@@ -8,9 +8,11 @@ without churn: the request/response shapes below should not need to change
 when a panel replaces its module's stubs with real calls into the
 corresponding SHADI crate.
 
-**Scope**: signatures and types only. Every command in `src-tauri/src/commands/`
-currently returns `not_implemented(<panel-issue>)` — see that module's own
-doc comment. Implementing them is each panel issue's job, not this one's.
+**Scope**: signatures and types. Implementing them is each panel issue's job,
+not this one's — `agentbridge.rs` (#120) and `slim.rs` (#118) are real; the
+remaining modules still return `not_implemented(<panel-issue>)`. Where a panel's
+implementation had to extend its own signatures, this document follows it rather
+than the other way round.
 
 ## Conventions
 
@@ -50,6 +52,22 @@ doc comment. Implementing them is each panel issue's job, not this one's.
   and the command's return value is only the final result. The frontend must
   call `listen("coordinate:round", ...)` *before* invoking the command, or it
   will miss early rounds.
+- **Some commands are stateful, and that state is the panel's own.** `slim.rs`
+  is the one module backed by Tauri managed state (`SlimState`), because a SLIM
+  node and its group sessions outlive a single command. It deliberately does
+  *not* mirror `shadictl shell`'s single-active-session model: the shell deletes
+  the previous group when you create or join another, which makes a rooms
+  overview impossible. So `slim_group_list`/`slim_group_roster`/
+  `slim_group_remove_member`/`slim_group_forget` have no CLI equivalent to
+  mirror — the first two read that state, and the last two mutate it.
+- **Known rooms outlive the process; their sessions do not.** Room metadata
+  (channel, role, roster) is persisted, so `slim_group_list` returns rooms from
+  earlier launches with `connected: false`. A disconnected room's roster is
+  readable, but `slim_group_invite`/`slim_group_remove_member` require a live
+  session and fail with a rejoin hint — panels should gate those controls on
+  `connected` rather than only on `role`. Sessions and credentials are never
+  written to disk; a `did:key` is a public key, so the stored roster holds no
+  secrets. See agntcy/shadi#138.
 - **Tagged unions over mutually-exclusive optional fields.** The CLI models
   "secret ref xor file path" as two `Option<T>` args with `conflicts_with`/
   `required_unless_present` clap attributes — that's a clap ergonomics
@@ -64,7 +82,7 @@ doc comment. Implementing them is each panel issue's job, not this one's.
 | `sandbox.rs` | `sandbox_launch`, `sandbox_list_sessions`, `sandbox_attach`, `sandbox_detach`, `sandbox_kill`, `sandbox_status` | `shadictl <flags> -- <cmd>`, shell `/sessions` `/attach` `/detach` `/kill` `/status` |
 | `policy.rs` | `policy_query`, `policy_patch`, `policy_explain`, `policy_diff`, `policy_profiles` | shell `/policy query\|patch\|explain\|diff`, `--profile` |
 | `identity.rs` | `identity_did_from_gpg`, `identity_did_from_github`, `identity_derive_agent`, `identity_verify_agent`, `secret_get`, `secret_put_key`, `secret_list_keychain`, `secret_backend_status` | `shadictl did-from-gpg\|did-from-github\|derive-agent-identity\|verify-agent-identity\|get-secret\|put-key`, `--list-keychain` |
-| `slim.rs` | `slim_node_start`, `slim_node_status`, `slim_group_create`, `slim_group_invite`, `slim_group_join`, `slim_controller_list_connections`, `slim_controller_list_routes` | shell `/slim start-node\|create-group\|invite\|join\|controller` |
+| `slim.rs` | `slim_node_start`, `slim_node_status`, `slim_group_create`, `slim_group_invite`, `slim_group_join`, `slim_group_list`, `slim_group_roster`, `slim_group_remove_member`, `slim_group_forget`, `slim_controller_list_connections`, `slim_controller_list_routes` | shell `/slim start-node\|create-group\|invite\|join\|controller`; the room-list/roster/remove/forget commands have no CLI equivalent (see below) |
 | `dir.rs` | `dir_search`, `dir_pull`, `dir_info`, `dir_register` | `shadictl dir search\|pull\|info`, `agentbridge register --dir-publish` |
 | `agentbridge.rs` | `agentbridge_list_adapters`, `agentbridge_handoff`, `agentbridge_delegate`, `agentbridge_coordinate` | `agentbridge list\|handoff\|delegate\|coordinate` |
 | `trace_memory.rs` | `trace_list`, `trace_summary`, `memory_get`, `memory_search`, `memory_list` | `shadictl trace list\|summary`, `shadictl memory get\|search\|list` |

--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -990,9 +990,16 @@ fn resolve_client_tls_material() -> Result<TlsMaterial, String> {
                         .map(|(c, k)| format!("{} + {}", c.display(), k.display()))
                         .collect::<Vec<_>>()
                         .join(", ");
+                    let set_hint = if std::env::var_os("SHADI_TMP_DIR").is_some() {
+                        ""
+                    } else {
+                        " SHADI_TMP_DIR is not set, so these are the default locations."
+                    };
                     format!(
-                        "no SLIM client certificate found; checked {checked}. Set SHADI_AGENT_ID \
-                         or SLIM_TLS_CERT/SLIM_TLS_KEY explicitly"
+                        "no SLIM client certificate found; checked {checked}.{set_hint} Set \
+                         SHADI_TMP_DIR (and SHADI_AGENT_ID), or SLIM_TLS_CERT/SLIM_TLS_KEY \
+                         explicitly, and generate the material with: bash \
+                         tools/generate_slim_mtls_certs.sh \"$SHADI_TMP_DIR/shadi-slim-mtls\""
                     )
                 })?
         }
@@ -1063,18 +1070,48 @@ fn parse_name(raw: &str) -> Result<Name, String> {
     })
 }
 
+/// Directory holding the SLIM mTLS material, always absolute.
+///
+/// A GUI app has no meaningful working directory — launched from Finder or the
+/// Dock it is `/` — so a relative fallback would report a path that means
+/// nothing to the user. Anything relative is resolved against the current
+/// directory here so errors name a real location.
 fn slim_tls_dir() -> PathBuf {
-    std::env::var_os("SHADI_TMP_DIR")
+    let base = std::env::var_os("SHADI_TMP_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(".tmp"))
-        .join("shadi-slim-mtls")
+        .unwrap_or_else(|| PathBuf::from(".tmp"));
+    let base = if base.is_absolute() {
+        base
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&base))
+            .unwrap_or(base)
+    };
+    base.join("shadi-slim-mtls")
+}
+
+/// Missing mTLS material is the first thing a new user hits, and the cause is
+/// almost always an unset `SHADI_TMP_DIR` rather than a genuinely absent file —
+/// so say both, and say how to produce it.
+fn tls_material_error(label: &str, path: &Path) -> String {
+    let set_hint = if std::env::var_os("SHADI_TMP_DIR").is_some() {
+        String::new()
+    } else {
+        " SHADI_TMP_DIR is not set, so this is the default location.".to_string()
+    };
+    format!(
+        "{label} not found at {}.{set_hint} Point SHADI_TMP_DIR at the directory \
+         holding shadi-slim-mtls/, and generate the material with: \
+         bash tools/generate_slim_mtls_certs.sh \"$SHADI_TMP_DIR/shadi-slim-mtls\"",
+        path.display()
+    )
 }
 
 fn ensure_file_exists(path: &Path, label: &str) -> Result<(), String> {
     if path.is_file() {
         Ok(())
     } else {
-        Err(format!("{label} not found at {}", path.display()))
+        Err(tls_material_error(label, path))
     }
 }
 
@@ -1354,6 +1391,37 @@ mod tests {
         }
 
         let _ = std::fs::remove_file(&store);
+    }
+
+    /// A GUI app's working directory is not the repo — launched from Finder it
+    /// is `/` — so a relative `.tmp` fallback reported a path the user could
+    /// not act on ("not found at .tmp/shadi-slim-mtls/server.crt").
+    #[test]
+    fn tls_dir_is_always_absolute() {
+        let dir = slim_tls_dir();
+        assert!(
+            dir.is_absolute(),
+            "tls dir must be absolute so errors name a real location, got {}",
+            dir.display()
+        );
+        assert!(dir.ends_with("shadi-slim-mtls"));
+    }
+
+    /// The usual cause of missing material is an unset `SHADI_TMP_DIR`, not a
+    /// genuinely absent file, so the error has to name it and say how to
+    /// generate the certs.
+    #[test]
+    fn missing_tls_material_error_is_actionable() {
+        let err = tls_material_error(
+            "SLIM server certificate",
+            Path::new("/somewhere/shadi-slim-mtls/server.crt"),
+        );
+        assert!(err.contains("/somewhere/shadi-slim-mtls/server.crt"));
+        assert!(err.contains("SHADI_TMP_DIR"), "must name the env var: {err}");
+        assert!(
+            err.contains("generate_slim_mtls_certs.sh"),
+            "must say how to generate the material: {err}"
+        );
     }
 
     #[test]

--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -136,8 +136,38 @@ struct Inner {
 
 /// Registered with `.manage(...)` in `lib.rs`; the SLIM node/session lifecycle
 /// spans commands, so unlike the other panels this one cannot be stateless.
+///
+/// The state is behind an `Arc` so [`with_state`] can move a handle onto a
+/// blocking thread — see that function for why every command must.
 #[derive(Default)]
-pub struct SlimState(Mutex<Inner>);
+pub struct SlimState(Arc<Mutex<Inner>>);
+
+/// Run `f` against the SLIM state on a blocking thread.
+///
+/// Every blocking `slim_bindings` entry point this module uses — `run_server`,
+/// `connect`, `create_session_and_wait`, `subscribe`, `set_route`,
+/// `listen_for_session`, `invite_and_wait`, `remove_and_wait`,
+/// `participants_list`, `delete_session_and_wait` — is a
+/// `get_runtime().block_on(..)` wrapper. Calling one directly from an
+/// `async` command runs it on a Tauri async worker and panics with "Cannot
+/// start a runtime from within a runtime", killing the command. So the work
+/// has to leave the async runtime first; `spawn_blocking` is what does that.
+///
+/// The lock is held for the whole closure, which serializes room operations.
+/// That is intended: they mutate one shared node/app/session graph.
+async fn with_state<T, F>(state: &tauri::State<'_, SlimState>, f: F) -> Result<T, String>
+where
+    F: FnOnce(&mut Inner) -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    let state = state.0.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut inner = state.lock().map_err(|_| "SLIM state poisoned".to_string())?;
+        f(&mut inner)
+    })
+    .await
+    .map_err(|e| format!("task failed: {e}"))?
+}
 
 impl SlimState {
     /// Point the state at its on-disk room store and load whatever is already
@@ -334,32 +364,32 @@ impl Inner {
 /// Start a local native SLIM node with SHADI mTLS defaults (`/slim start-node`).
 #[tauri::command]
 pub async fn slim_node_start(state: tauri::State<'_, SlimState>) -> Result<SlimNodeStatus, String> {
-    let mut inner = lock(&state)?;
-    if inner.node_started {
-        return Ok(SlimNodeStatus {
+    with_state(&state, |inner| {
+        if !inner.node_started {
+            let config = build_server_config()?;
+            inner
+                .node_service_mut()
+                .run_server(config)
+                .map_err(slim_err)?;
+            inner.node_started = true;
+        }
+        Ok(SlimNodeStatus {
             running: true,
             endpoint: Some(resolve_endpoint()),
-        });
-    }
-    let config = build_server_config()?;
-    inner
-        .node_service_mut()
-        .run_server(config)
-        .map_err(slim_err)?;
-    inner.node_started = true;
-    Ok(SlimNodeStatus {
-        running: true,
-        endpoint: Some(resolve_endpoint()),
+        })
     })
+    .await
 }
 
 #[tauri::command]
 pub async fn slim_node_status(state: tauri::State<'_, SlimState>) -> Result<SlimNodeStatus, String> {
-    let inner = lock(&state)?;
-    Ok(SlimNodeStatus {
-        running: inner.node_started,
-        endpoint: Some(resolve_endpoint()),
+    with_state(&state, |inner| {
+        Ok(SlimNodeStatus {
+            running: inner.node_started,
+            endpoint: Some(resolve_endpoint()),
+        })
     })
+    .await
 }
 
 // --- Rooms -------------------------------------------------------------------
@@ -377,29 +407,33 @@ pub async fn slim_group_create(
     member_specs: Vec<String>,
     dir_server: String,
 ) -> Result<SlimGroupInfo, String> {
-    let candidates = resolve_candidates(&member_specs, &dir_server)?;
-    admit_dids_to_trust_set(candidates.iter().map(|(m, _)| m.did.as_str()));
+    with_state(&state, move |inner| {
+        // Directory resolution shells out to `dirctl`, so it belongs on the
+        // blocking thread too.
+        let candidates = resolve_candidates(&member_specs, &dir_server)?;
+        admit_dids_to_trust_set(candidates.iter().map(|(m, _)| m.did.as_str()));
 
-    let mut inner = lock(&state)?;
-    let channel_name = Arc::new(parse_name(&channel)?);
-    let app = inner.ensure_app()?;
-    let session = app
-        .create_session_and_wait(group_session_config(), channel_name.clone())
-        .map_err(slim_err)?;
+        let channel_name = Arc::new(parse_name(&channel)?);
+        let app = inner.ensure_app()?;
+        let session = app
+            .create_session_and_wait(group_session_config(), channel_name.clone())
+            .map_err(slim_err)?;
 
-    inner.rooms.insert(
-        channel_name.to_string(),
-        Room {
-            session: Some(session),
-            moderator: true,
-            admitted: candidates
-                .into_iter()
-                .map(|(member, _)| (member.name.clone(), member))
-                .collect(),
-        },
-    );
-    inner.persist()?;
-    inner.group_info(&channel_name.to_string())
+        inner.rooms.insert(
+            channel_name.to_string(),
+            Room {
+                session: Some(session),
+                moderator: true,
+                admitted: candidates
+                    .into_iter()
+                    .map(|(member, _)| (member.name.clone(), member))
+                    .collect(),
+            },
+        );
+        inner.persist()?;
+        inner.group_info(&channel_name.to_string())
+    })
+    .await
 }
 
 /// Invite a member into a room (`/slim invite`, `/slim invite-from`).
@@ -419,63 +453,69 @@ pub async fn slim_group_invite(
     dir_server: Option<String>,
     kind: Option<String>,
 ) -> Result<SlimGroupInfo, String> {
-    let mut resolved = if is_member_spec(&member_spec) {
-        // Only Directory-backed specs need a server; `explicit:` carries its
-        // own DID and resolves locally.
-        let dir_server = if spec_needs_directory(&member_spec) {
-            dir_server.ok_or_else(|| {
-                format!("member spec '{member_spec}' needs a Directory server to resolve against")
-            })?
+    with_state(&state, move |inner| {
+        let mut resolved = if is_member_spec(&member_spec) {
+            // Only Directory-backed specs need a server; `explicit:` carries its
+            // own DID and resolves locally.
+            let dir_server = if spec_needs_directory(&member_spec) {
+                dir_server.ok_or_else(|| {
+                    format!(
+                        "member spec '{member_spec}' needs a Directory server to resolve against"
+                    )
+                })?
+            } else {
+                dir_server.unwrap_or_default()
+            };
+            resolve_candidates(std::slice::from_ref(&member_spec), &dir_server)?
         } else {
-            dir_server.unwrap_or_default()
+            vec![(
+                SlimGroupMember {
+                    name: member_spec.clone(),
+                    did: String::new(),
+                    endpoint: None,
+                    kind: "human".to_string(),
+                },
+                None,
+            )]
         };
-        resolve_candidates(std::slice::from_ref(&member_spec), &dir_server)?
-    } else {
-        vec![(
-            SlimGroupMember {
-                name: member_spec.clone(),
-                did: String::new(),
-                endpoint: None,
-                kind: "human".to_string(),
-            },
-            None,
-        )]
-    };
-    if resolved.is_empty() {
-        return Err(format!("member spec '{member_spec}' resolved to no candidates"));
-    }
-    if let Some(kind) = kind {
-        for (member, _) in &mut resolved {
-            member.kind = kind.clone();
+        if resolved.is_empty() {
+            return Err(format!(
+                "member spec '{member_spec}' resolved to no candidates"
+            ));
         }
-    }
-    admit_dids_to_trust_set(
-        resolved
-            .iter()
-            .map(|(m, _)| m.did.as_str())
-            .filter(|d| !d.is_empty()),
-    );
+        if let Some(kind) = kind {
+            for (member, _) in &mut resolved {
+                member.kind = kind.clone();
+            }
+        }
+        admit_dids_to_trust_set(
+            resolved
+                .iter()
+                .map(|(m, _)| m.did.as_str())
+                .filter(|d| !d.is_empty()),
+        );
 
-    let mut inner = lock(&state)?;
-    let connection_id = inner.ensure_connection()?;
-    let app = inner.ensure_app()?;
-    let session = inner.live_session(&channel)?;
+        let connection_id = inner.ensure_connection()?;
+        let app = inner.ensure_app()?;
+        let session = inner.live_session(&channel)?;
 
-    for (member, _) in &resolved {
-        let name = Arc::new(parse_name(&member.name)?);
-        app.set_route(name.clone(), connection_id).map_err(slim_err)?;
-        session.invite_and_wait(name).map_err(slim_err)?;
-    }
+        for (member, _) in &resolved {
+            let name = Arc::new(parse_name(&member.name)?);
+            app.set_route(name.clone(), connection_id).map_err(slim_err)?;
+            session.invite_and_wait(name).map_err(slim_err)?;
+        }
 
-    let room = inner
-        .rooms
-        .get_mut(&channel)
-        .ok_or_else(|| format!("no room '{channel}'"))?;
-    for (member, _) in resolved {
-        room.admitted.insert(member.name.clone(), member);
-    }
-    inner.persist()?;
-    inner.group_info(&channel)
+        let room = inner
+            .rooms
+            .get_mut(&channel)
+            .ok_or_else(|| format!("no room '{channel}'"))?;
+        for (member, _) in resolved {
+            room.admitted.insert(member.name.clone(), member);
+        }
+        inner.persist()?;
+        inner.group_info(&channel)
+    })
+    .await
 }
 
 /// Join a room created by a moderator (`/slim join`), or rejoin a known one.
@@ -489,7 +529,7 @@ pub async fn slim_group_join(
     channel: String,
     timeout_secs: Option<u64>,
 ) -> Result<SlimGroupInfo, String> {
-    let mut inner = lock(&state)?;
+    with_state(&state, move |inner| {
     let expected = parse_name(&channel)?;
     inner.ensure_channel_subscription(&channel)?;
     let connection_id = inner.ensure_connection()?;
@@ -526,6 +566,8 @@ pub async fn slim_group_join(
     }
     inner.persist()?;
     inner.group_info(&actual)
+    })
+    .await
 }
 
 /// Every known room, moderator or participant, connected or not — rooms
@@ -537,13 +579,15 @@ pub async fn slim_group_join(
 pub async fn slim_group_list(
     state: tauri::State<'_, SlimState>,
 ) -> Result<Vec<SlimGroupInfo>, String> {
-    let inner = lock(&state)?;
-    let mut channels: Vec<&String> = inner.rooms.keys().collect();
-    channels.sort();
-    channels
-        .into_iter()
-        .map(|channel| inner.group_info(channel))
-        .collect()
+    with_state(&state, |inner| {
+        let mut channels: Vec<&String> = inner.rooms.keys().collect();
+        channels.sort();
+        channels
+            .into_iter()
+            .map(|channel| inner.group_info(channel))
+            .collect()
+    })
+    .await
 }
 
 /// Re-read a room's membership roster on demand.
@@ -552,7 +596,7 @@ pub async fn slim_group_roster(
     state: tauri::State<'_, SlimState>,
     channel: String,
 ) -> Result<Vec<SlimGroupMember>, String> {
-    lock(&state)?.roster(&channel)
+    with_state(&state, move |inner| inner.roster(&channel)).await
 }
 
 /// Remove a member from a room. Moderator-only.
@@ -562,7 +606,7 @@ pub async fn slim_group_remove_member(
     channel: String,
     member_name: String,
 ) -> Result<SlimGroupInfo, String> {
-    let mut inner = lock(&state)?;
+    with_state(&state, move |inner| {
     if !inner.room(&channel)?.moderator {
         return Err(format!(
             "only the moderator of '{channel}' can remove members"
@@ -578,6 +622,8 @@ pub async fn slim_group_remove_member(
     }
     inner.persist()?;
     inner.group_info(&channel)
+    })
+    .await
 }
 
 /// Drop a room from the known list, tearing down its session if connected.
@@ -589,26 +635,28 @@ pub async fn slim_group_forget(
     state: tauri::State<'_, SlimState>,
     channel: String,
 ) -> Result<Vec<SlimGroupInfo>, String> {
-    let mut inner = lock(&state)?;
-    let room = inner
-        .rooms
-        .remove(&channel)
-        .ok_or_else(|| format!("no room '{channel}'"))?;
+    with_state(&state, move |inner| {
+        let room = inner
+            .rooms
+            .remove(&channel)
+            .ok_or_else(|| format!("no room '{channel}'"))?;
 
-    // Best-effort teardown: the room is already gone from the list, so a
-    // failure here must not resurrect it or fail the call.
-    if let (Some(session), Some(app)) = (room.session, inner.app.clone()) {
-        let _ = app.delete_session_and_wait(session);
-    }
-    inner.subscribed_channels.retain(|c| c != &channel);
+        // Best-effort teardown: the room is already gone from the list, so a
+        // failure here must not resurrect it or fail the call.
+        if let (Some(session), Some(app)) = (room.session, inner.app.clone()) {
+            let _ = app.delete_session_and_wait(session);
+        }
+        inner.subscribed_channels.retain(|c| c != &channel);
 
-    inner.persist()?;
-    let mut channels: Vec<String> = inner.rooms.keys().cloned().collect();
-    channels.sort();
-    channels
-        .iter()
-        .map(|channel| inner.group_info(channel))
-        .collect()
+        inner.persist()?;
+        let mut channels: Vec<String> = inner.rooms.keys().cloned().collect();
+        channels.sort();
+        channels
+            .iter()
+            .map(|channel| inner.group_info(channel))
+            .collect()
+    })
+    .await
 }
 
 // --- Controller --------------------------------------------------------------
@@ -970,10 +1018,6 @@ fn client_identity_candidates(dir: &Path, agent_id: Option<&str>) -> Vec<(PathBu
 
 // --- Small helpers -----------------------------------------------------------
 
-fn lock<'a>(state: &'a tauri::State<'_, SlimState>) -> Result<std::sync::MutexGuard<'a, Inner>, String> {
-    state.0.lock().map_err(|_| "SLIM state poisoned".to_string())
-}
-
 fn slim_err(err: slim_bindings::SlimError) -> String {
     err.to_string()
 }
@@ -1171,6 +1215,145 @@ mod tests {
         let _ = std::fs::remove_file(&missing);
         assert!(state.init_store(missing).is_ok());
         assert!(state.0.lock().unwrap_or_else(|e| e.into_inner()).rooms.is_empty());
+    }
+
+    /// Pins the invariant that makes this whole module work.
+    ///
+    /// Every blocking `slim_bindings` call is `get_runtime().block_on(..)`.
+    /// Invoked straight from an `async` command it lands on a Tauri async
+    /// worker and panics — "Cannot start a runtime from within a runtime" —
+    /// which made the panel compile, pass its tests, and then die on the first
+    /// real SLIM call. `with_state` exists to move that work off the runtime.
+    ///
+    /// Needs no node: connecting nowhere must come back as `Err`, and the point
+    /// is that it comes back at all instead of unwinding.
+    #[test]
+    fn blocking_slim_calls_survive_inside_an_async_runtime() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        rt.block_on(async {
+            let outcome = tokio::task::spawn_blocking(|| {
+                let service = Service::new("shadi-desktop-runtime-invariant".to_string());
+                service.connect(ClientConfig::default()).is_err()
+            })
+            .await;
+
+            match outcome {
+                Ok(errored) => assert!(errored, "connecting to nowhere should return Err"),
+                Err(join) if join.is_panic() => panic!(
+                    "blocking SLIM call panicked inside the async runtime — the \
+                     spawn_blocking hop in with_state is missing or ineffective"
+                ),
+                Err(join) => panic!("blocking task failed: {join}"),
+            }
+        });
+    }
+
+    /// Live end-to-end coverage of the room admin surface against a real SLIM
+    /// node with real DID auth — create a room as moderator, invite two waiting
+    /// agents, read the roster, then reload the store as a restart would.
+    ///
+    /// Ignored by default: needs a running node, mTLS material and the DID env
+    /// contract, so CI skips it. `docs/content/demos/desktop-room-e2e.sh` sets
+    /// all of that up and runs it.
+    ///
+    /// This is the coverage whose absence let the runtime panic ship: the panel
+    /// compiled with a green suite and still died on its first real SLIM call.
+    #[test]
+    #[ignore = "needs a live SLIM node; run docs/content/demos/desktop-room-e2e.sh"]
+    fn live_moderator_creates_room_invites_two_agents_and_sees_the_roster() {
+        let channel = std::env::var("SHADI_E2E_ROOM").expect("SHADI_E2E_ROOM");
+        let members: Vec<String> = std::env::var("SHADI_E2E_MEMBERS")
+            .expect("SHADI_E2E_MEMBERS")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(members.len(), 2, "expects exactly two agents");
+
+        let store = std::env::temp_dir().join("shadi-desktop-e2e-rooms.json");
+        let _ = std::fs::remove_file(&store);
+
+        let state = SlimState::default();
+        {
+            let mut inner = state.0.lock().unwrap_or_else(|e| e.into_inner());
+            inner.store_path = Some(store.clone());
+
+            // slim_group_create's core: DID connect, build app, open the group.
+            let channel_name = Arc::new(parse_name(&channel).expect("channel name"));
+            let app = inner.ensure_app().expect("ensure_app: DID auth + connect");
+            let session = app
+                .create_session_and_wait(group_session_config(), channel_name.clone())
+                .expect("create group session");
+            inner.rooms.insert(
+                channel_name.to_string(),
+                Room {
+                    session: Some(session),
+                    moderator: true,
+                    admitted: HashMap::new(),
+                },
+            );
+            inner.persist().expect("persist after create");
+
+            let info = inner.group_info(&channel).expect("group info");
+            assert_eq!(info.role, "moderator");
+            assert!(info.connected, "a freshly created room is connected");
+
+            // Participants can only be invited once they're already listening;
+            // the harness starts them right after this test creates the room.
+            std::thread::sleep(Duration::from_secs(12));
+
+            // slim_group_invite's core.
+            let connection_id = inner.ensure_connection().expect("connection");
+            for member in &members {
+                let name = Arc::new(parse_name(member).expect("member name"));
+                let session = inner.live_session(&channel).expect("live session");
+                app.set_route(name.clone(), connection_id).expect("set route");
+                session
+                    .invite_and_wait(name)
+                    .unwrap_or_else(|e| panic!("invite {member} failed: {e}"));
+                inner.rooms.get_mut(&channel).unwrap().admitted.insert(
+                    member.clone(),
+                    SlimGroupMember {
+                        name: member.clone(),
+                        did: String::new(),
+                        endpoint: None,
+                        kind: "agent".to_string(),
+                    },
+                );
+            }
+            inner.persist().expect("persist after invites");
+
+            // Roster reads the live session's participants_list.
+            let roster = inner.roster(&channel).expect("roster");
+            let names: Vec<&str> = roster.iter().map(|m| m.name.as_str()).collect();
+            for member in &members {
+                assert!(
+                    names.iter().any(|n| n == member),
+                    "{member} missing from live roster {names:?}"
+                );
+            }
+        }
+
+        // Reload as a restart would (#138): known, not connected, roster intact.
+        let restarted = SlimState::default();
+        restarted.init_store(store.clone()).expect("reload store");
+        let inner = restarted.0.lock().unwrap_or_else(|e| e.into_inner());
+        let restored = inner.group_info(&channel).expect("restored room");
+        assert!(!restored.connected, "a restored room has no live session");
+        assert_eq!(restored.role, "moderator");
+        let restored_names: Vec<&str> = restored.members.iter().map(|m| m.name.as_str()).collect();
+        for member in &members {
+            assert!(
+                restored_names.iter().any(|n| n == member),
+                "{member} did not survive the restart: {restored_names:?}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&store);
     }
 
     #[test]

--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -75,6 +75,10 @@ pub struct SlimGroupInfo {
     pub channel: String,
     /// "moderator" | "participant".
     pub role: String,
+    /// Whether a live SLIM session backs this room right now. A known room
+    /// restored from disk is `false` until rejoined: its roster is readable,
+    /// but it cannot be invited into or removed from.
+    pub connected: bool,
     pub members: Vec<SlimGroupMember>,
 }
 
@@ -93,12 +97,26 @@ pub struct SlimRoute {
 // --- Managed state -----------------------------------------------------------
 
 struct Room {
-    session: Arc<Session>,
+    /// `None` for a room that is *known* but not currently *connected* — it was
+    /// restored from disk, or its session hasn't been re-established since
+    /// launch. Invites and removals need a live session; the roster does not.
+    session: Option<Arc<Session>>,
     moderator: bool,
     /// Members this process admitted, keyed by SLIM name. `participants_list`
     /// reports names only, so DID/endpoint/kind are carried here from
-    /// admission-time resolution.
+    /// admission-time resolution — and are what a disconnected room shows.
     admitted: HashMap<String, SlimGroupMember>,
+}
+
+/// The on-disk form of a [`Room`] (agntcy/shadi#138). Only metadata: sessions
+/// and credentials are never written, and a `did:key` is a public key, so
+/// nothing here is secret.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedRoom {
+    channel: String,
+    moderator: bool,
+    #[serde(default)]
+    members: Vec<SlimGroupMember>,
 }
 
 #[derive(Default)]
@@ -111,12 +129,48 @@ struct Inner {
     node_started: bool,
     rooms: HashMap<String, Room>,
     subscribed_channels: Vec<String>,
+    /// Where known rooms are persisted. `None` until `lib.rs`'s setup hook
+    /// resolves the app data dir, which also makes this harmless in tests.
+    store_path: Option<PathBuf>,
 }
 
 /// Registered with `.manage(...)` in `lib.rs`; the SLIM node/session lifecycle
 /// spans commands, so unlike the other panels this one cannot be stateless.
 #[derive(Default)]
 pub struct SlimState(Mutex<Inner>);
+
+impl SlimState {
+    /// Point the state at its on-disk room store and load whatever is already
+    /// there. Called once from `lib.rs`'s setup hook, where the app data dir is
+    /// first available. A load failure is reported but not fatal — a corrupt or
+    /// unreadable store must not stop the app from starting.
+    pub fn init_store(&self, path: PathBuf) -> Result<(), String> {
+        let mut inner = self.0.lock().map_err(|_| "SLIM state poisoned")?;
+        inner.store_path = Some(path.clone());
+        if !path.is_file() {
+            return Ok(());
+        }
+        let data = std::fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        let stored: Vec<PersistedRoom> = serde_json::from_str(&data)
+            .map_err(|e| format!("invalid room store {}: {e}", path.display()))?;
+        for room in stored {
+            inner.rooms.insert(
+                room.channel,
+                Room {
+                    session: None,
+                    moderator: room.moderator,
+                    admitted: room
+                        .members
+                        .into_iter()
+                        .map(|m| (m.name.clone(), m))
+                        .collect(),
+                },
+            );
+        }
+        Ok(())
+    }
+}
 
 impl Inner {
     fn ensure_connection(&mut self) -> Result<u64, String> {
@@ -181,7 +235,47 @@ impl Inner {
     fn room(&self, channel: &str) -> Result<&Room, String> {
         self.rooms
             .get(channel)
-            .ok_or_else(|| format!("not in room '{channel}'; create or join it first"))
+            .ok_or_else(|| format!("no room '{channel}'; create or join it first"))
+    }
+
+    /// The live session for a room, or an error naming what to do about it —
+    /// a known-but-disconnected room needs rejoining before it can be modified.
+    fn live_session(&self, channel: &str) -> Result<Arc<Session>, String> {
+        self.room(channel)?.session.clone().ok_or_else(|| {
+            format!("room '{channel}' is known but not connected; rejoin it first")
+        })
+    }
+
+    /// Write every known room's metadata to the store. Called after each
+    /// mutation. A write failure is surfaced to the caller rather than
+    /// swallowed — silently losing rooms is what this feature exists to stop.
+    fn persist(&self) -> Result<(), String> {
+        let Some(path) = &self.store_path else {
+            return Ok(());
+        };
+        let mut stored: Vec<PersistedRoom> = self
+            .rooms
+            .iter()
+            .map(|(channel, room)| PersistedRoom {
+                channel: channel.clone(),
+                moderator: room.moderator,
+                members: room.admitted.values().cloned().collect(),
+            })
+            .collect();
+        // Stable order so the file doesn't churn between writes.
+        stored.sort_by(|a, b| a.channel.cmp(&b.channel));
+        for room in &mut stored {
+            room.members.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+        }
+        let data = serde_json::to_string_pretty(&stored)
+            .map_err(|e| format!("failed to serialize rooms: {e}"))?;
+        std::fs::write(path, data)
+            .map_err(|e| format!("failed to write {}: {e}", path.display()))
     }
 
     fn node_service_mut(&mut self) -> &mut Service {
@@ -194,11 +288,18 @@ impl Inner {
             .get_or_insert_with(|| Service::new(client_service_name()))
     }
 
-    /// Roster for a room: live `participants_list` names, enriched with
-    /// admission-time DID/endpoint/kind where this process knows them.
+    /// Roster for a room. Connected: live `participants_list` names, enriched
+    /// with admission-time DID/endpoint/kind where this process knows them.
+    /// Disconnected: the last-known admitted members, so a restored room still
+    /// shows who belongs to it.
     fn roster(&self, channel: &str) -> Result<Vec<SlimGroupMember>, String> {
         let room = self.room(channel)?;
-        let participants = room.session.participants_list().map_err(slim_err)?;
+        let Some(session) = &room.session else {
+            let mut members: Vec<SlimGroupMember> = room.admitted.values().cloned().collect();
+            members.sort_by(|a, b| a.name.cmp(&b.name));
+            return Ok(members);
+        };
+        let participants = session.participants_list().map_err(slim_err)?;
         Ok(participants
             .into_iter()
             .map(|name| {
@@ -222,6 +323,7 @@ impl Inner {
             } else {
                 "participant".to_string()
             },
+            connected: room.session.is_some(),
             members: self.roster(channel)?,
         })
     }
@@ -288,7 +390,7 @@ pub async fn slim_group_create(
     inner.rooms.insert(
         channel_name.to_string(),
         Room {
-            session,
+            session: Some(session),
             moderator: true,
             admitted: candidates
                 .into_iter()
@@ -296,6 +398,7 @@ pub async fn slim_group_create(
                 .collect(),
         },
     );
+    inner.persist()?;
     inner.group_info(&channel_name.to_string())
 }
 
@@ -356,7 +459,7 @@ pub async fn slim_group_invite(
     let mut inner = lock(&state)?;
     let connection_id = inner.ensure_connection()?;
     let app = inner.ensure_app()?;
-    let session = inner.room(&channel)?.session.clone();
+    let session = inner.live_session(&channel)?;
 
     for (member, _) in &resolved {
         let name = Arc::new(parse_name(&member.name)?);
@@ -367,14 +470,19 @@ pub async fn slim_group_invite(
     let room = inner
         .rooms
         .get_mut(&channel)
-        .ok_or_else(|| format!("not in room '{channel}'"))?;
+        .ok_or_else(|| format!("no room '{channel}'"))?;
     for (member, _) in resolved {
         room.admitted.insert(member.name.clone(), member);
     }
+    inner.persist()?;
     inner.group_info(&channel)
 }
 
-/// Join a room created by a moderator (`/slim join`).
+/// Join a room created by a moderator (`/slim join`), or rejoin a known one.
+///
+/// Rejoining reattaches the live session to the existing record, keeping the
+/// role and admitted-member metadata a restored room already carries — losing
+/// that on rejoin would defeat persisting it.
 #[tauri::command]
 pub async fn slim_group_join(
     state: tauri::State<'_, SlimState>,
@@ -402,18 +510,26 @@ pub async fn slim_group_join(
         ));
     }
 
-    inner.rooms.insert(
-        actual.clone(),
-        Room {
-            session,
-            moderator: false,
-            admitted: HashMap::new(),
-        },
-    );
+    match inner.rooms.get_mut(&actual) {
+        // Rejoin: keep the role and roster this room already carries.
+        Some(room) => room.session = Some(session),
+        None => {
+            inner.rooms.insert(
+                actual.clone(),
+                Room {
+                    session: Some(session),
+                    moderator: false,
+                    admitted: HashMap::new(),
+                },
+            );
+        }
+    }
+    inner.persist()?;
     inner.group_info(&actual)
 }
 
-/// Every room this process is currently in, moderator or participant.
+/// Every known room, moderator or participant, connected or not — rooms
+/// restored from the store appear here with `connected: false`.
 ///
 /// Has no `shadictl` equivalent — the shell holds one session slot and has no
 /// notion of a rooms overview.
@@ -447,21 +563,52 @@ pub async fn slim_group_remove_member(
     member_name: String,
 ) -> Result<SlimGroupInfo, String> {
     let mut inner = lock(&state)?;
-    let room = inner.room(&channel)?;
-    if !room.moderator {
+    if !inner.room(&channel)?.moderator {
         return Err(format!(
             "only the moderator of '{channel}' can remove members"
         ));
     }
-    let session = room.session.clone();
-    session
+    inner
+        .live_session(&channel)?
         .remove_and_wait(Arc::new(parse_name(&member_name)?))
         .map_err(slim_err)?;
 
     if let Some(room) = inner.rooms.get_mut(&channel) {
         room.admitted.remove(&member_name);
     }
+    inner.persist()?;
     inner.group_info(&channel)
+}
+
+/// Drop a room from the known list, tearing down its session if connected.
+///
+/// Persisting rooms means they otherwise accumulate with no way to remove one.
+/// This is local bookkeeping — it does not remove anyone else from the group.
+#[tauri::command]
+pub async fn slim_group_forget(
+    state: tauri::State<'_, SlimState>,
+    channel: String,
+) -> Result<Vec<SlimGroupInfo>, String> {
+    let mut inner = lock(&state)?;
+    let room = inner
+        .rooms
+        .remove(&channel)
+        .ok_or_else(|| format!("no room '{channel}'"))?;
+
+    // Best-effort teardown: the room is already gone from the list, so a
+    // failure here must not resurrect it or fail the call.
+    if let (Some(session), Some(app)) = (room.session, inner.app.clone()) {
+        let _ = app.delete_session_and_wait(session);
+    }
+    inner.subscribed_channels.retain(|c| c != &channel);
+
+    inner.persist()?;
+    let mut channels: Vec<String> = inner.rooms.keys().cloned().collect();
+    channels.sort();
+    channels
+        .iter()
+        .map(|channel| inner.group_info(channel))
+        .collect()
 }
 
 // --- Controller --------------------------------------------------------------
@@ -890,6 +1037,141 @@ fn ensure_file_exists(path: &Path, label: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn member(name: &str, kind: &str) -> SlimGroupMember {
+        SlimGroupMember {
+            name: name.to_string(),
+            did: format!("did:key:z6Mk{name}"),
+            endpoint: Some("127.0.0.1:47357".to_string()),
+            kind: kind.to_string(),
+        }
+    }
+
+    fn room_with(moderator: bool, members: Vec<SlimGroupMember>) -> Room {
+        Room {
+            // No live session: exactly the shape a restored room has.
+            session: None,
+            moderator,
+            admitted: members
+                .into_iter()
+                .map(|m| (m.name.clone(), m))
+                .collect(),
+        }
+    }
+
+    fn store_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "shadi-desktop-rooms-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir.join("nested").join("rooms.json")
+    }
+
+    /// The core of agntcy/shadi#138: a room written before "restart" comes
+    /// back with its role and roster intact, and reports itself disconnected.
+    #[test]
+    fn known_rooms_survive_a_restart() {
+        let path = store_path();
+        let _ = std::fs::remove_file(&path);
+
+        let before = SlimState::default();
+        {
+            let mut inner = before.0.lock().unwrap_or_else(|e| e.into_inner());
+            inner.store_path = Some(path.clone());
+            inner.rooms.insert(
+                "agntcy/shadi/review".to_string(),
+                room_with(true, vec![member("agntcy/shadi/bot", "agent")]),
+            );
+            inner.rooms.insert(
+                "agntcy/shadi/standup".to_string(),
+                room_with(false, vec![member("agntcy/shadi/lead", "human")]),
+            );
+            // Writes through a directory that doesn't exist yet.
+            inner.persist().expect("persist");
+        }
+
+        let after = SlimState::default();
+        after.init_store(path.clone()).expect("init store");
+        let inner = after.0.lock().unwrap_or_else(|e| e.into_inner());
+
+        let review = inner.group_info("agntcy/shadi/review").expect("review room");
+        assert_eq!(review.role, "moderator");
+        assert!(!review.connected, "a restored room has no live session");
+        assert_eq!(review.members.len(), 1);
+        assert_eq!(review.members[0].name, "agntcy/shadi/bot");
+        assert_eq!(review.members[0].kind, "agent");
+        assert_eq!(review.members[0].did, "did:key:z6Mkagntcy/shadi/bot");
+        assert_eq!(
+            review.members[0].endpoint.as_deref(),
+            Some("127.0.0.1:47357"),
+            "endpoint must survive — coordinate specs are built from it"
+        );
+
+        // Role and the human/agent label are per-room, not global.
+        let standup = inner.group_info("agntcy/shadi/standup").expect("standup room");
+        assert_eq!(standup.role, "participant");
+        assert_eq!(standup.members[0].kind, "human");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A disconnected room is readable but not modifiable: `live_session`
+    /// gates invite/remove, and says what to do about it.
+    #[test]
+    fn disconnected_room_is_readable_but_not_modifiable() {
+        let state = SlimState::default();
+        let mut inner = state.0.lock().unwrap_or_else(|e| e.into_inner());
+        inner.rooms.insert(
+            "agntcy/shadi/review".to_string(),
+            room_with(true, vec![member("agntcy/shadi/bot", "agent")]),
+        );
+
+        // Roster works without a session.
+        assert_eq!(inner.roster("agntcy/shadi/review").unwrap().len(), 1);
+
+        // `unwrap_err` would require the Ok type (Arc<Session>) to be Debug.
+        let err = match inner.live_session("agntcy/shadi/review") {
+            Ok(_) => panic!("a room with no session must not yield one"),
+            Err(err) => err,
+        };
+        assert!(err.contains("not connected"), "unexpected: {err}");
+        assert!(err.contains("rejoin"), "should say how to fix it: {err}");
+    }
+
+    #[test]
+    fn unknown_room_is_distinguished_from_disconnected_one() {
+        let state = SlimState::default();
+        let inner = state.0.lock().unwrap_or_else(|e| e.into_inner());
+        let err = match inner.room("agntcy/shadi/nope") {
+            Ok(_) => panic!("unknown room must not resolve"),
+            Err(err) => err,
+        };
+        assert!(err.contains("no room"), "unexpected: {err}");
+    }
+
+    /// Persisting with no store configured must not fail — that is the state
+    /// during tests and if the app data dir can't be resolved.
+    #[test]
+    fn persist_without_a_store_is_a_no_op() {
+        let state = SlimState::default();
+        let mut inner = state.0.lock().unwrap_or_else(|e| e.into_inner());
+        inner
+            .rooms
+            .insert("agntcy/shadi/review".to_string(), room_with(true, vec![]));
+        assert!(inner.persist().is_ok());
+    }
+
+    /// A missing store is a first launch, not an error.
+    #[test]
+    fn init_store_tolerates_a_missing_file() {
+        let state = SlimState::default();
+        let missing = std::env::temp_dir().join("shadi-desktop-definitely-absent.json");
+        let _ = std::fs::remove_file(&missing);
+        assert!(state.init_store(missing).is_ok());
+        assert!(state.0.lock().unwrap_or_else(|e| e.into_inner()).rooms.is_empty());
+    }
 
     #[test]
     fn member_specs_are_recognised() {

--- a/apps/shadi_desktop/src-tauri/src/lib.rs
+++ b/apps/shadi_desktop/src-tauri/src/lib.rs
@@ -5,8 +5,9 @@
 //! the SHADI shell. See agntcy/shadi#112 for the epic and panel breakdown.
 //!
 //! The Tauri IPC command contract (agntcy/shadi#114) is defined in
-//! `commands/` — see `../docs/ipc-contract.md`. Every command there is
-//! currently a stub; no feature panels exist yet.
+//! `commands/` — see `../docs/ipc-contract.md`.
+
+use tauri::Manager;
 
 mod commands;
 
@@ -15,6 +16,23 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(commands::slim::SlimState::default())
+        .setup(|app| {
+            // Known rooms are persisted (agntcy/shadi#138); the app data dir is
+            // only resolvable once the app exists. A failure here is reported
+            // and tolerated — a bad room store must not block startup.
+            match app.path().app_data_dir() {
+                Ok(dir) => {
+                    if let Err(err) = app
+                        .state::<commands::slim::SlimState>()
+                        .init_store(dir.join("rooms.json"))
+                    {
+                        eprintln!("warning: could not load saved rooms: {err}");
+                    }
+                }
+                Err(err) => eprintln!("warning: no app data dir, rooms will not persist: {err}"),
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::sandbox::sandbox_launch,
             commands::sandbox::sandbox_list_sessions,
@@ -43,6 +61,7 @@ pub fn run() {
             commands::slim::slim_group_list,
             commands::slim::slim_group_roster,
             commands::slim::slim_group_remove_member,
+            commands::slim::slim_group_forget,
             commands::slim::slim_controller_list_connections,
             commands::slim::slim_controller_list_routes,
             commands::dir::dir_search,

--- a/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
+++ b/apps/shadi_desktop/src/panels/AgentBridgePanel.tsx
@@ -58,7 +58,9 @@ function AddToRoom({ adapter }: { adapter: AdapterInfo }) {
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
 
-  const moderated = rooms.filter((r) => r.role === "moderator");
+  // Inviting needs both moderator rights and a live session, so a known but
+  // unrejoined room isn't a valid target (agntcy/shadi#138).
+  const targets = rooms.filter((r) => r.role === "moderator" && r.connected);
 
   async function add(channel: string) {
     setBusy(true);
@@ -84,8 +86,14 @@ function AddToRoom({ adapter }: { adapter: AdapterInfo }) {
     }
   }
 
-  if (moderated.length === 0) {
-    return <span className="ab-hint">no moderated room</span>;
+  if (targets.length === 0) {
+    // Distinguish "you moderate nothing" from "rejoin the room you moderate".
+    const needsRejoin = rooms.some((r) => r.role === "moderator");
+    return (
+      <span className="ab-hint">
+        {needsRejoin ? "rejoin a room first" : "no moderated room"}
+      </span>
+    );
   }
 
   return (
@@ -99,7 +107,7 @@ function AddToRoom({ adapter }: { adapter: AdapterInfo }) {
         }}
       >
         <option value="">{busy ? "Adding…" : "Add to…"}</option>
-        {moderated.map((r) => (
+        {targets.map((r) => (
           <option key={r.channel} value={r.channel}>
             {r.channel}
           </option>

--- a/apps/shadi_desktop/src/panels/SlimRoomsPanel.css
+++ b/apps/shadi_desktop/src/panels/SlimRoomsPanel.css
@@ -126,6 +126,32 @@
   background: rgba(127, 127, 127, 0.22);
 }
 
+.sl-room-offline {
+  border-style: dashed;
+}
+
+.sl-conn {
+  font-size: 0.72rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.sl-conn-on {
+  background: rgba(63, 185, 80, 0.2);
+}
+
+.sl-conn-off {
+  background: rgba(127, 127, 127, 0.2);
+  opacity: 0.85;
+}
+
+.sl-forget {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.5rem;
+  margin-left: auto;
+}
+
 .sl-kind {
   font-size: 0.72rem;
   padding: 0.1rem 0.4rem;

--- a/apps/shadi_desktop/src/panels/SlimRoomsPanel.tsx
+++ b/apps/shadi_desktop/src/panels/SlimRoomsPanel.tsx
@@ -100,7 +100,8 @@ function Roster({
     }
   }
 
-  const isModerator = room.role === "moderator";
+  // Removing needs a live session, so a disconnected room is read-only.
+  const canRemove = room.role === "moderator" && room.connected;
 
   return (
     <div className="sl-roster">
@@ -115,7 +116,7 @@ function Roster({
               <th>Member</th>
               <th>DID</th>
               <th>Endpoint</th>
-              {isModerator && <th />}
+              {canRemove && <th />}
             </tr>
           </thead>
           <tbody>
@@ -129,7 +130,7 @@ function Roster({
                 <td>{m.name}</td>
                 <td className="sl-did">{m.did || "—"}</td>
                 <td>{m.endpoint ?? "—"}</td>
-                {isModerator && (
+                {canRemove && (
                   <td>
                     <button
                       className="sl-remove"
@@ -173,38 +174,93 @@ function RoomCard({ room, onChanged }: { room: SlimGroupInfo; onChanged: () => v
     }
   }
 
+  async function onRejoin() {
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke<SlimGroupInfo>("slim_group_join", {
+        channel: room.channel,
+        timeoutSecs: 30,
+      });
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onForget() {
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke<SlimGroupInfo[]>("slim_group_forget", {
+        channel: room.channel,
+      });
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
-    <div className="sl-room">
+    <div className={room.connected ? "sl-room" : "sl-room sl-room-offline"}>
       <div className="sl-room-head">
         <strong>{room.channel}</strong>
         <span className={`sl-role sl-role-${room.role}`}>{room.role}</span>
+        <span
+          className={`sl-conn ${room.connected ? "sl-conn-on" : "sl-conn-off"}`}
+          title={
+            room.connected
+              ? "live session — can invite and remove"
+              : "known but not joined this session — roster is last known"
+          }
+        >
+          {room.connected ? "connected" : "not connected"}
+        </span>
         <span className="sl-muted">
           {room.members.length} member{room.members.length === 1 ? "" : "s"}
         </span>
-        <button onClick={onChanged}>Refresh roster</button>
+        {room.connected ? (
+          <button onClick={onChanged}>Refresh roster</button>
+        ) : (
+          <button onClick={onRejoin} disabled={busy}>
+            {busy ? "Rejoining…" : "Rejoin"}
+          </button>
+        )}
+        <button className="sl-forget" onClick={onForget} disabled={busy}>
+          Forget
+        </button>
       </div>
 
       <Roster room={room} onRemoved={onChanged} />
 
-      {room.role === "moderator" && (
-        <div className="sl-row sl-invite">
-          <input
-            className="sl-input"
-            placeholder="Member: skill:… | did:… | explicit:name=did | org/ns/app"
-            value={memberSpec}
-            onChange={(e) => setMemberSpec(e.target.value)}
-          />
-          <input
-            className="sl-input"
-            placeholder="DIR server (for skill:/did: specs)"
-            value={dirServer}
-            onChange={(e) => setDirServer(e.target.value)}
-          />
-          <button onClick={onInvite} disabled={busy || !memberSpec}>
-            {busy ? "Inviting…" : "Invite"}
-          </button>
-        </div>
-      )}
+      {room.role === "moderator" &&
+        (room.connected ? (
+          <div className="sl-row sl-invite">
+            <input
+              className="sl-input"
+              placeholder="Member: skill:… | did:… | explicit:name=did | org/ns/app"
+              value={memberSpec}
+              onChange={(e) => setMemberSpec(e.target.value)}
+            />
+            <input
+              className="sl-input"
+              placeholder="DIR server (for skill:/did: specs)"
+              value={dirServer}
+              onChange={(e) => setDirServer(e.target.value)}
+            />
+            <button onClick={onInvite} disabled={busy || !memberSpec}>
+              {busy ? "Inviting…" : "Invite"}
+            </button>
+          </div>
+        ) : (
+          <p className="sl-muted sl-invite">
+            Rejoin to invite or remove members.
+          </p>
+        ))}
       <ErrorText message={error} />
     </div>
   );
@@ -263,8 +319,9 @@ function RoomsSection() {
     <section className="sl-card">
       <h2>Rooms</h2>
       <p className="sl-muted sl-note">
-        Rooms are live SLIM sessions this app is joined to — the list is empty on
-        a fresh launch until you create or join one. Messaging between members
+        Rooms are remembered across restarts, but their SLIM sessions are not —
+        a room from a previous launch shows its last-known roster and needs a
+        rejoin before you can invite or remove. Messaging between members
         happens over SLIM via each member's own harness; this panel administers
         membership.
       </p>

--- a/apps/shadi_desktop/src/shared/rooms.tsx
+++ b/apps/shadi_desktop/src/shared/rooms.tsx
@@ -20,6 +20,12 @@ export interface SlimGroupMember {
 export interface SlimGroupInfo {
   channel: string;
   role: string;
+  /**
+   * Whether a live SLIM session backs this room right now. A known room
+   * restored from disk is `false` until rejoined: its roster is readable, but
+   * it cannot be invited into or removed from (agntcy/shadi#138).
+   */
+  connected: boolean;
   members: SlimGroupMember[];
 }
 

--- a/docs/content/demos/desktop-room-e2e.sh
+++ b/docs/content/demos/desktop-room-e2e.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# End-to-end harness for the SHADI Desktop room admin surface
+# (agntcy/shadi#118, #135, #138).
+#
+# Stands up a real SLIM node with DID auth and mTLS, derives a moderator and two
+# agent identities (claude-code, codex) from a throwaway seed, starts the two
+# agents listening for an invite, and runs the desktop crate's live test as the
+# moderator: create a room, invite both, read the roster, reload after restart.
+#
+#   bash docs/content/demos/desktop-room-e2e.sh
+#
+# Everything lands in a scratch dir that is removed on exit. The seed is
+# generated per run and is not any real key — SHADI derives agent DIDs from a
+# human *secret* (HKDF, salt "shadi-agent-derive"), so a dedicated seed keeps
+# long-term keys out of a throwaway test. SSH keys are not a supported source;
+# `did-from-github` fetches a GPG *public* key, which cannot derive agents.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+E2E="${SHADI_E2E_DIR:-/tmp/shadi-desktop-room-e2e}"
+mkdir -p "$E2E"
+# Resolve to the real path: macOS /tmp is a symlink to /private/tmp, and a
+# Seatbelt subpath rule generated for the canonical form does not match a path
+# reached through the symlink.
+E2E="$(cd "$E2E" && pwd -P)"
+
+ROOM="agntcy/shadi/dev-room"
+AGENTS=(claude-code codex)
+PIDS=()
+
+cleanup() {
+  for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+  [ -n "${SHADI_E2E_KEEP:-}" ] || rm -rf "$E2E"
+}
+trap cleanup EXIT
+
+echo "==> scratch dir $E2E"
+
+echo "==> building shadictl"
+cargo build -q -p agntcy-shadi-cli --bin shadictl
+
+echo "==> generating mTLS material"
+bash tools/generate_slim_mtls_certs.sh "$E2E/shadi-slim-mtls" >"$E2E/certs.log" 2>&1
+
+echo "==> deriving identities from a throwaway seed"
+umask 077
+# No trailing newline: the file bytes must equal the env value exactly, or
+# derive-agent-identity and did_auth_from_env produce *different* DIDs and the
+# allow-list silently fails to match.
+printf %s "$(openssl rand -hex 32)" >"$E2E/human-seed.txt"
+target/debug/shadictl derive-agent-identity --source seed --in "$E2E/human-seed.txt" \
+  --name avatar --name "${AGENTS[0]}" --name "${AGENTS[1]}" \
+  --out-dir "$E2E/identities" >"$E2E/derive.log" 2>&1
+
+did_of() {
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['id'])" \
+    "$E2E/identities/$1.did.json"
+}
+AVATAR_DID="$(did_of avatar)"
+DIDS="$AVATAR_DID"
+for a in "${AGENTS[@]}"; do DIDS="$DIDS,$(did_of "$a")"; done
+
+export SHADI_SLIM_AUTH=did
+export SLIM_HUMAN_SEED="$(cat "$E2E/human-seed.txt")"
+export SHADI_TMP_DIR="$E2E"
+export SLIM_ENDPOINT="${SLIM_ENDPOINT:-127.0.0.1:47610}"
+export SLIM_TLS_CERT="$E2E/shadi-slim-mtls/client-avatar.crt"
+export SLIM_TLS_KEY="$E2E/shadi-slim-mtls/client-avatar.key"
+export SLIM_TLS_CA="$E2E/shadi-slim-mtls/ca.crt"
+export SLIM_MEMBER_DIDS="$DIDS"
+echo "    moderator $AVATAR_DID"
+
+echo "==> starting SLIM node on $SLIM_ENDPOINT"
+SHADI_AGENT_ID=avatar target/debug/shadictl slim start-node >"$E2E/node.log" 2>&1 &
+PIDS+=($!)
+for _ in $(seq 1 30); do
+  grep -q 'dataplane server started' "$E2E/node.log" 2>/dev/null && break
+  sleep 1
+done
+grep -q 'dataplane server started' "$E2E/node.log" || { echo "node failed:"; cat "$E2E/node.log"; exit 1; }
+
+echo "==> running the desktop room test as moderator"
+# The test creates the room, then waits ~12s before inviting, which is the
+# window the joiners below use to reach listen_for_session.
+(
+  cd apps/shadi_desktop/src-tauri
+  SHADI_AGENT_ID=avatar \
+  SHADI_E2E_ROOM="$ROOM" \
+  SHADI_E2E_MEMBERS="agntcy/shadi/${AGENTS[0]},agntcy/shadi/${AGENTS[1]}" \
+    cargo test --quiet live_moderator_creates_room_invites_two_agents_and_sees_the_roster \
+      -- --ignored --nocapture
+) >"$E2E/desktop-test.log" 2>&1 &
+TEST_PID=$!
+
+sleep 5
+echo "==> starting agent joiners"
+for a in "${AGENTS[@]}"; do
+  # Keep stdin open after joining: exiting deletes the group session and breaks
+  # the moderator's next invite.
+  ( printf '/slim join %s --timeout 120\n' "$ROOM"; sleep 120 ) \
+    | SHADI_AGENT_ID="$a" target/debug/shadictl shell >"$E2E/join-$a.log" 2>&1 &
+  PIDS+=($!)
+done
+
+set +e
+wait "$TEST_PID"
+TEST_RC=$?
+set -e
+
+echo
+echo "==> agent join results"
+for a in "${AGENTS[@]}"; do
+  printf '  %-13s ' "$a"
+  grep -m1 'joined group session' "$E2E/join-$a.log" 2>/dev/null \
+    || grep -m1 -iE 'error|timed out' "$E2E/join-$a.log" 2>/dev/null \
+    || echo "(no result)"
+done
+
+echo
+echo "==> desktop test output"
+grep -vE '^\s*$' "$E2E/desktop-test.log" | tail -25
+
+echo
+if [ "$TEST_RC" -eq 0 ]; then
+  echo "PASS — moderator created the room, both agents were invited and appeared"
+  echo "       in the roster, and the roster survived a simulated restart."
+else
+  echo "FAIL — see $E2E (re-run with SHADI_E2E_KEEP=1 to keep the scratch dir)"
+fi
+exit "$TEST_RC"

--- a/docs/content/demos/desktop-room-live.sh
+++ b/docs/content/demos/desktop-room-live.sh
@@ -39,12 +39,35 @@ cleanup() {
   echo
   echo "==> shutting down"
   for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+  # `tauri dev` spawns vite as a child; killing only the parent orphans it and
+  # it keeps holding port 1420, breaking the next run.
+  lsof -tnP -iTCP:1420 -sTCP:LISTEN 2>/dev/null | xargs kill 2>/dev/null || true
   wait 2>/dev/null || true
   [ -n "${SHADI_LIVE_KEEP:-}" ] || rm -rf "$E2E"
 }
 trap cleanup EXIT INT TERM
 
 echo "==> scratch dir $E2E"
+
+# Vite's dev port. A `tauri dev` killed at the parent leaves its vite child
+# holding 1420, and the next run dies with "Port 1420 is already in use" — so
+# say what is holding it rather than leaving the user to hunt.
+if lsof -nP -iTCP:1420 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "    port 1420 is already in use by:"
+  lsof -nP -iTCP:1420 -sTCP:LISTEN | tail -n +2 | sed 's/^/      /'
+  if [ -n "${SHADI_LIVE_FREE_PORT:-}" ]; then
+    echo "    SHADI_LIVE_FREE_PORT set — terminating it"
+    lsof -tnP -iTCP:1420 -sTCP:LISTEN | xargs kill 2>/dev/null || true
+    sleep 2
+  else
+    echo
+    echo "    Usually a leftover vite from an earlier 'tauri dev'. Free it with:"
+    echo "      lsof -tnP -iTCP:1420 -sTCP:LISTEN | xargs kill"
+    echo "    or re-run with SHADI_LIVE_FREE_PORT=1 to do that automatically."
+    exit 1
+  fi
+fi
+
 cargo build -q -p agntcy-shadi-cli --bin shadictl
 
 echo "==> generating mTLS material"

--- a/docs/content/demos/desktop-room-live.sh
+++ b/docs/content/demos/desktop-room-live.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Launch SHADI Desktop against a live SLIM room, for clicking through by hand
+# (agntcy/shadi#118, #135, #138).
+#
+#   bash docs/content/demos/desktop-room-live.sh
+#
+# Stands up everything the Rooms panel needs — a SLIM node, mTLS material, DID
+# auth, and two agents (claude-code, codex) waiting to be invited — then starts
+# the app with that environment. Without it the panel cannot work: "Start node"
+# reports missing mTLS material because SHADI_TMP_DIR is unset.
+#
+# Then, in the app:
+#   1. Rooms tab -> Start node        (attaches to the node this script started)
+#   2. New room channel: agntcy/shadi/dev-room  -> Create room
+#   3. Invite  agntcy/shadi/claude-code   then  agntcy/shadi/codex
+#   4. The roster shows both, tagged agent
+#   5. Quit and re-run: the room comes back "not connected" with its roster
+#
+# Ctrl-C tears the whole thing down. The seed is generated per run and is not
+# any real key: SHADI derives agent DIDs from a human *secret* (HKDF, salt
+# "shadi-agent-derive"). SSH keys are not a supported source, and
+# `did-from-github` fetches a GPG *public* key, which cannot derive agents.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+E2E="${SHADI_LIVE_DIR:-/tmp/shadi-desktop-room-live}"
+mkdir -p "$E2E"
+# macOS /tmp is a symlink to /private/tmp; resolve it so sandbox --read rules
+# and the paths actually opened agree.
+E2E="$(cd "$E2E" && pwd -P)"
+
+ROOM="agntcy/shadi/dev-room"
+AGENTS=(claude-code codex)
+PIDS=()
+
+cleanup() {
+  echo
+  echo "==> shutting down"
+  for pid in "${PIDS[@]:-}"; do kill "$pid" 2>/dev/null || true; done
+  wait 2>/dev/null || true
+  [ -n "${SHADI_LIVE_KEEP:-}" ] || rm -rf "$E2E"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> scratch dir $E2E"
+cargo build -q -p agntcy-shadi-cli --bin shadictl
+
+echo "==> generating mTLS material"
+bash tools/generate_slim_mtls_certs.sh "$E2E/shadi-slim-mtls" >"$E2E/certs.log" 2>&1
+
+echo "==> deriving identities from a throwaway seed"
+umask 077
+# No trailing newline: the file bytes must equal the env value exactly, or
+# derive-agent-identity and did_auth_from_env yield *different* DIDs and the
+# allow-list silently fails to match.
+printf %s "$(openssl rand -hex 32)" >"$E2E/human-seed.txt"
+target/debug/shadictl derive-agent-identity --source seed --in "$E2E/human-seed.txt" \
+  --name avatar --name "${AGENTS[0]}" --name "${AGENTS[1]}" \
+  --out-dir "$E2E/identities" >"$E2E/derive.log" 2>&1
+
+did_of() {
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['id'])" \
+    "$E2E/identities/$1.did.json"
+}
+DIDS="$(did_of avatar)"
+for a in "${AGENTS[@]}"; do DIDS="$DIDS,$(did_of "$a")"; done
+
+export SHADI_SLIM_AUTH=did
+export SLIM_HUMAN_SEED="$(cat "$E2E/human-seed.txt")"
+export SHADI_TMP_DIR="$E2E"
+export SLIM_ENDPOINT="${SLIM_ENDPOINT:-127.0.0.1:47610}"
+export SLIM_TLS_CERT="$E2E/shadi-slim-mtls/client-avatar.crt"
+export SLIM_TLS_KEY="$E2E/shadi-slim-mtls/client-avatar.key"
+export SLIM_TLS_CA="$E2E/shadi-slim-mtls/ca.crt"
+export SLIM_MEMBER_DIDS="$DIDS"
+export SHADI_AGENT_ID=avatar
+
+echo "==> starting SLIM node on $SLIM_ENDPOINT"
+target/debug/shadictl slim start-node >"$E2E/node.log" 2>&1 &
+PIDS+=($!)
+for _ in $(seq 1 30); do
+  grep -q 'dataplane server started' "$E2E/node.log" 2>/dev/null && break
+  sleep 1
+done
+grep -q 'dataplane server started' "$E2E/node.log" \
+  || { echo "node failed to start:"; cat "$E2E/node.log"; exit 1; }
+
+echo "==> starting agents waiting for an invite to $ROOM"
+for a in "${AGENTS[@]}"; do
+  # Keep stdin open after joining: exiting deletes the shared group session and
+  # breaks the moderator's next invite.
+  ( printf '/slim join %s --timeout 1800\n' "$ROOM"; sleep 1800 ) \
+    | SHADI_AGENT_ID="$a" target/debug/shadictl shell >"$E2E/join-$a.log" 2>&1 &
+  PIDS+=($!)
+  echo "    $a  -> $E2E/join-$a.log"
+done
+
+cat <<EOF
+
+==> launching SHADI Desktop as moderator 'avatar'
+
+  In the app (Rooms tab):
+    1. Start node
+    2. New room channel: $ROOM   -> Create room
+    3. Invite  agntcy/shadi/${AGENTS[0]}   then  agntcy/shadi/${AGENTS[1]}
+    4. Roster shows both, tagged 'agent'
+
+  Note: the two agents above are already waiting, so invite them without
+  restarting them — a participant that exits tears down the group session.
+
+  Ctrl-C here tears everything down.
+
+EOF
+
+cd apps/shadi_desktop
+pnpm tauri dev


### PR DESCRIPTION
Closes #138.

## The important part: a runtime panic in already-merged #118 code

Testing this end-to-end against a real SLIM node surfaced that the Rooms panel **never worked at runtime**. Every blocking `slim_bindings` entry point it uses — `run_server`, `connect`, `create_session_and_wait`, `subscribe`, `set_route`, `listen_for_session`, `invite_and_wait`, `remove_and_wait`, `participants_list`, `delete_session_and_wait` — is a `get_runtime().block_on(..)` wrapper. Called from an `async` command it lands on a Tauri async worker and panics with *"Cannot start a runtime from within a runtime"*. Clicking **Start node** killed the command.

It compiled, passed its entire unit suite, and was dead on first use. Every command now hops to `spawn_blocking` via `with_state` before touching state (Directory resolution moved there too — it shells out to `dirctl`).

Two pieces of coverage so it can't regress:
- A **unit test** pinning the invariant, needing no node. Verified non-vacuous: removing the `spawn_blocking` hop reproduces the exact production panic.
- An **ignored live test** driving the real sequence against a real node with DID auth. `docs/content/demos/desktop-room-e2e.sh` stands up the node, mTLS material and two agent identities derived from a throwaway seed, then runs it.

## Room persistence (#138)

Rooms were in-memory only, so a restart emptied the list. Metadata is now persisted to the app data dir; a room is **known** across restarts even when not **connected**:
- `SlimGroupInfo` gains `connected`. A restored room reads `false`: roster shows, but invite/remove need a live session and fail with a rejoin hint. Both panels gate on this, not just `role`.
- **Rejoin** reattaches the session to the existing record — replacing it would discard the roster.
- **Forget** (`slim_group_forget`) drops a room; otherwise they accumulate with no way out.

**Not via `slim_mas`/`mas.toml`:** `MemberConfig` is `{did, role}` only. Dropping `name`/`endpoint` would break what #135 builds from them — invite/remove matching, and coordinate's `slim:<agent-id>@<host:port>` specs. Nothing stored is secret; a `did:key` is a public key, and sessions/credentials are never written.

## Test plan
- [x] `cargo clippy --all-targets` clean; 13 unit tests pass (1 ignored live)
- [x] `pnpm build` clean
- [x] UI verified against a stubbed IPC bridge: connected room keeps Refresh roster/Remove/Invite; disconnected shows Rejoin, drops the Remove column and invite form; `AddToRoom` offers only connected rooms; coordinate's picker counts agents only
- [x] **End-to-end against a real SLIM node** — `bash docs/content/demos/desktop-room-e2e.sh`: moderator creates the room, `claude-code` and `codex` both join and appear in the roster, roster survives a restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rooms persist across app restarts and display connection status.
  * Rejoin disconnected rooms or permanently forget them from the room list.
  * Room administration actions are available only when connected and authorized.
  * Invitation targets include only connected moderated rooms.
* **Bug Fixes**
  * Improved handling and messaging for disconnected rooms.
* **Documentation**
  * Expanded room command and lifecycle documentation.
  * Added live and end-to-end desktop room demonstration workflows.
* **Tests**
  * Added end-to-end coverage for desktop room administration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->