### PR TITLE
fix(winget): a working OpenSSL dependency, and a manifest test that can fail

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -217,7 +217,8 @@ jobs:
           gh workflow run winget-manifests.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
-            -f release_tag="$RELEASE_TAG"
+            -f release_tag="$RELEASE_TAG" \
+            -f publish=true
 
   release-shadictl-homebrew:
     name: Publish shadictl Homebrew formula
@@ -401,7 +402,8 @@ jobs:
             --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
             -f cli=agentbridge \
-            -f release_tag="$RELEASE_TAG"
+            -f release_tag="$RELEASE_TAG" \
+            -f publish=true
 
   release-agentbridge-homebrew:
     name: Publish agentbridge Homebrew formula

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -145,20 +145,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install nettle pkg-config
 
-      - name: Set OpenSSL env vars (Windows)
+      - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
-          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $opensslDir) {
-            choco install openssl -y --no-progress
-            $opensslDir = "C:\Program Files\OpenSSL-Win64"
-          }
-          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
-          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/install_openssl_windows.py
 
       - name: Resolve release metadata
         id: metadata
@@ -329,20 +321,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install nettle pkg-config
 
-      - name: Set OpenSSL env vars (Windows)
+      - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
-          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $opensslDir) {
-            choco install openssl -y --no-progress
-            $opensslDir = "C:\Program Files\OpenSSL-Win64"
-          }
-          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
-          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/install_openssl_windows.py
 
       - name: Resolve release metadata
         id: metadata

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -59,20 +59,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install nettle pkg-config
 
-      - name: Set OpenSSL env vars (Windows)
+      - name: Install OpenSSL (Windows)
         if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $candidates = @("C:\Program Files\OpenSSL-Win64", "C:\Program Files\OpenSSL", "C:\OpenSSL-Win64")
-          $opensslDir = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $opensslDir) {
-            choco install openssl -y --no-progress
-            $opensslDir = "C:\Program Files\OpenSSL-Win64"
-          }
-          $libDir = if (Test-Path "$opensslDir\lib\VC\x64\MD") { "$opensslDir\lib\VC\x64\MD" } else { "$opensslDir\lib" }
-          "OPENSSL_DIR=$opensslDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_LIB_DIR=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "OPENSSL_INCLUDE_DIR=$opensslDir\include" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/install_openssl_windows.py
 
       - name: Resolve shadictl release metadata
         id: metadata

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -92,6 +92,20 @@ jobs:
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Check the imported OpenSSL major (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $exe = "${{ steps.metadata.outputs.binary_path }}"
+          $text = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($exe))
+          $majors = [regex]::Matches($text, 'libcrypto-(\d+)-x64\.dll') |
+            ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+          $found = $majors -join ","
+          Write-Host "$exe imports libcrypto major(s): $(if ($found) { $found } else { 'none' })"
+          if ($found -ne $env:OPENSSL_MAJOR) {
+            throw "built against OpenSSL $env:OPENSSL_MAJOR, which is what the WinGet dependency installs, but the binary imports '$found'"
+          }
+
       - name: Resolve agentbridge release metadata
         id: metadata-agentbridge
         shell: bash

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -35,10 +35,10 @@ jobs:
     permissions:
       contents: read
     outputs:
-      manifest_rel_dir: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
-      package_identifier: ${{ needs.render-winget-manifests.outputs.package_identifier }}
-      package_version: ${{ needs.render-winget-manifests.outputs.package_version }}
-      release_url: ${{ needs.render-winget-manifests.outputs.release_url }}
+      manifest_rel_dir: ${{ steps.render.outputs.manifest_rel_dir }}
+      package_identifier: ${{ steps.render.outputs.package_identifier }}
+      package_version: ${{ steps.render.outputs.package_version }}
+      release_url: ${{ steps.render.outputs.release_url }}
     env:
       CLI: ${{ inputs.cli }}
       RELEASE_TAG: ${{ inputs.release_tag }}
