### PR TITLE
feat(identity): root human and agent DIDs in an SSH Ed25519 key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "signal-hook",
+ "ssh-key",
  "tempfile",
  "tokio",
  "tonic 0.14.5",
@@ -299,6 +300,7 @@ dependencies = [
  "pkcs8",
  "serde_json",
  "sha2",
+ "ssh-key",
  "tokio",
 ]
 
@@ -1289,6 +1291,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1561,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
 
 [[package]]
 name = "chacha20"
@@ -4504,6 +4528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,6 +4697,17 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"
@@ -5090,7 +5134,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -6091,6 +6135,51 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20 0.9.1",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/shadi_identity/Cargo.toml
+++ b/crates/shadi_identity/Cargo.toml
@@ -19,6 +19,9 @@ serde_json = "1.0"
 hkdf = "0.12"
 sha2 = "0.10"
 slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
+# OpenSSH key parsing for the SSH-rooted identity source (agntcy/shadi#140).
+# `encryption` brings bcrypt-pbkdf so passphrase-protected keys work.
+ssh-key = { version = "0.6", default-features = false, features = ["alloc", "ed25519", "encryption", "rand_core", "getrandom"] }
 
 [dev-dependencies]
 slim_config = { package = "agntcy-slim-config", version = "0.12.6" }

--- a/crates/shadi_identity/src/lib.rs
+++ b/crates/shadi_identity/src/lib.rs
@@ -19,6 +19,7 @@ use pkcs8::LineEnding;
 
 pub mod auth;
 pub mod config;
+pub mod ssh;
 
 pub use auth::{build_did_auth, create_app, did_auth_from_env, require_did_auth_from_env, SlimAuth};
 

--- a/crates/shadi_identity/src/ssh.rs
+++ b/crates/shadi_identity/src/ssh.rs
@@ -1,44 +1,28 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-//! Rooting SHADI identities in an SSH Ed25519 key (agntcy/shadi#140).
+//! SSH Ed25519 keys as a SHADI identity root (agntcy/shadi#140).
 //!
-//! An SSH Ed25519 key is the same primitive `did:key` already encodes, so it can
-//! serve as both halves of the identity story:
-//!
-//! - the **public** key gives the human `did:key`. Published at
-//!   `github.com/<user>.keys`, that makes the binding checkable by anyone —
-//!   which is the useful part of "sign in with GitHub", not secret material.
-//! - the **private** key's 32-byte seed is the HKDF root every agent DID is
-//!   derived from, so the human and its agents share one real key rather than a
-//!   synthetic seed.
-//!
-//! Why the 32-byte seed and not the key file's bytes: the OpenSSH container is
-//! not a stable encoding of the key. Re-encrypting with a new passphrase, or
-//! rewriting the comment, changes the file while the key stays the same. Feeding
-//! the file to HKDF would silently change every derived agent DID; the seed is
-//! the key itself, so derivation is stable. (The OpenPGP path predates this and
-//! hashes its cert bytes — see [`crate::AgentIdentity::derive`] callers.)
-//!
-//! Hardware-backed `sk-ssh-ed25519` keys have no extractable private key, so
-//! they cannot be a derivation root and are rejected with that explanation.
+//! An SSH Ed25519 key encodes the same primitive as `did:key`: the public half
+//! gives a human DID, the private half roots agent derivation. See
+//! `docs/content/security.md` for how the sources compare.
 
 use ed25519_dalek::VerifyingKey;
 use ssh_key::{PrivateKey, PublicKey};
 
 use crate::IdentityError;
 
-/// Algorithm name of the only SSH key type usable here.
 pub const SSH_ED25519: &str = "ssh-ed25519";
 
 fn invalid(msg: impl Into<String>) -> IdentityError {
     IdentityError::Config(msg.into())
 }
 
-/// The 32-byte Ed25519 seed of an OpenSSH private key, for use as the HKDF root
-/// of every agent identity derived from this human.
+/// The key's 32-byte seed, used as the agent-derivation root.
 ///
