### PR TITLE
test: build shadictl on Windows with vendored OpenSSL

### DIFF
--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -88,6 +88,22 @@ jobs:
       - name: Build shadictl
         run: cargo build -p agntcy-shadi-cli --release --locked --target ${{ matrix.target }}
 
+      - name: Assert no dynamic OpenSSL import (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $exe = "target/${{ matrix.target }}/release/${{ steps.metadata.outputs.binary_name }}.exe"
+          $dumpbin = Get-ChildItem -Path "C:/Program Files*/Microsoft Visual Studio" `
+            -Filter dumpbin.exe -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $dumpbin) { throw "dumpbin.exe not found; cannot verify imports" }
+          $imports = & $dumpbin /dependents $exe
+          $imports | Write-Host
+          if ($imports | Select-String -Pattern 'libcrypto|libssl') {
+            throw "binary dynamically imports OpenSSL"
+          }
+          Write-Host "OK - no dynamic OpenSSL import"
+
       - name: Package shadictl release archive
         id: package
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -4231,6 +4232,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"

--- a/crates/shadi_memory/Cargo.toml
+++ b/crates/shadi_memory/Cargo.toml
@@ -11,7 +11,7 @@ name = "shadi_memory"
 
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.0", path = "../agent_secrets" }
-rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
+rusqlite = { version = "0.31", features = ["bundled-sqlcipher-vendored-openssl"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
Draft, for evidence — not for merge as-is.

Answers two questions about static vendoring that we could only guess at:

1. Does OpenSSL build on the Windows release runner (it needs Perl; NASM is auto-detected with a fallback)?
2. Does the Windows binary actually stop importing `libcrypto-3-x64.dll`?

Switches `shadi_memory` to `bundled-sqlcipher-vendored-openssl` and adds a `dumpbin /dependents` assertion to the Windows release build, which runs on `pull_request`.

Context: the winget `PackageDependencies` route was tested and does not work — winget resolved `>= 3.0.0` to OpenSSL **4.0.1**, installing `libcrypto-4-x64.dll`. See #144.