### PR TITLE
fix(winget): only shadictl depends on OpenSSL

### DIFF
--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -92,20 +92,6 @@ jobs:
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Check the imported OpenSSL major (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $exe = "${{ steps.metadata.outputs.binary_path }}"
-          $text = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($exe))
-          $majors = [regex]::Matches($text, 'libcrypto-(\d+)-x64\.dll') |
-            ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
-          $found = $majors -join ","
-          Write-Host "$exe imports libcrypto major(s): $(if ($found) { $found } else { 'none' })"
-          if ($found -ne $env:OPENSSL_MAJOR) {
-            throw "built against OpenSSL $env:OPENSSL_MAJOR, which is what the WinGet dependency installs, but the binary imports '$found'"
-          }
-
       - name: Resolve agentbridge release metadata
         id: metadata-agentbridge
         shell: bash
@@ -131,3 +117,30 @@ jobs:
             --name "${{ steps.metadata-agentbridge.outputs.binary_name }}" \
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Check the imported OpenSSL major (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          function Get-LibcryptoMajors($exe) {
+            $text = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($exe))
+            ([regex]::Matches($text, 'libcrypto-(\d+)-x64\.dll') |
+              ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique) -join ","
+          }
+
+          $expected = [ordered]@{
+            "${{ steps.metadata.outputs.binary_path }}" = $env:OPENSSL_MAJOR
+            "${{ steps.metadata-agentbridge.outputs.binary_path }}" = ""
+          }
+          foreach ($exe in $expected.Keys) {
+            $found = Get-LibcryptoMajors $exe
+            Write-Host "$exe imports libcrypto major(s): $(if ($found) { $found } else { 'none' })"
+            if ($found -ne $expected[$exe]) {
+              $want = if ($expected[$exe]) {
+                "OpenSSL $($expected[$exe]), the major the WinGet dependency installs"
+              } else {
+                "no OpenSSL, since its manifest declares no dependency"
+              }
+              throw "$exe should need $want, but it imports '$found'"
+            }
+          }

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -46,6 +46,7 @@ CLI_CONFIGS = {
         "package_name": "shadictl",
         "moniker": "shadictl",
         "binary_name": "shadictl",
+        "openssl_dependency": OPENSSL_DEPENDENCY,
     },
     "agentbridge": {
         "manifest": ROOT / "crates" / "agentbridge_cli" / "Cargo.toml",
@@ -56,6 +57,7 @@ CLI_CONFIGS = {
         "package_name": "agentbridge",
         "moniker": "agentbridge",
         "binary_name": "agentbridge",
+        "openssl_dependency": None,
     },
 }
 
@@ -296,12 +298,22 @@ def render_default_locale_manifest(
 
 
 def render_installer_manifest(
-    *, package_identifier: str, moniker: str, binary_name: str, release_assets: ReleaseAssets
+    *,
+    package_identifier: str,
+    moniker: str,
+    binary_name: str,
+    release_assets: ReleaseAssets,
+    openssl_dependency: str | None,
 ) -> str:
     relative_file_path = (
         f"{binary_name}-v{release_assets.version}-{WINDOWS_TARGET}\\{binary_name}.exe"
     )
-    return textwrap.dedent(
+    dependencies = (
+        f"Dependencies:\n  PackageDependencies:\n  - PackageIdentifier: {openssl_dependency}\n"
+        if openssl_dependency
+        else ""
+    )
+    manifest = textwrap.dedent(
         f"""\
         # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.{MANIFEST_VERSION}.schema.json
 
@@ -312,10 +324,7 @@ def render_installer_manifest(
         Commands:
         - {moniker}
         ReleaseDate: {release_assets.release_date}
-        Dependencies:
-          PackageDependencies:
-          - PackageIdentifier: {OPENSSL_DEPENDENCY}
-        Installers:
+        __DEPENDENCIES__Installers:
         - Architecture: {WINDOWS_ARCHITECTURE}
           InstallerUrl: {release_assets.installer_url}
           InstallerSha256: {release_assets.installer_sha256}
@@ -326,6 +335,7 @@ def render_installer_manifest(
         ManifestVersion: {MANIFEST_VERSION}
         """
     )
+    return manifest.replace("__DEPENDENCIES__", dependencies)
 
 
 def manifest_directory(output_dir: Path, package_identifier: str, version: str) -> Path:
@@ -387,6 +397,7 @@ def main() -> int:
             moniker=config["moniker"],
             binary_name=config["binary_name"],
             release_assets=release_assets,
+            openssl_dependency=config["openssl_dependency"],
         ),
         encoding="utf-8",
     )


### PR DESCRIPTION
The OpenSSL dependency added in #146 was rendered for both CLIs, but
`agentbridge` never reaches `rusqlite` — no SQLCipher, no dynamic libcrypto.
Declaring it there would make every agentbridge user install OpenSSL for
nothing.

The Windows check now covers both binaries and asserts agentbridge imports no
libcrypto, so this is tested rather than read off the dependency graph.

- [x] Windows job shows `shadictl` at major 4 and `agentbridge` at none