-/// `passphrase` is required for an encrypted key and ignored otherwise.
+/// The seed rather than the file's bytes: re-encrypting with a new passphrase
+/// rewrites the file while the key is unchanged, so hashing the file would
+/// silently change every derived agent DID.
 pub fn seed_from_openssh_private_key(
     key_bytes: &[u8],
     passphrase: Option<&str>,
@@ -74,8 +58,7 @@ pub fn seed_from_openssh_private_key(
     Ok(keypair.private.to_bytes())
 }
 
-/// The Ed25519 public key of an OpenSSH public key line
-/// (`ssh-ed25519 AAAA... comment`), for the human `did:key`.
+/// The Ed25519 key behind an `ssh-ed25519 AAAA... comment` line.
 pub fn verifying_key_from_openssh_public_key(line: &str) -> Result<VerifyingKey, IdentityError> {
     let key = PublicKey::from_openssh(line.trim()).map_err(|err| {
         invalid(format!(
@@ -93,11 +76,9 @@ pub fn verifying_key_from_openssh_public_key(line: &str) -> Result<VerifyingKey,
         .map_err(|err| invalid(format!("SSH public key is not a valid Ed25519 point: {err}")))
 }
 
-/// Pick the first `ssh-ed25519` key out of an `authorized_keys`-style listing,
-/// such as the body of `https://github.com/<user>.keys`.
-///
-/// GitHub accounts commonly hold several keys of mixed algorithms, so selecting
-/// by algorithm — rather than taking the first line — is what makes this usable.
+/// First `ssh-ed25519` key in an `authorized_keys`-style listing, e.g.
+/// `github.com/<user>.keys`. Selects by algorithm because accounts commonly
+/// publish several keys of mixed types.
 pub fn first_ed25519_in_authorized_keys(listing: &str) -> Result<VerifyingKey, IdentityError> {
     let mut seen = 0usize;
     for line in listing.lines() {
@@ -116,8 +97,7 @@ pub fn first_ed25519_in_authorized_keys(listing: &str) -> Result<VerifyingKey, I
     )))
 }
 
-/// The public key matching an OpenSSH private key, so a human DID can be taken
-/// from the private key alone — no separate `.pub` file or network fetch.
+/// Public key of an OpenSSH private key, so a human DID needs no `.pub` file.
 pub fn verifying_key_from_openssh_private_key(
     key_bytes: &[u8],
     passphrase: Option<&str>,
@@ -132,9 +112,7 @@ mod tests {
     use super::*;
     use crate::encode_did_key;
 
-    /// A real OpenSSH key built from a fixed seed, so the fixture round-trips
-    /// through the library's own encoder instead of being a hand-written blob
-    /// that only looks like a key.
+    /// Fixed seed, encoded by the library itself so the fixture is a real key.
     const TEST_SEED: [u8; 32] = [
         0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
         0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
@@ -167,8 +145,7 @@ mod tests {
             .to_string()
     }
 
-    /// Encryption needs an RNG for its salt; the value does not affect what the
-    /// decrypted seed is, which is all these tests assert.
+    /// Only used for the encryption salt.
     fn rand_core_stub() -> impl ssh_key::rand_core::CryptoRng + ssh_key::rand_core::RngCore {
         ssh_key::rand_core::OsRng
     }
@@ -182,8 +159,7 @@ mod tests {
         assert_ne!(a, [0u8; 32]);
     }
 
-    /// The whole point of rooting in one key: the human DID taken from the
-    /// public half must match the private half the agents derive from.
+    /// One key, one human DID — whichever half it is read from.
     #[test]
     fn public_and_private_halves_agree() {
         let from_private =
@@ -225,9 +201,7 @@ mod tests {
         assert!(msg.contains("ssh-keygen -t ed25519"), "must say how to fix: {msg}");
     }
 
-    /// Real SSH keys are usually passphrase-protected, and an encrypted key must
-    /// yield the same seed as the plaintext one — otherwise adding a passphrase
-    /// would silently change every derived agent DID.
+    /// Adding a passphrase must not change the derivation root.
     #[test]
     fn encrypted_key_yields_the_same_seed_as_plaintext() {
         let encrypted = encrypted_key("correct horse");

--- a/crates/shadi_identity/src/ssh.rs
+++ b/crates/shadi_identity/src/ssh.rs
@@ -1,0 +1,266 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rooting SHADI identities in an SSH Ed25519 key (agntcy/shadi#140).
+//!
+//! An SSH Ed25519 key is the same primitive `did:key` already encodes, so it can
+//! serve as both halves of the identity story:
+//!
+//! - the **public** key gives the human `did:key`. Published at
+//!   `github.com/<user>.keys`, that makes the binding checkable by anyone —
+//!   which is the useful part of "sign in with GitHub", not secret material.
+//! - the **private** key's 32-byte seed is the HKDF root every agent DID is
+//!   derived from, so the human and its agents share one real key rather than a
+//!   synthetic seed.
+//!
+//! Why the 32-byte seed and not the key file's bytes: the OpenSSH container is
+//! not a stable encoding of the key. Re-encrypting with a new passphrase, or
+//! rewriting the comment, changes the file while the key stays the same. Feeding
+//! the file to HKDF would silently change every derived agent DID; the seed is
+//! the key itself, so derivation is stable. (The OpenPGP path predates this and
+//! hashes its cert bytes — see [`crate::AgentIdentity::derive`] callers.)
+//!
+//! Hardware-backed `sk-ssh-ed25519` keys have no extractable private key, so
+//! they cannot be a derivation root and are rejected with that explanation.
+
+use ed25519_dalek::VerifyingKey;
+use ssh_key::{PrivateKey, PublicKey};
+
+use crate::IdentityError;
+
+/// Algorithm name of the only SSH key type usable here.
+pub const SSH_ED25519: &str = "ssh-ed25519";
+
+fn invalid(msg: impl Into<String>) -> IdentityError {
+    IdentityError::Config(msg.into())
+}
+
+/// The 32-byte Ed25519 seed of an OpenSSH private key, for use as the HKDF root
+/// of every agent identity derived from this human.
+///
+/// `passphrase` is required for an encrypted key and ignored otherwise.
+pub fn seed_from_openssh_private_key(
+    key_bytes: &[u8],
+    passphrase: Option<&str>,
+) -> Result<[u8; 32], IdentityError> {
+    let text = std::str::from_utf8(key_bytes)
+        .map_err(|_| invalid("SSH private key is not valid UTF-8 (expected OpenSSH PEM)"))?;
+    let key = PrivateKey::from_openssh(text.trim()).map_err(|err| {
+        invalid(format!(
+            "failed to parse OpenSSH private key: {err}. Expected an unencrypted or \
+             passphrase-protected OpenSSH key (BEGIN OPENSSH PRIVATE KEY)"
+        ))
+    })?;
+
+    let key = if key.is_encrypted() {
+        let passphrase = passphrase.filter(|p| !p.is_empty()).ok_or_else(|| {
+            invalid("SSH private key is encrypted; a passphrase is required to derive from it")
+        })?;
+        key.decrypt(passphrase)
+            .map_err(|_| invalid("failed to decrypt SSH private key: wrong passphrase"))?
+    } else {
+        key
+    };
+
+    let keypair = key.key_data().ed25519().ok_or_else(|| {
+        invalid(format!(
+            "SSH key algorithm is {}, but only {SSH_ED25519} can root a SHADI identity. \
+             Hardware-backed sk-ssh-ed25519 keys expose no private key and cannot be used; \
+             generate one with: ssh-keygen -t ed25519",
+            key.algorithm()
+        ))
+    })?;
+
+    Ok(keypair.private.to_bytes())
+}
+
+/// The Ed25519 public key of an OpenSSH public key line
+/// (`ssh-ed25519 AAAA... comment`), for the human `did:key`.
+pub fn verifying_key_from_openssh_public_key(line: &str) -> Result<VerifyingKey, IdentityError> {
+    let key = PublicKey::from_openssh(line.trim()).map_err(|err| {
+        invalid(format!(
+            "failed to parse OpenSSH public key: {err}. Expected a line like \
+             '{SSH_ED25519} AAAA...'"
+        ))
+    })?;
+    let public = key.key_data().ed25519().ok_or_else(|| {
+        invalid(format!(
+            "SSH key algorithm is {}, but only {SSH_ED25519} maps to an Ed25519 did:key",
+            key.algorithm()
+        ))
+    })?;
+    VerifyingKey::from_bytes(&public.0)
+        .map_err(|err| invalid(format!("SSH public key is not a valid Ed25519 point: {err}")))
+}
+
+/// Pick the first `ssh-ed25519` key out of an `authorized_keys`-style listing,
+/// such as the body of `https://github.com/<user>.keys`.
+///
+/// GitHub accounts commonly hold several keys of mixed algorithms, so selecting
+/// by algorithm — rather than taking the first line — is what makes this usable.
+pub fn first_ed25519_in_authorized_keys(listing: &str) -> Result<VerifyingKey, IdentityError> {
+    let mut seen = 0usize;
+    for line in listing.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        seen += 1;
+        if line.starts_with(SSH_ED25519) {
+            return verifying_key_from_openssh_public_key(line);
+        }
+    }
+    Err(invalid(format!(
+        "no {SSH_ED25519} key found among {seen} published SSH key(s). SHADI's did:key is \
+         Ed25519-only; add one with: ssh-keygen -t ed25519"
+    )))
+}
+
+/// The public key matching an OpenSSH private key, so a human DID can be taken
+/// from the private key alone — no separate `.pub` file or network fetch.
+pub fn verifying_key_from_openssh_private_key(
+    key_bytes: &[u8],
+    passphrase: Option<&str>,
+) -> Result<VerifyingKey, IdentityError> {
+    let seed = seed_from_openssh_private_key(key_bytes, passphrase)?;
+    let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+    Ok(signing.verifying_key())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encode_did_key;
+
+    /// A real OpenSSH key built from a fixed seed, so the fixture round-trips
+    /// through the library's own encoder instead of being a hand-written blob
+    /// that only looks like a key.
+    const TEST_SEED: [u8; 32] = [
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
+        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
+        0x7f, 0x60,
+    ];
+
+    fn plain_key() -> String {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&TEST_SEED);
+        PrivateKey::from(keypair)
+            .to_openssh(ssh_key::LineEnding::LF)
+            .expect("encode openssh")
+            .to_string()
+    }
+
+    fn plain_public_line() -> String {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&TEST_SEED);
+        PrivateKey::from(keypair)
+            .public_key()
+            .to_openssh()
+            .expect("encode public")
+    }
+
+    fn encrypted_key(passphrase: &str) -> String {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&TEST_SEED);
+        PrivateKey::from(keypair)
+            .encrypt(&mut rand_core_stub(), passphrase)
+            .expect("encrypt")
+            .to_openssh(ssh_key::LineEnding::LF)
+            .expect("encode encrypted")
+            .to_string()
+    }
+
+    /// Encryption needs an RNG for its salt; the value does not affect what the
+    /// decrypted seed is, which is all these tests assert.
+    fn rand_core_stub() -> impl ssh_key::rand_core::CryptoRng + ssh_key::rand_core::RngCore {
+        ssh_key::rand_core::OsRng
+    }
+
+    #[test]
+    fn seed_is_32_bytes_and_stable() {
+        let a = seed_from_openssh_private_key(plain_key().as_bytes(), None).expect("parse");
+        let b = seed_from_openssh_private_key(plain_key().as_bytes(), None).expect("parse");
+        assert_eq!(a.len(), 32);
+        assert_eq!(a, b, "derivation root must be deterministic");
+        assert_ne!(a, [0u8; 32]);
+    }
+
+    /// The whole point of rooting in one key: the human DID taken from the
+    /// public half must match the private half the agents derive from.
+    #[test]
+    fn public_and_private_halves_agree() {
+        let from_private =
+            verifying_key_from_openssh_private_key(plain_key().as_bytes(), None).expect("private");
+        let from_public =
+            verifying_key_from_openssh_public_key(&plain_public_line()).expect("public");
+        assert_eq!(from_private.as_bytes(), from_public.as_bytes());
+        assert!(encode_did_key(&from_private).starts_with("did:key:z"));
+    }
+
+    #[test]
+    fn agents_derived_from_the_ssh_seed_are_distinct_and_stable() {
+        let seed = seed_from_openssh_private_key(plain_key().as_bytes(), None).unwrap();
+        let a1 = crate::AgentIdentity::derive(&seed, "claude-code").unwrap();
+        let a2 = crate::AgentIdentity::derive(&seed, "claude-code").unwrap();
+        let b = crate::AgentIdentity::derive(&seed, "codex").unwrap();
+        assert_eq!(a1.did(), a2.did(), "same name must re-derive the same DID");
+        assert_ne!(a1.did(), b.did(), "different agents must differ");
+    }
+
+    #[test]
+    fn algorithm_selection_skips_non_ed25519_keys() {
+        let listing = format!(
+            "ssh-rsa AAAAB3NzaC1yc2EAAAA notreal\n# a comment\n{}\n",
+            plain_public_line()
+        );
+        let vk = first_ed25519_in_authorized_keys(&listing).expect("should find the ed25519 key");
+        let expected =
+            verifying_key_from_openssh_private_key(plain_key().as_bytes(), None).unwrap();
+        assert_eq!(vk.as_bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn listing_without_an_ed25519_key_explains_what_to_do() {
+        let err = first_ed25519_in_authorized_keys("ssh-rsa AAAAB3NzaC1yc2EAAAA nope\n")
+            .expect_err("must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("no ssh-ed25519 key found"), "{msg}");
+        assert!(msg.contains("ssh-keygen -t ed25519"), "must say how to fix: {msg}");
+    }
+
+    /// Real SSH keys are usually passphrase-protected, and an encrypted key must
+    /// yield the same seed as the plaintext one — otherwise adding a passphrase
+    /// would silently change every derived agent DID.
+    #[test]
+    fn encrypted_key_yields_the_same_seed_as_plaintext() {
+        let encrypted = encrypted_key("correct horse");
+        let from_encrypted =
+            seed_from_openssh_private_key(encrypted.as_bytes(), Some("correct horse"))
+                .expect("decrypt with the right passphrase");
+        let from_plain = seed_from_openssh_private_key(plain_key().as_bytes(), None).unwrap();
+        assert_eq!(
+            from_encrypted, from_plain,
+            "a passphrase must not change the derivation root"
+        );
+    }
+
+    #[test]
+    fn encrypted_key_without_or_with_a_wrong_passphrase_is_refused() {
+        let encrypted = encrypted_key("correct horse");
+
+        let missing = seed_from_openssh_private_key(encrypted.as_bytes(), None)
+            .expect_err("must not silently succeed");
+        assert!(missing.to_string().contains("passphrase is required"), "{missing}");
+
+        // An empty passphrase is treated as absent rather than tried.
+        assert!(seed_from_openssh_private_key(encrypted.as_bytes(), Some("")).is_err());
+
+        let wrong = seed_from_openssh_private_key(encrypted.as_bytes(), Some("nope"))
+            .expect_err("wrong passphrase must fail");
+        assert!(wrong.to_string().contains("wrong passphrase"), "{wrong}");
+    }
+
+    #[test]
+    fn garbage_input_is_rejected() {
+        assert!(seed_from_openssh_private_key(b"not a key", None).is_err());
+        assert!(verifying_key_from_openssh_public_key("nonsense").is_err());
+        assert!(first_ed25519_in_authorized_keys("").is_err());
+    }
+}

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -63,5 +63,7 @@ windows-sys = { version = "0.61", features = [
 sequoia-openpgp = { version = "2.2", default-features = false, features = ["crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto", "compression-deflate", "compression-bzip2"] }
 
 [dev-dependencies]
+# Building OpenSSH key fixtures for the SSH identity tests (agntcy/shadi#140).
+ssh-key = { version = "0.6", default-features = false, features = ["alloc", "ed25519"] }
 tempfile = "3.27"
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../shadi_identity" }

--- a/crates/shadictl/src/cli_types.rs
+++ b/crates/shadictl/src/cli_types.rs
@@ -150,6 +150,8 @@ pub(crate) enum Commands {
     DidFromGpg(DidFromGpgArgs),
     #[command(name = "did-from-github")]
     DidFromGitHub(DidFromGitHubArgs),
+    #[command(name = "did-from-ssh")]
+    DidFromSsh(DidFromSshArgs),
     #[command(name = "get-secret")]
     GetSecret(GetSecretArgs),
     #[command(name = "derive-agent-did")]
@@ -816,14 +818,67 @@ pub(crate) struct DidFromGpgArgs {
     pub(crate) out_file: PathBuf,
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GitHubKeyType {
+    /// `/users/<u>/gpg_keys`; needs GH_TOKEN and an Ed25519 GPG key.
+    Gpg,
+    /// `github.com/<u>.keys`; unauthenticated, picks the first ssh-ed25519 key.
+    Ssh,
+}
+
 #[derive(Parser, Debug)]
-#[command(name = "did-from-github", about = "Create did:key DID document from a GitHub GPG public key")]
+#[command(
+    name = "did-from-github",
+    about = "Create did:key DID document from a public key published on GitHub"
+)]
 pub(crate) struct DidFromGitHubArgs {
     #[arg(long = "user", value_name = "USERNAME")]
     pub(crate) user: String,
 
+    /// Which published key to read. `ssh` needs no token and is the only option
+    /// that works when the account's GPG key is not Ed25519.
+    #[arg(long = "key-type", value_enum, default_value = "gpg")]
+    pub(crate) key_type: GitHubKeyType,
+
     #[arg(long = "out", value_name = "FILE")]
     pub(crate) out_file: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "did-from-ssh",
+    about = "Create did:key DID document from an SSH Ed25519 key (public line or private key)"
+)]
+pub(crate) struct DidFromSshArgs {
+    /// Secret-store reference holding the key.
+    #[arg(
+        short = 'k',
+        long = "key",
+        value_name = "SECRET",
+        required_unless_present = "input",
+        conflicts_with = "input"
+    )]
+    pub(crate) key_ref: Option<String>,
+
+    /// File holding the key. An `ssh-ed25519 AAAA...` line or an OpenSSH private
+    /// key; which one it is is detected from the content.
+    #[arg(
+        short = 'i',
+        long = "in",
+        value_name = "FILE",
+        required_unless_present = "key_ref",
+        conflicts_with = "key_ref"
+    )]
+    pub(crate) input: Option<PathBuf>,
+
+    /// Secret-store reference holding the passphrase, when the key is an
+    /// encrypted private key. Never passed as a literal: an argument would be
+    /// visible to anyone running `ps`. `SHADI_SSH_PASSPHRASE` is also honoured.
+    #[arg(long = "passphrase-secret", value_name = "SECRET")]
+    pub(crate) passphrase_secret: Option<String>,
+
+    #[arg(short = 'o', long = "out", value_name = "FILE", default_value = "did-document.json")]
+    pub(crate) out_file: PathBuf,
 }
 
 #[derive(Parser, Debug)]
@@ -868,6 +923,9 @@ pub(crate) struct DeriveAgentDidArgs {
 pub(crate) enum HumanIdentitySource {
     Gpg,
     Seed,
+    /// An OpenSSH Ed25519 private key; its 32-byte seed is the HKDF root
+    /// (agntcy/shadi#140).
+    Ssh,
 }
 
 #[derive(Parser, Debug)]
@@ -900,6 +958,12 @@ pub(crate) struct DeriveAgentIdentityArgs {
     #[arg(long = "prefix", value_name = "PATH", default_value = "agent_keys")]
     pub(crate) prefix: String,
 
+
+    /// Secret-store reference holding the SSH key passphrase (`--source ssh`
+    /// with an encrypted key). Never a literal argument — that would be visible
+    /// via `ps`. `SHADI_SSH_PASSPHRASE` is also honoured.
+    #[arg(long = "ssh-passphrase-secret", value_name = "SECRET")]
+    pub(crate) ssh_passphrase_secret: Option<String>,
     #[arg(long = "human-did-key", value_name = "SECRET")]
     pub(crate) human_did_key: Option<String>,
 
@@ -936,6 +1000,12 @@ pub(crate) struct VerifyAgentIdentityArgs {
 
     #[arg(long = "prefix", value_name = "PATH", default_value = "agent_keys")]
     pub(crate) prefix: String,
+
+    /// Secret-store reference holding the SSH key passphrase (`--source ssh`
+    /// with an encrypted key). Never a literal argument — that would be visible
+    /// via `ps`. `SHADI_SSH_PASSPHRASE` is also honoured.
+    #[arg(long = "ssh-passphrase-secret", value_name = "SECRET")]
+    pub(crate) ssh_passphrase_secret: Option<String>,
 
     #[arg(long = "public-key-key", value_name = "SECRET")]
     pub(crate) public_key_key: Option<String>,

--- a/crates/shadictl/src/identity_command.rs
+++ b/crates/shadictl/src/identity_command.rs
@@ -547,41 +547,51 @@ fn github_api_get_gpg_keys(_user: &str) -> Result<String, String> {
         .ok_or_else(|| "test github payload not set".to_string())
 }
 
+/// One GET against GitHub, shared by both key fetchers.
+///
+/// `token` is `Some` only for the authenticated REST API; `github.com/<u>.keys`
+/// is public and deliberately unauthenticated.
 #[cfg(not(test))]
-fn github_api_get_gpg_keys(user: &str) -> Result<String, String> {
-    let token = std::env::var("GH_TOKEN")
-        .or_else(|_| std::env::var("GITHUB_TOKEN"))
-        .map_err(|_| "GH_TOKEN or GITHUB_TOKEN must be set for GitHub API".to_string())?;
-
-    let url = format!("https://api.github.com/users/{}/gpg_keys", user);
+fn github_get_text(url: &str, token: Option<String>) -> Result<String, String> {
     let mut headers = HeaderMap::new();
-    headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.github+json"));
     headers.insert(USER_AGENT, HeaderValue::from_static("shadi-shadictl"));
-    let auth = format!("Bearer {}", token);
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(&auth).map_err(|_| "invalid GitHub token".to_string())?,
-    );
+    if let Some(token) = token {
+        headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.github+json"));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", token))
+                .map_err(|_| "invalid GitHub token".to_string())?,
+        );
+    }
 
-    let client = Client::builder()
+    let response = Client::builder()
         .default_headers(headers)
         .build()
-        .map_err(|err| format!("failed to build HTTP client: {}", err))?;
-
-    let response = client
+        .map_err(|err| format!("failed to build HTTP client: {}", err))?
         .get(url)
         .send()
-        .map_err(|err| format!("GitHub API request failed: {}", err))?;
+        .map_err(|err| format!("GitHub request failed: {}", err))?;
 
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().unwrap_or_default();
-        return Err(format!("GitHub API error {}: {}", status, body));
+        return Err(format!("GitHub error {} for {}: {}", status, url, body));
     }
 
     response
         .text()
         .map_err(|err| format!("failed to read GitHub response: {}", err))
+}
+
+#[cfg(not(test))]
+fn github_api_get_gpg_keys(user: &str) -> Result<String, String> {
+    let token = std::env::var("GH_TOKEN")
+        .or_else(|_| std::env::var("GITHUB_TOKEN"))
+        .map_err(|_| "GH_TOKEN or GITHUB_TOKEN must be set for GitHub API".to_string())?;
+    github_get_text(
+        &format!("https://api.github.com/users/{}/gpg_keys", user),
+        Some(token),
+    )
 }
 
 pub(crate) fn derive_agent_keypair(secret_key: &[u8], agent_name: &str) -> Result<(Vec<u8>, Vec<u8>), String> {
@@ -690,23 +700,7 @@ pub(crate) fn run_did_from_ssh(args: DidFromSshArgs) -> Result<(), String> {
 /// so anyone can verify a human DID against the account that claims it.
 #[cfg(not(test))]
 fn fetch_github_ssh_keys(user: &str) -> Result<String, String> {
-    let url = format!("https://github.com/{}.keys", user);
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("shadi-shadictl"));
-    let client = Client::builder()
-        .default_headers(headers)
-        .build()
-        .map_err(|err| format!("failed to build HTTP client: {}", err))?;
-    let response = client
-        .get(&url)
-        .send()
-        .map_err(|err| format!("GitHub request failed: {}", err))?;
-    if !response.status().is_success() {
-        return Err(format!("GitHub returned {} for {}", response.status(), url));
-    }
-    response
-        .text()
-        .map_err(|err| format!("failed to read GitHub response: {}", err))
+    github_get_text(&format!("https://github.com/{}.keys", user), None)
 }
 
 #[cfg(test)]

--- a/crates/shadictl/src/identity_command.rs
+++ b/crates/shadictl/src/identity_command.rs
@@ -547,10 +547,8 @@ fn github_api_get_gpg_keys(_user: &str) -> Result<String, String> {
         .ok_or_else(|| "test github payload not set".to_string())
 }
 
-/// One GET against GitHub, shared by both key fetchers.
-///
-/// `token` is `Some` only for the authenticated REST API; `github.com/<u>.keys`
-/// is public and deliberately unauthenticated.
+/// One GET against GitHub. `token` is `Some` only for the REST API;
+/// `github.com/<u>.keys` is public.
 #[cfg(not(test))]
 fn github_get_text(url: &str, token: Option<String>) -> Result<String, String> {
     let mut headers = HeaderMap::new();
@@ -634,8 +632,7 @@ pub(crate) fn extract_ed25519_public_key(openpgp_bytes: &[u8]) -> Result<Vec<u8>
     Err("no Ed25519 public key found in OpenPGP certificate".to_string())
 }
 
-/// Resolve an SSH key passphrase without ever taking it as a CLI argument,
-/// which would expose it to anyone able to run `ps`.
+/// Never a CLI argument: that would be visible via `ps`.
 pub(crate) fn resolve_ssh_passphrase(secret_ref: Option<&str>) -> Result<Option<String>, String> {
     if let Some(secret_ref) = secret_ref {
         let store = default_secret_store();
@@ -651,8 +648,7 @@ pub(crate) fn resolve_ssh_passphrase(secret_ref: Option<&str>) -> Result<Option<
     }
 }
 
-/// Read an OpenSSH private key from the secret store or a file and reduce it to
-/// the 32-byte Ed25519 seed used as the agent-derivation root (agntcy/shadi#140).
+/// Reduce an OpenSSH private key to the seed agent derivation roots in.
 pub(crate) fn read_ssh_seed_input(
     label: &str,
     secret_key: Option<&str>,
@@ -666,10 +662,8 @@ pub(crate) fn read_ssh_seed_input(
     Ok(seed.to_vec())
 }
 
-/// `did-from-ssh`: build a human `did:key` from an SSH Ed25519 key.
-///
-/// The input may be a public `ssh-ed25519 AAAA...` line or an OpenSSH private
-/// key; which one is detected from the content, so there is no flag to get wrong.
+/// Human `did:key` from an SSH key. Public line or private key — detected from
+/// the content, so there is no flag to get wrong.
 pub(crate) fn run_did_from_ssh(args: DidFromSshArgs) -> Result<(), String> {
     let raw = read_seed_input("--key", args.key_ref.as_deref(), args.input.as_ref())?;
     let text = String::from_utf8_lossy(&raw);
@@ -694,10 +688,7 @@ pub(crate) fn run_did_from_ssh(args: DidFromSshArgs) -> Result<(), String> {
     Ok(())
 }
 
-/// `github.com/<user>.keys` — the published SSH keys.
-///
-/// Unauthenticated on purpose: unlike `/users/<u>/gpg_keys` this needs no token,
-/// so anyone can verify a human DID against the account that claims it.
+/// `github.com/<user>.keys`. Unauthenticated, unlike `/users/<u>/gpg_keys`.
 #[cfg(not(test))]
 fn fetch_github_ssh_keys(user: &str) -> Result<String, String> {
     github_get_text(&format!("https://github.com/{}.keys", user), None)

--- a/crates/shadictl/src/identity_command.rs
+++ b/crates/shadictl/src/identity_command.rs
@@ -50,6 +50,16 @@ pub(crate) fn run_did_from_github_command(parsed: DidFromGitHubArgs) -> ExitCode
     }
 }
 
+pub(crate) fn run_did_from_ssh_command(parsed: DidFromSshArgs) -> ExitCode {
+    match run_did_from_ssh(parsed) {
+        Ok(()) => ExitCode::from(0),
+        Err(err) => {
+            eprintln!("{}", err);
+            ExitCode::from(2)
+        }
+    }
+}
+
 pub(crate) fn run_did_from_gpg_command(parsed: DidFromGpgArgs) -> ExitCode {
     match run_did_from_gpg(parsed) {
         Ok(()) => ExitCode::from(0),
@@ -77,8 +87,18 @@ pub(crate) fn run_did_from_gpg(args: DidFromGpgArgs) -> Result<(), String> {
 }
 
 pub(crate) fn run_did_from_github(args: DidFromGitHubArgs) -> Result<(), String> {
-    let public_key = fetch_github_gpg_key(&args.user)?;
-    let pkey = extract_ed25519_public_key(&public_key)?;
+    let pkey = match args.key_type {
+        GitHubKeyType::Gpg => {
+            let public_key = fetch_github_gpg_key(&args.user)?;
+            extract_ed25519_public_key(&public_key)?
+        }
+        GitHubKeyType::Ssh => {
+            let listing = fetch_github_ssh_keys(&args.user)?;
+            let vk = shadi_identity::ssh::first_ed25519_in_authorized_keys(&listing)
+                .map_err(|err| err.to_string())?;
+            vk.as_bytes().to_vec()
+        }
+    };
 
     let (did, vm_id, doc) = build_did_document(&pkey)?;
     let output = serde_json::to_string_pretty(&doc).map_err(|err| err.to_string())?;
@@ -177,6 +197,12 @@ pub(crate) fn run_derive_agent_identity(args: DeriveAgentIdentityArgs) -> Result
         HumanIdentitySource::Seed => {
             read_seed_input("--human-secret", args.human_secret.as_deref(), args.input.as_ref())?
         }
+        HumanIdentitySource::Ssh => read_ssh_seed_input(
+            "--human-secret",
+            args.human_secret.as_deref(),
+            args.input.as_ref(),
+            args.ssh_passphrase_secret.as_deref(),
+        )?,
     };
 
     let human_did = match args.human_did_key.as_deref() {
@@ -241,6 +267,12 @@ pub(crate) fn run_verify_agent_identity(args: VerifyAgentIdentityArgs) -> Result
         HumanIdentitySource::Seed => {
             read_seed_input("--human-secret", args.human_secret.as_deref(), args.input.as_ref())?
         }
+        HumanIdentitySource::Ssh => read_ssh_seed_input(
+            "--human-secret",
+            args.human_secret.as_deref(),
+            args.input.as_ref(),
+            args.ssh_passphrase_secret.as_deref(),
+        )?,
     };
 
     let (_private_key, expected_public_key) = derive_agent_keypair(&seed_material, &args.agent_name)?;
@@ -590,4 +622,97 @@ pub(crate) fn extract_ed25519_public_key(openpgp_bytes: &[u8]) -> Result<Vec<u8>
     }
 
     Err("no Ed25519 public key found in OpenPGP certificate".to_string())
+}
+
+/// Resolve an SSH key passphrase without ever taking it as a CLI argument,
+/// which would expose it to anyone able to run `ps`.
+pub(crate) fn resolve_ssh_passphrase(secret_ref: Option<&str>) -> Result<Option<String>, String> {
+    if let Some(secret_ref) = secret_ref {
+        let store = default_secret_store();
+        let secret = store
+            .get(secret_ref)
+            .map_err(|_| format!("keychain lookup failed for {}", secret_ref))?;
+        let bytes = secret.expose(|b| b.to_vec());
+        return Ok(Some(secret_bytes_to_utf8(&bytes)?));
+    }
+    match std::env::var("SHADI_SSH_PASSPHRASE") {
+        Ok(value) if !value.is_empty() => Ok(Some(value)),
+        _ => Ok(None),
+    }
+}
+
+/// Read an OpenSSH private key from the secret store or a file and reduce it to
+/// the 32-byte Ed25519 seed used as the agent-derivation root (agntcy/shadi#140).
+pub(crate) fn read_ssh_seed_input(
+    label: &str,
+    secret_key: Option<&str>,
+    input: Option<&PathBuf>,
+    passphrase_secret: Option<&str>,
+) -> Result<Vec<u8>, String> {
+    let key_bytes = read_seed_input(label, secret_key, input)?;
+    let passphrase = resolve_ssh_passphrase(passphrase_secret)?;
+    let seed = shadi_identity::ssh::seed_from_openssh_private_key(&key_bytes, passphrase.as_deref())
+        .map_err(|err| err.to_string())?;
+    Ok(seed.to_vec())
+}
+
+/// `did-from-ssh`: build a human `did:key` from an SSH Ed25519 key.
+///
+/// The input may be a public `ssh-ed25519 AAAA...` line or an OpenSSH private
+/// key; which one is detected from the content, so there is no flag to get wrong.
+pub(crate) fn run_did_from_ssh(args: DidFromSshArgs) -> Result<(), String> {
+    let raw = read_seed_input("--key", args.key_ref.as_deref(), args.input.as_ref())?;
+    let text = String::from_utf8_lossy(&raw);
+
+    let vk = if text.contains("OPENSSH PRIVATE KEY") {
+        let passphrase = resolve_ssh_passphrase(args.passphrase_secret.as_deref())?;
+        shadi_identity::ssh::verifying_key_from_openssh_private_key(&raw, passphrase.as_deref())
+            .map_err(|err| err.to_string())?
+    } else {
+        shadi_identity::ssh::first_ed25519_in_authorized_keys(&text)
+            .map_err(|err| err.to_string())?
+    };
+
+    let (did, vm_id, doc) = build_did_document(vk.as_bytes())?;
+    let output = serde_json::to_string_pretty(&doc).map_err(|err| err.to_string())?;
+    std::fs::write(&args.out_file, format!("{}\n", output))
+        .map_err(|err| format!("failed to write {}: {}", args.out_file.display(), err))?;
+
+    println!("Wrote DID Document: {}", args.out_file.display());
+    println!("DID: {}", did);
+    println!("Verification Method ID: {}", vm_id);
+    Ok(())
+}
+
+/// `github.com/<user>.keys` — the published SSH keys.
+///
+/// Unauthenticated on purpose: unlike `/users/<u>/gpg_keys` this needs no token,
+/// so anyone can verify a human DID against the account that claims it.
+#[cfg(not(test))]
+fn fetch_github_ssh_keys(user: &str) -> Result<String, String> {
+    let url = format!("https://github.com/{}.keys", user);
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static("shadi-shadictl"));
+    let client = Client::builder()
+        .default_headers(headers)
+        .build()
+        .map_err(|err| format!("failed to build HTTP client: {}", err))?;
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|err| format!("GitHub request failed: {}", err))?;
+    if !response.status().is_success() {
+        return Err(format!("GitHub returned {} for {}", response.status(), url));
+    }
+    response
+        .text()
+        .map_err(|err| format!("failed to read GitHub response: {}", err))
+}
+
+#[cfg(test)]
+fn fetch_github_ssh_keys(_user: &str) -> Result<String, String> {
+    let guard = test_github_payload_slot().lock().expect("github payload lock");
+    guard
+        .clone()
+        .ok_or_else(|| "test github payload not set".to_string())
 }

--- a/crates/shadictl/src/main.rs
+++ b/crates/shadictl/src/main.rs
@@ -205,6 +205,7 @@ fn run_named_command(command: Commands) -> ExitCode {
         Commands::SlimMas(command) => run_slim_mas_command(command),
         Commands::DidFromGpg(command) => run_did_from_gpg_command(command),
         Commands::DidFromGitHub(command) => run_did_from_github_command(command),
+        Commands::DidFromSsh(command) => run_did_from_ssh_command(command),
         Commands::GetSecret(command) => run_get_secret_command(command),
         Commands::DeriveAgentDid(command) => run_derive_agent_did_command(command),
         Commands::DeriveAgentIdentity(command) => run_derive_agent_identity_command(command),

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -3188,6 +3188,169 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(of(&pub_out), expected_did, "halves must agree");
     }
 
+    /// `--source ssh` is the headline of agntcy/shadi#140: agents rooted in the
+    /// SSH key rather than a synthetic seed, and re-derivable.
+    #[test]
+    fn run_cli_derive_and_verify_agent_identity_from_ssh_key() {
+        let (pem, _public_line, _did) = ssh_test_key();
+        let dir = temp_dir();
+        let key_path = dir.path().join("id_ed25519");
+        std::fs::write(&key_path, &pem).expect("write key");
+
+        let agent = unique_key("ssh-rooted-agent");
+        let prefix = unique_key("ssh-agents");
+
+        let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+            ssh_passphrase_secret: None,
+            source: HumanIdentitySource::Ssh,
+            human_secret: None,
+            input: Some(key_path.clone()),
+            agent_names: vec![agent.clone()],
+            prefix: prefix.clone(),
+            human_did_key: None,
+            out_dir: None,
+        });
+        assert_eq!(code, ExitCode::from(0));
+
+        let stored_did = test_store_get(&format!("{prefix}/{agent}/did")).expect("stored did");
+        let did = String::from_utf8(stored_did).expect("utf8");
+        assert!(did.starts_with("did:key:z"), "unexpected did: {did}");
+
+        // Verification must re-derive the same key from the same SSH root.
+        let code = run_verify_agent_identity_command(VerifyAgentIdentityArgs {
+            ssh_passphrase_secret: None,
+            source: HumanIdentitySource::Ssh,
+            human_secret: None,
+            input: Some(key_path),
+            agent_name: agent,
+            prefix,
+            public_key_key: None,
+            did_key: None,
+            human_did_key: None,
+            require_human_binding: false,
+        });
+        assert_eq!(code, ExitCode::from(0));
+    }
+
+    /// The same SSH key must not derive the same agent as `--source seed` would:
+    /// `ssh` roots in the key's 32-byte seed, `seed` in the file's bytes.
+    #[test]
+    fn run_cli_ssh_and_seed_sources_are_not_interchangeable() {
+        let (pem, _pub_line, _did) = ssh_test_key();
+        let dir = temp_dir();
+        let key_path = dir.path().join("id_ed25519");
+        std::fs::write(&key_path, &pem).expect("write key");
+
+        let mut dids = Vec::new();
+        for source in [HumanIdentitySource::Ssh, HumanIdentitySource::Seed] {
+            let agent = unique_key("src-compare-agent");
+            let prefix = unique_key("src-compare");
+            let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+                ssh_passphrase_secret: None,
+                source,
+                human_secret: None,
+                input: Some(key_path.clone()),
+                agent_names: vec![agent.clone()],
+                prefix: prefix.clone(),
+                human_did_key: None,
+                out_dir: None,
+            });
+            assert_eq!(code, ExitCode::from(0));
+            dids.push(
+                String::from_utf8(test_store_get(&format!("{prefix}/{agent}/did")).unwrap())
+                    .unwrap(),
+            );
+        }
+        assert_ne!(dids[0], dids[1], "sources must not collide");
+    }
+
+    /// `SHADI_SSH_PASSPHRASE` is the other accepted source, for shells that
+    /// already hold it. Serialized against other env-mutating tests via the
+    /// github payload lock, which this module already uses as a process mutex.
+    #[test]
+    fn run_cli_did_from_ssh_reads_passphrase_from_the_environment() {
+        let _guard = github_payload_lock().lock().expect("env lock");
+        let (pem, _pub_line, expected_did) = ssh_test_key();
+        let encrypted = {
+            let key = ssh_key::PrivateKey::from_openssh(&pem).expect("parse");
+            key.encrypt(&mut ssh_key::rand_core::OsRng, "envpass")
+                .expect("encrypt")
+                .to_openssh(ssh_key::LineEnding::LF)
+                .expect("encode")
+                .to_string()
+        };
+
+        let dir = temp_dir();
+        let key_path = dir.path().join("enc_env");
+        std::fs::write(&key_path, &encrypted).expect("write key");
+        let out = dir.path().join("from-env.json");
+
+        let previous = std::env::var_os("SHADI_SSH_PASSPHRASE");
+        std::env::set_var("SHADI_SSH_PASSPHRASE", "envpass");
+        let code = run_did_from_ssh_command(DidFromSshArgs {
+            key_ref: None,
+            input: Some(key_path),
+            passphrase_secret: None,
+            out_file: out.clone(),
+        });
+        match previous {
+            Some(value) => std::env::set_var("SHADI_SSH_PASSPHRASE", value),
+            None => std::env::remove_var("SHADI_SSH_PASSPHRASE"),
+        }
+
+        assert_eq!(code, ExitCode::from(0));
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(doc["id"].as_str(), Some(expected_did.as_str()));
+    }
+
+    /// Passphrases come from the secret store, never argv (visible via `ps`).
+    #[test]
+    fn run_cli_did_from_ssh_reads_passphrase_from_the_secret_store() {
+        let (pem, _pub_line, expected_did) = ssh_test_key();
+        let encrypted = {
+            let key = ssh_key::PrivateKey::from_openssh(&pem).expect("parse");
+            key.encrypt(&mut ssh_key::rand_core::OsRng, "s3cret")
+                .expect("encrypt")
+                .to_openssh(ssh_key::LineEnding::LF)
+                .expect("encode")
+                .to_string()
+        };
+
+        let dir = temp_dir();
+        let key_path = dir.path().join("enc_key");
+        std::fs::write(&key_path, &encrypted).expect("write key");
+        let out = dir.path().join("from-encrypted.json");
+
+        let pass_key = unique_key("ssh-passphrase");
+        test_store_put(&pass_key, b"s3cret");
+
+        let code = run_did_from_ssh_command(DidFromSshArgs {
+            key_ref: None,
+            input: Some(key_path.clone()),
+            passphrase_secret: Some(pass_key),
+            out_file: out.clone(),
+        });
+        assert_eq!(code, ExitCode::from(0));
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(
+            doc["id"].as_str(),
+            Some(expected_did.as_str()),
+            "an encrypted key must yield the same DID as its plaintext form"
+        );
+
+        // Without the passphrase the same key is refused.
+        let code = run_did_from_ssh_command(DidFromSshArgs {
+            key_ref: None,
+            input: Some(key_path),
+            passphrase_secret: None,
+            out_file: dir.path().join("nope.json"),
+        });
+        assert_eq!(code, ExitCode::from(2));
+    }
+
     #[test]
     fn run_cli_did_from_ssh_rejects_a_non_key_file() {
         let dir = temp_dir();

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -3085,8 +3085,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(run_cli(cli), ExitCode::from(2));
     }
 