@@ -66,7 +66,7 @@ jobs:
       - name: Upload WinGet manifest artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
+          name: winget-manifests-${{ steps.render.outputs.package_version }}
           path: dist/winget/manifests
 
 

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -125,6 +125,11 @@ jobs:
             --accept-package-agreements --accept-source-agreements --disable-interactivity
           Assert-LastExit "winget install"
 
+          Write-Host "--- libcrypto on PATH after install ---"
+          $found = & where.exe libcrypto-3-x64.dll 2>$null
+          if ($found) { $found | Write-Host } else { Write-Host "libcrypto-3-x64.dll: not on PATH" }
+          & where.exe libcrypto-4-x64.dll 2>$null | Write-Host
+
           $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:PATH"
           & $env:CLI --help
           Assert-LastExit "$env:CLI --help"

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -125,11 +125,6 @@ jobs:
             --accept-package-agreements --accept-source-agreements --disable-interactivity
           Assert-LastExit "winget install"
 
-          Write-Host "--- libcrypto on PATH after install ---"
-          $found = & where.exe libcrypto-3-x64.dll 2>$null
-          if ($found) { $found | Write-Host } else { Write-Host "libcrypto-3-x64.dll: not on PATH" }
-          & where.exe libcrypto-4-x64.dll 2>$null | Write-Host
-
           $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:PATH"
           & $env:CLI --help
           Assert-LastExit "$env:CLI --help"

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -125,7 +125,11 @@ jobs:
             --accept-package-agreements --accept-source-agreements --disable-interactivity
           Assert-LastExit "winget install"
 
-          $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:PATH"
+          $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:SystemRoot\System32;$env:SystemRoot"
+          $dll = & where.exe libcrypto-3-x64.dll 2>$null
+          $global:LASTEXITCODE = 0
+          Write-Host "libcrypto-3-x64.dll -> $(if ($dll) { $dll -join '; ' } else { 'not found' })"
+
           & $env:CLI --help
           Assert-LastExit "$env:CLI --help"
           Write-Host "OK - installed via winget and the binary runs"

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -103,7 +103,8 @@ jobs:
         run: |
           $dir = Join-Path "manifests" ($env:MANIFEST_REL_DIR -replace '^manifests/', '')
           Get-ChildItem $dir | ForEach-Object { Write-Host $_.Name }
-          winget validate --manifest $dir
+          winget validate --manifest $dir --ignore-warnings
+          if ($LASTEXITCODE -ne 0) { throw "winget validate failed with exit $LASTEXITCODE" }
 
       - name: Install from the manifest and run the command
         shell: pwsh

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -12,6 +12,11 @@ on:
         description: CLI release tag to render into WinGet manifests
         required: true
         type: string
+      publish:
+        description: Open or update the winget-pkgs PR. Off by default so a manual run only validates.
+        required: false
+        type: boolean
+        default: false
     secrets:
       PROJECT_APP_ID:
         required: false
@@ -28,6 +33,11 @@ on:
         description: CLI release tag to render into WinGet manifests
         required: true
         type: string
+      publish:
+        description: Open or update the winget-pkgs PR. Off by default so a manual run only validates.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   render-winget-manifests:
@@ -121,6 +131,7 @@ jobs:
 
   publish-winget-manifests:
     needs: [render-winget-manifests, validate-winget-manifests]
+    if: inputs.publish == true || inputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -126,9 +126,11 @@ jobs:
           Assert-LastExit "winget install"
 
           $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:SystemRoot\System32;$env:SystemRoot"
