### PR TITLE
ci(winget): validate the manifest on Windows before opening the PR

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -30,10 +30,15 @@ on:
         type: string
 
 jobs:
-  publish-winget-manifests:
+  render-winget-manifests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      manifest_rel_dir: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+      package_identifier: ${{ needs.render-winget-manifests.outputs.package_identifier }}
+      package_version: ${{ needs.render-winget-manifests.outputs.package_version }}
+      release_url: ${{ needs.render-winget-manifests.outputs.release_url }}
     env:
       CLI: ${{ inputs.cli }}
       RELEASE_TAG: ${{ inputs.release_tag }}
@@ -61,7 +66,73 @@ jobs:
       - name: Upload WinGet manifest artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: winget-manifests-${{ steps.render.outputs.package_version }}
+          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
+          path: dist/winget/manifests
+
+
+  validate-winget-manifests:
+    needs: render-winget-manifests
+    runs-on: windows-2025
+    permissions:
+      contents: read
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
+          path: manifests
+
+      - name: Show winget version
+        shell: pwsh
+        run: winget --version
+
+      - name: Validate manifests
+        shell: pwsh
+        env:
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+        run: |
+          $dir = Join-Path "manifests" ($env:MANIFEST_REL_DIR -replace '^manifests/', '')
+          Get-ChildItem $dir | ForEach-Object { Write-Host $_.Name }
+          winget validate --manifest $dir
+
+      - name: Install from the manifest and run the command
+        shell: pwsh
+        env:
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          CLI: ${{ inputs.cli }}
+        run: |
+          function Assert-LastExit($what) {
+            if ($LASTEXITCODE -ne 0) { throw "$what failed with exit $LASTEXITCODE" }
+          }
+
+          $dir = Join-Path "manifests" ($env:MANIFEST_REL_DIR -replace '^manifests/', '')
+
+          winget settings --enable LocalManifestFiles
+          Assert-LastExit "winget settings --enable LocalManifestFiles"
+
+          winget install --manifest $dir `
+            --accept-package-agreements --accept-source-agreements --disable-interactivity
+          Assert-LastExit "winget install"
+
+          $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:PATH"
+          & $env:CLI --help
+          Assert-LastExit "$env:CLI --help"
+          Write-Host "OK - installed via winget and the binary runs"
+
+  publish-winget-manifests:
+    needs: [render-winget-manifests, validate-winget-manifests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CLI: ${{ inputs.cli }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
           path: dist/winget/manifests
 
       - name: Authenticate with GitHub App Bot
@@ -87,11 +158,11 @@ jobs:
           FORK_OWNER: ${{ github.repository_owner }}
           GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
-          MANIFEST_DIR: ${{ steps.render.outputs.manifest_dir }}
-          MANIFEST_REL_DIR: ${{ steps.render.outputs.manifest_rel_dir }}
-          PACKAGE_IDENTIFIER: ${{ steps.render.outputs.package_identifier }}
-          PACKAGE_VERSION: ${{ steps.render.outputs.package_version }}
-          RELEASE_URL: ${{ steps.render.outputs.release_url }}
+          MANIFEST_DIR: dist/winget/${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          PACKAGE_IDENTIFIER: ${{ needs.render-winget-manifests.outputs.package_identifier }}
+          PACKAGE_VERSION: ${{ needs.render-winget-manifests.outputs.package_version }}
+          RELEASE_URL: ${{ needs.render-winget-manifests.outputs.release_url }}
         run: |
           if [ -z "$WINGET_PKGS_TOKEN" ]; then
             echo "::notice::PROJECT_APP_ID / PROJECT_APP_KEY are not configured; uploaded generated WinGet manifests as a workflow artifact only."


### PR DESCRIPTION
Refs #144.

The manifest was rendered on Linux and pushed straight to winget-pkgs. `winget` only exists on Windows, so the first thing to exercise it was a reviewer — which is how [microsoft/winget-pkgs#408502](https://github.com/microsoft/winget-pkgs/pull/408502) came back with a runtime failure.

Splits the workflow into render → validate → publish. A `windows-2025` job runs `winget validate`, installs from the local manifest, and runs the binary through its portable alias — proving the asset downloads, its checksum matches, `NestedInstallerFiles` resolves inside the zip, and the alias works. Publishing `needs` it.

Two details worth a look:

- `--help`, not `--version`: neither CLI defines `--version` and clap exits 2 on an unknown flag, so it would have failed every release on a good manifest.
- Exit codes are asserted explicitly. PowerShell does not fail on a non-zero native exit and only the last command's code reaches the runner, so a failed `winget install` would have passed silently.

Does not catch a missing system OpenSSL — the runners have it preinstalled. This verifies the manifest, not the portability of the binary; see #144.

## Test plan
- [x] YAML validates; `download-artifact` SHA checked against the real v4 tag
- [x] Ran the render script against the v0.1.2 tag to confirm the artifact paths and that the alias matches the `cli` input
- [x] Confirmed on both CLIs: `--version` exits 2, `--help` exits 0
- [ ] The job only runs on release (`workflow_call`/`workflow_dispatch`), so it is unexercised until the next release or a manual dispatch