-    /// A fixed OpenSSH Ed25519 key and the DID it must produce, so the
-    /// SSH-rooted identity path (agntcy/shadi#140) is pinned end to end.
+    /// Fixed key plus the DID it must produce.
     fn ssh_test_key() -> (String, String, String) {
         let seed = [7u8; 32];
         let keypair = ssh_key::private::Ed25519Keypair::from_seed(&seed);
@@ -3146,8 +3145,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(run_cli(cli), ExitCode::from(2));
     }
 
-    /// The private and public halves of one SSH key must yield the same human
-    /// DID — that shared root is what binds a human to its agents.
+    /// One key, one human DID — whichever half it is read from.
     #[test]
     fn run_cli_did_from_ssh_agrees_across_key_halves() {
         let (pem, public_line, expected_did) = ssh_test_key();
@@ -3188,8 +3186,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(of(&pub_out), expected_did, "halves must agree");
     }
 
-    /// `--source ssh` is the headline of agntcy/shadi#140: agents rooted in the
-    /// SSH key rather than a synthetic seed, and re-derivable.
+    /// Agents rooted in the SSH key, and re-derivable from it.
     #[test]
     fn run_cli_derive_and_verify_agent_identity_from_ssh_key() {
         let (pem, _public_line, _did) = ssh_test_key();
@@ -3232,8 +3229,8 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(code, ExitCode::from(0));
     }
 