-          $dll = & where.exe libcrypto-3-x64.dll 2>$null
-          $global:LASTEXITCODE = 0
-          Write-Host "libcrypto-3-x64.dll -> $(if ($dll) { $dll -join '; ' } else { 'not found' })"
+          foreach ($dll in @("libcrypto-3-x64.dll", "libcrypto-4-x64.dll")) {
+            $hits = & where.exe $dll 2>$null
+            $global:LASTEXITCODE = 0
+            Write-Host "$dll -> $(if ($hits) { $hits -join '; ' } else { 'not found' })"
+          }
 
           & $env:CLI --help
           Assert-LastExit "$env:CLI --help"

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -82,6 +82,21 @@ winget install --id AGNTCY.shadictl -e
 winget upgrade --id AGNTCY.shadictl -e
 ```
 
+`shadictl` links OpenSSL dynamically for its encrypted memory store, so the
+manifest declares `ShiningLight.OpenSSL.Light` as a dependency and WinGet
+installs it for you. If you install by downloading the release archive instead,
+install OpenSSL yourself — without it the CLI cannot start:
+
+```powershell
+winget install --id ShiningLight.OpenSSL.Light -e
+```
+
+The major matters: the Windows binaries are built against OpenSSL 4 and load
+`libcrypto-4-x64.dll`, which an OpenSSL 3 install does not provide. Check what
+you have with `where.exe libcrypto-4-x64.dll`. The DLL has to sit in a
+directory Windows searches — `System32` (where the installer puts it), the
+directory holding `shadictl.exe`, or one on `PATH`.
+
 ## Next steps
 
 Once `shadictl` is installed, continue to [Getting Started](getting_started.md)

--- a/scripts/install_openssl_windows.py
+++ b/scripts/install_openssl_windows.py
@@ -144,6 +144,7 @@ def main() -> int:
         lib_dir = openssl_dir / "lib"
 
     variables = {
+        "OPENSSL_MAJOR": version.split(".")[0],
         "OPENSSL_DIR": str(openssl_dir),
         "OPENSSL_LIB_DIR": str(lib_dir),
         "OPENSSL_INCLUDE_DIR": str(openssl_dir / "include"),

--- a/scripts/install_openssl_windows.py
+++ b/scripts/install_openssl_windows.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install the OpenSSL build that WinGet will install alongside the CLI.
+
+SQLCipher links libcrypto dynamically, so the DLL major the released binary
+imports has to match the one WinGet resolves for the manifest dependency.
+PackageDependencies carries no version ceiling and WinGet installs the newest
+version satisfying the minimum, so the only way to keep the two in step is to
+build against the same publisher and major. This reads the installer URL and
+digest straight out of the winget-pkgs manifest for that reason.
+
+ShiningLight serves only the current build of each line, so pinning an exact
+version here would start 404ing the moment they publish a patch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+from urllib.error import HTTPError
+
+DEV_PACKAGE_PATH = "manifests/s/ShiningLight/OpenSSL/Dev"
+CONTENTS_API = f"https://api.github.com/repos/microsoft/winget-pkgs/contents/{DEV_PACKAGE_PATH}"
+RAW_MANIFEST = (
+    "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/"
+    f"{DEV_PACKAGE_PATH}/{{version}}/ShiningLight.OpenSSL.Dev.installer.yaml"
+)
+INSTALL_CANDIDATES = (
+    r"C:\Program Files\OpenSSL",
+    r"C:\Program Files\OpenSSL-Win64",
+    r"C:\OpenSSL-Win64",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--major",
+        default="4",
+        help="OpenSSL major to build against. Bump together with the WinGet "
+        "dependency in render_winget_manifests.py (default: 4).",
+    )
+    parser.add_argument(
+        "--github-env",
+        type=Path,
+        default=os.environ.get("GITHUB_ENV"),
+        help="File to append OPENSSL_* variables to (default: $GITHUB_ENV).",
+    )
+    return parser.parse_args()
+
+
+def fetch(url: str) -> bytes:
+    headers = {"User-Agent": "agntcy-shadi", "Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return response.read()
+    except HTTPError as error:
+        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", version))
+
+
+def latest_version(major: str) -> str:
+    entries = json.loads(fetch(CONTENTS_API))
+    versions = [
+        entry["name"]
+        for entry in entries
+        if entry.get("type") == "dir" and entry["name"].startswith(f"{major}.")
+    ]
+    if not versions:
+        raise SystemExit(f"winget-pkgs publishes no OpenSSL {major}.x dev package")
+    return max(versions, key=version_key)
+
+
+def x64_installer(version: str) -> tuple[str, str]:
+    """The x64 .msi URL and its expected SHA-256, from the winget manifest."""
+    manifest = fetch(RAW_MANIFEST.format(version=version)).decode("utf-8")
+    for block in manifest.split("\n- Architecture: ")[1:]:
+        if not block.startswith("x64"):
+            continue
+        url = re.search(r"InstallerUrl:\s*(\S+)", block)
+        digest = re.search(r"InstallerSha256:\s*(\S+)", block)
+        if url and digest and url.group(1).lower().endswith(".msi"):
+            return url.group(1), digest.group(1).lower()
+    raise SystemExit(f"no x64 .msi installer in the OpenSSL {version} manifest")
+
+
+def download_verified(url: str, expected_sha256: str, destination: Path) -> None:
+    destination.write_bytes(fetch(url))
+    actual = hashlib.sha256(destination.read_bytes()).hexdigest()
+    if actual != expected_sha256:
+        raise SystemExit(
+            f"{url} digest mismatch: manifest says {expected_sha256}, got {actual}"
+        )
+
+
+def install(msi: Path) -> None:
+    result = subprocess.run(
+        ["msiexec", "/i", str(msi), "/quiet", "/norestart"], check=False
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"msiexec exited {result.returncode}")
+
+
+def resolve_install_dir() -> Path:
+    for candidate in INSTALL_CANDIDATES:
+        if (Path(candidate) / "include" / "openssl" / "evp.h").is_file():
+            return Path(candidate)
+    raise SystemExit("no OpenSSL headers found after install")
+
+
+def main() -> int:
+    args = parse_args()
+    if os.name != "nt":
+        raise SystemExit("this script only applies to Windows builds")
+
+    version = latest_version(args.major)
+    url, expected = x64_installer(version)
+    print(f"OpenSSL {version} from {url}")
+
+    with tempfile.TemporaryDirectory() as work:
+        msi = Path(work) / "openssl-dev.msi"
+        download_verified(url, expected, msi)
+        install(msi)
+
+    openssl_dir = resolve_install_dir()
+    lib_dir = openssl_dir / "lib" / "VC" / "x64" / "MD"
+    if not lib_dir.is_dir():
+        lib_dir = openssl_dir / "lib"
+
+    variables = {
+        "OPENSSL_DIR": str(openssl_dir),
+        "OPENSSL_LIB_DIR": str(lib_dir),
+        "OPENSSL_INCLUDE_DIR": str(openssl_dir / "include"),
+    }
+    for name, value in variables.items():
+        print(f"{name}={value}")
+    if args.github_env:
+        with Path(args.github_env).open("a", encoding="utf-8") as handle:
+            for name, value in variables.items():
+                handle.write(f"{name}={value}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -27,11 +27,12 @@ PACKAGE_LOCALE = "en-US"
 PUBLISHER = "AGNTCY"
 WINDOWS_ARCHITECTURE = "x64"
 WINDOWS_TARGET = "x86_64-pc-windows-msvc"
-# SQLCipher links libcrypto-3-x64.dll dynamically. PackageDependencies has no
-# version ceiling and winget installs the newest version satisfying it, so the
-# non-LTS ShiningLight.OpenSSL.Light (4.0.1) would install libcrypto-4-x64.dll
-# and leave the CLI unable to start. The LTS package stays on OpenSSL 3.
-OPENSSL_DEPENDENCY = "ShiningLight.OpenSSL.LTS.Light"
+# SQLCipher links libcrypto dynamically, so this has to be the package whose
+# newest version matches the major scripts/install_openssl_windows.py builds
+# against: PackageDependencies has no version ceiling, and winget installs the
+# newest version satisfying it. No MinimumVersion for the same reason - it
+# would suggest a bound that winget does not honour.
+OPENSSL_DEPENDENCY = "ShiningLight.OpenSSL.Light"
 DOCS_URL = "https://agntcy.github.io/shadi"
 REPOSITORY_PATTERN = re.compile(
     r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -306,10 +306,6 @@ def render_installer_manifest(
         Commands:
         - {moniker}
         ReleaseDate: {release_assets.release_date}
-        Dependencies:
-          PackageDependencies:
-          - PackageIdentifier: ShiningLight.OpenSSL.Light
-            MinimumVersion: 3.0.0
         Installers:
         - Architecture: {WINDOWS_ARCHITECTURE}
           InstallerUrl: {release_assets.installer_url}

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -27,6 +27,11 @@ PACKAGE_LOCALE = "en-US"
 PUBLISHER = "AGNTCY"
 WINDOWS_ARCHITECTURE = "x64"
 WINDOWS_TARGET = "x86_64-pc-windows-msvc"
+# SQLCipher links libcrypto-3-x64.dll dynamically. PackageDependencies has no
+# version ceiling and winget installs the newest version satisfying it, so the
+# non-LTS ShiningLight.OpenSSL.Light (4.0.1) would install libcrypto-4-x64.dll
+# and leave the CLI unable to start. The LTS package stays on OpenSSL 3.
+OPENSSL_DEPENDENCY = "ShiningLight.OpenSSL.LTS.Light"
 DOCS_URL = "https://agntcy.github.io/shadi"
 REPOSITORY_PATTERN = re.compile(
     r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
@@ -306,6 +311,9 @@ def render_installer_manifest(
         Commands:
         - {moniker}
         ReleaseDate: {release_assets.release_date}
+        Dependencies:
+          PackageDependencies:
+          - PackageIdentifier: {OPENSSL_DEPENDENCY}
         Installers:
         - Architecture: {WINDOWS_ARCHITECTURE}
           InstallerUrl: {release_assets.installer_url}

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -306,6 +306,10 @@ def render_installer_manifest(
         Commands:
         - {moniker}
         ReleaseDate: {release_assets.release_date}
+        Dependencies:
+          PackageDependencies:
+          - PackageIdentifier: ShiningLight.OpenSSL.Light
+            MinimumVersion: 3.0.0
         Installers:
         - Architecture: {WINDOWS_ARCHITECTURE}
           InstallerUrl: {release_assets.installer_url}


### PR DESCRIPTION
The winget OpenSSL dependency could not work as written. `PackageDependencies`
has no version ceiling and winget installs the newest version satisfying the
minimum, while the Windows build linked whatever OpenSSL the runner image
shipped. The two ends were picked independently: the binary imported
`libcrypto-3-x64.dll`, the declaration installed OpenSSL 4.0.1.

No package fixes this from the manifest side — `ShiningLight.OpenSSL.Light` and
`FireDaemon.OpenSSL` are both 4.0.1, and `ShiningLight.OpenSSL.LTS.Light`, the
last 3.x entry, points at a URL that 404s. So the build follows winget instead:
`install_openssl_windows.py` reads the installer URL and digest from the same
winget-pkgs manifest winget resolves.

Also here: the render job referenced its own outputs, publishing is now opt-in,
and the smoke test runs on a `PATH` reduced to the winget shim and system
directories — the runner carries `libcrypto-3-x64.dll` via Git, MySQL and PHP,
so the old test passed no matter what winget installed.

Verified on windows-2025: SQLCipher builds against OpenSSL 4, the binary
imports `libcrypto-4-x64.dll`, and the encrypted-store tests pass.

Manifest validation stays red until a release is built from this branch — v0.1.3
imports libcrypto-3 and the dependency now installs OpenSSL 4.

- [x] Windows build resolves OpenSSL 4.0.1 from winget-pkgs and the packaged binary imports libcrypto-4
- [ ] manifest validation green against a release built from this change