-    /// The same SSH key must not derive the same agent as `--source seed` would:
-    /// `ssh` roots in the key's 32-byte seed, `seed` in the file's bytes.
+    /// `ssh` roots in the key's seed, `seed` in the file's bytes — so the same
+    /// file must not yield the same agent.
     #[test]
     fn run_cli_ssh_and_seed_sources_are_not_interchangeable() {
         let (pem, _pub_line, _did) = ssh_test_key();
@@ -3264,9 +3261,8 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_ne!(dids[0], dids[1], "sources must not collide");
     }
 
-    /// `SHADI_SSH_PASSPHRASE` is the other accepted source, for shells that
-    /// already hold it. Serialized against other env-mutating tests via the
-    /// github payload lock, which this module already uses as a process mutex.
+    /// The env source. Takes the github payload lock only as a process mutex,
+    /// since this mutates a shared env var.
     #[test]
     fn run_cli_did_from_ssh_reads_passphrase_from_the_environment() {
         let _guard = github_payload_lock().lock().expect("env lock");

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -2270,6 +2270,7 @@ members = [{ did = "did:key:zA", role = "human" }]
     #[test]
     fn run_cli_derive_agent_identity_missing_seed_returns_error() {
         let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+            ssh_passphrase_secret: None,
             source: HumanIdentitySource::Seed,
             human_secret: None,
             input: None,
@@ -2288,6 +2289,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         test_store_put(&seed_key, b"seed-material");
 
         let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+            ssh_passphrase_secret: None,
             source: HumanIdentitySource::Seed,
             human_secret: Some(seed_key),
             input: None,
@@ -2309,6 +2311,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         std::fs::write(&out_dir, b"not a directory").expect("write blocker file");
 
         let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+            ssh_passphrase_secret: None,
             source: HumanIdentitySource::Seed,
             human_secret: Some(seed_key),
             input: None,
@@ -2333,6 +2336,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         test_store_fail_put(&private_key);
 
         let code = run_derive_agent_identity_command(DeriveAgentIdentityArgs {
+            ssh_passphrase_secret: None,
             source: HumanIdentitySource::Seed,
             human_secret: Some(seed_key),
             input: None,
@@ -3081,6 +3085,123 @@ members = [{ did = "did:key:zA", role = "human" }]
         assert_eq!(run_cli(cli), ExitCode::from(2));
     }
 
+    /// A fixed OpenSSH Ed25519 key and the DID it must produce, so the
+    /// SSH-rooted identity path (agntcy/shadi#140) is pinned end to end.
+    fn ssh_test_key() -> (String, String, String) {
+        let seed = [7u8; 32];
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&seed);
+        let private = ssh_key::PrivateKey::from(keypair.clone());
+        let pem = private
+            .to_openssh(ssh_key::LineEnding::LF)
+            .expect("encode")
+            .to_string();
+        let public_line = private.public_key().to_openssh().expect("encode pub");
+        let did = shadi_identity::encode_did_key(
+            &ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key(),
+        );
+        (pem, public_line, did)
+    }
+
+    #[test]
+    fn run_cli_did_from_github_ssh_key_type_uses_published_ssh_key() {
+        let _guard = github_payload_lock().lock().expect("github payload lock");
+        let (_pem, public_line, expected_did) = ssh_test_key();
+        // GitHub lists several keys of mixed algorithms; the ed25519 one wins.
+        set_test_github_payload(Some(format!(
+            "ssh-rsa AAAAB3NzaC1yc2EAAAA someone\n{public_line}\n"
+        )));
+
+        let dir = temp_dir();
+        let output = dir.path().join("github-ssh.json");
+        let mut cli = build_cli();
+        cli.run_command = vec![
+            "did-from-github".to_string(),
+            "--user".to_string(),
+            "alice".to_string(),
+            "--key-type".to_string(),
+            "ssh".to_string(),
+            "--out".to_string(),
+            output.to_string_lossy().to_string(),
+        ];
+
+        assert_eq!(run_cli(cli), ExitCode::from(0));
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&output).expect("read")).expect("json");
+        assert_eq!(doc["id"].as_str(), Some(expected_did.as_str()));
+    }
+
+    #[test]
+    fn run_cli_did_from_github_ssh_key_type_needs_an_ed25519_key() {
+        let _guard = github_payload_lock().lock().expect("github payload lock");
+        set_test_github_payload(Some("ssh-rsa AAAAB3NzaC1yc2EAAAA only-rsa\n".to_string()));
+
+        let mut cli = build_cli();
+        cli.run_command = vec![
+            "did-from-github".to_string(),
+            "--user".to_string(),
+            "alice".to_string(),
+            "--key-type".to_string(),
+            "ssh".to_string(),
+        ];
+        assert_eq!(run_cli(cli), ExitCode::from(2));
+    }
+
+    /// The private and public halves of one SSH key must yield the same human
+    /// DID — that shared root is what binds a human to its agents.
+    #[test]
+    fn run_cli_did_from_ssh_agrees_across_key_halves() {
+        let (pem, public_line, expected_did) = ssh_test_key();
+        let dir = temp_dir();
+
+        let priv_path = dir.path().join("id_ed25519");
+        std::fs::write(&priv_path, &pem).expect("write private");
+        let priv_out = dir.path().join("from-private.json");
+        let mut cli = build_cli();
+        cli.run_command = vec![
+            "did-from-ssh".to_string(),
+            "--in".to_string(),
+            priv_path.to_string_lossy().to_string(),
+            "--out".to_string(),
+            priv_out.to_string_lossy().to_string(),
+        ];
+        assert_eq!(run_cli(cli), ExitCode::from(0));
+
+        let pub_path = dir.path().join("id_ed25519.pub");
+        std::fs::write(&pub_path, &public_line).expect("write public");
+        let pub_out = dir.path().join("from-public.json");
+        let mut cli = build_cli();
+        cli.run_command = vec![
+            "did-from-ssh".to_string(),
+            "--in".to_string(),
+            pub_path.to_string_lossy().to_string(),
+            "--out".to_string(),
+            pub_out.to_string_lossy().to_string(),
+        ];
+        assert_eq!(run_cli(cli), ExitCode::from(0));
+
+        let of = |p: &std::path::Path| -> String {
+            let d: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(p).unwrap()).unwrap();
+            d["id"].as_str().unwrap().to_string()
+        };
+        assert_eq!(of(&priv_out), expected_did);
+        assert_eq!(of(&pub_out), expected_did, "halves must agree");
+    }
+
+    #[test]
+    fn run_cli_did_from_ssh_rejects_a_non_key_file() {
+        let dir = temp_dir();
+        let path = dir.path().join("junk");
+        std::fs::write(&path, b"not a key at all\n").expect("write");
+        let mut cli = build_cli();
+        cli.run_command = vec![
+            "did-from-ssh".to_string(),
+            "--in".to_string(),
+            path.to_string_lossy().to_string(),
+        ];
+        assert_eq!(run_cli(cli), ExitCode::from(2));
+    }
+
     #[test]
     fn run_cli_did_from_github_stores_outputs() {
         let _guard = github_payload_lock().lock().expect("github payload lock");
@@ -3210,6 +3331,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         set_test_github_payload(Some(github_payload_with_sample_cert()));
 
         let code = run_did_from_github_command(DidFromGitHubArgs {
+            key_type: GitHubKeyType::Gpg,
             user: user.clone(),
             out_file: None,
         });
@@ -3231,6 +3353,7 @@ members = [{ did = "did:key:zA", role = "human" }]
         set_test_github_payload(Some(github_payload_with_sample_cert()));
 
         let code = run_did_from_github_command(DidFromGitHubArgs {
+            key_type: GitHubKeyType::Gpg,
             user: user.clone(),
             out_file: None,
         });

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -388,6 +388,61 @@ cargo run -p agntcy-shadi-cli -- \
   --out github.did.json
 ```
 
+### SSH Ed25519 identities
+
+An Ed25519 SSH key encodes the same primitive as `did:key`, so it can root a
+human identity and every agent derived from it. Use it when the account has no
+Ed25519 *GPG* key — `did-from-github` defaults to `--key-type gpg`, which fails
+with `no Ed25519 public key found in OpenPGP certificate` if the GPG key is RSA.
+
+`--key-type ssh` reads `github.com/<user>.keys`, which needs **no token** and is
+publicly readable, so anyone can check a human DID against the account claiming
+it:
+
+```bash
+cargo run -p agntcy-shadi-cli -- \
+  did-from-github \
+  --user octocat \
+  --key-type ssh \
+  --out github.did.json
+```
+
+`did-from-ssh` does the same from a local key. The input may be a public
+`ssh-ed25519 AAAA...` line or an OpenSSH private key — which one is detected from
+the content, and both halves of a key yield the same DID:
+
+```bash
+cargo run -p agntcy-shadi-cli -- \
+  did-from-ssh \
+  --in ~/.ssh/id_ed25519.pub \
+  --out human.did.json
+```
+
+Agents derive from the private key's 32-byte Ed25519 seed, so a human and its
+agents share one real key:
+
+```bash
+cargo run -p agntcy-shadi-cli -- \
+  derive-agent-identity \
+  --source ssh \
+  --in ~/.ssh/id_ed25519 \
+  --name claude-code \
+  --name codex
+```
+
+The key may also come from the secret store (`--human-secret <ref>`), which is
+how a 1Password- or keychain-held key is used — see
+[security.md](security.md#secret-backends).
+
+For an encrypted key, supply the passphrase through the secret store
+(`--ssh-passphrase-secret <ref>`) or `SHADI_SSH_PASSPHRASE`. It is deliberately
+not a command-line argument, which would be visible to anyone running `ps`.
+Adding or changing a passphrase does not change the derived DIDs: derivation uses
+the key's seed, not the encoded file.
+
+Only `ssh-ed25519` works. Hardware-backed `sk-ssh-ed25519` keys expose no private
+key, so they cannot root a derivation.
+
 Store an OpenPGP secret key in the SHADI secret store:
 
 ```bash
@@ -423,7 +478,8 @@ cargo run -p agntcy-shadi-cli -- \
   --out-dir ./agent-dids
 ```
 
-For non-GPG identities, store source material in SHADI and use `--source seed`:
+For identities that are neither GPG nor SSH, store source material in SHADI and
+use `--source seed`:
 
 ```bash
 cargo run -p agntcy-shadi-cli -- \

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -20,11 +20,42 @@ SHADI derives local agent keys from human identity material using:
 
 - KDF: `HKDF-SHA256`
 - Salt: `shadi-agent-derive`
-- IKM: human source bytes (`gpg` material or generic seed bytes)
+- IKM: human source bytes — see the sources below
 - Info: agent name
 
 The 32-byte HKDF output becomes an Ed25519 private key seed. SHADI stores the
 derived public key and computes `did:key` from that key.
+
+### Human identity sources
+
+| `--source` | IKM | Human DID |
+|---|---|---|
+| `gpg` | OpenPGP secret-key material as stored | `did-from-gpg`, or `did-from-github` (Ed25519 GPG key only) |
+| `ssh` | the key's 32-byte Ed25519 seed | `did-from-ssh`, or `did-from-github --key-type ssh` |
+| `seed` | the stored bytes verbatim | none — the root is not a published key |
+
+Sources are not interchangeable: each produces different agent DIDs for the same
+agent name, because the IKM differs.
+
+The `ssh` source uses the key's **seed** rather than the key file's bytes,
+because the OpenSSH container is not a stable encoding — re-encrypting with a new
+passphrase rewrites the file while the key is unchanged. Deriving from the file
+would silently change every agent DID. (`gpg` predates this and hashes its stored
+material, so re-exporting a GPG key can change its derived agents.)
+
+Only `ssh-ed25519` is accepted. Hardware-backed `sk-ssh-ed25519` keys expose no
+private key and cannot root a derivation.
+
+An SSH passphrase is read from the secret store
+(`--ssh-passphrase-secret <ref>`) or `SHADI_SSH_PASSPHRASE`, never from a command
+-line argument, which would be visible to any local process via `ps`.
+
+Because an SSH key is normally published at `github.com/<user>.keys`, the human
+DID derived from its public half is verifiable by anyone against the account that
+claims it — the private half never leaves the machine. That public binding is
+what "sign in with GitHub" contributes; it is not secret material. What it does
+**not** yet establish is that a given agent belongs to that human at SLIM
+admission time — see the note below.
 
 ## Human-to-agent linkage verification
 
@@ -33,6 +64,11 @@ DID from the same human source and compare them to stored values.
 
 If a human DID binding is stored (`{prefix}/{agent}/human_did`), verification
 can additionally assert that the binding matches a specific human DID key.
+
+This check is local and offline. On the wire, SLIM admission verifies the *agent*
+DID against the `SLIM_MEMBER_DIDS` allow-list; `SLIM_HUMAN_DID` is reported for
+display and is not verified, so a peer cannot currently prove which human an
+agent belongs to. Tracked in agntcy/shadi#141.
 
 This is the trust bootstrap path end to end — from human identity material to
 gated secret and memory access:


### PR DESCRIPTION
Closes #140.

An Ed25519 SSH key encodes the same primitive as `did:key`, so it can be both the human identity and the root every agent DID derives from. Only GPG and a raw seed were accepted before, which left the intended flow with no path when an account's GPG key is not Ed25519:

```
$ shadictl did-from-github --user muscariello
no Ed25519 public key found in OpenPGP certificate
```

That account publishes an `ssh-ed25519` key — the key with the right algorithm was the one SHADI wouldn't take.

## What

- `shadi_identity::ssh` — parse OpenSSH keys (plain and passphrase-protected), select `ssh-ed25519` out of an `authorized_keys` listing.
- `--source ssh` for `derive-agent-identity` / `verify-agent-identity`, reading the key through the existing `--human-secret <ref>` / `--in <file>` input, so 1Password, the OS keychain and files all work unchanged.
- `did-from-ssh` — human DID from a public line *or* a private key; which one is detected from the content.
- `did-from-github --key-type ssh` — reads `github.com/<user>.keys`, **no token needed** and publicly readable, so a human DID is checkable against the account claiming it.

## Two deliberate choices

**Derivation uses the key's 32-byte seed, not the file's bytes.** The OpenSSH container isn't a stable encoding — re-encrypting with a new passphrase rewrites the file while the key is unchanged — so hashing the file would silently change every derived agent DID. A test pins that adding a passphrase leaves the seed identical.

**The passphrase never comes from argv**, which would be visible via `ps` — only the secret store (`--ssh-passphrase-secret`) or `SHADI_SSH_PASSPHRASE`.

Only `ssh-ed25519` is accepted; `sk-ssh-ed25519` exposes no private key and is rejected with that explanation.

## Test plan
- [x] 8 unit tests in `shadi_identity::ssh` + 4 CLI tests; full workspace green (698 in shadictl)
- [x] clippy: no new findings in changed files (`main_tests.rs` count identical before/after)
- [x] Verified against a real account: `did-from-github --key-type ssh --user muscariello` produces a DID with no token, while `--key-type gpg` still fails on the same account
- [x] Private and public halves of one key yield the same human DID; agents derive distinctly and stably; `verify-agent-identity --source ssh` reports `verified: true`
- [x] Encrypted key: refused without a passphrase, works via `SHADI_SSH_PASSPHRASE`, clear error on a wrong one
- [x] Confirmed sources are not interchangeable (`ssh` vs `seed` on the same file give different DIDs), as documented

Note: this does not make the human→agent binding verifiable at SLIM admission — `SLIM_HUMAN_DID` is still display-only. That's #141.