### PR TITLE
fix(policy): keep accepted control-socket connections blocking

### DIFF
--- a/crates/shadictl/src/policy_watch.rs
+++ b/crates/shadictl/src/policy_watch.rs
@@ -1518,6 +1518,7 @@ mod tests {
 
     /// A client that connects before it writes must still be served: the server
     /// has to block on the read rather than treat an empty socket as a dead peer.
+    #[cfg(unix)]
     #[test]
     fn control_socket_serves_a_client_that_pauses_before_writing() {
         use std::io::{BufRead, BufReader, Write};

--- a/crates/shadictl/src/policy_watch.rs
+++ b/crates/shadictl/src/policy_watch.rs
@@ -236,6 +236,11 @@ fn accept_loop(listener: &UnixListener, live: &Arc<Mutex<LivePolicy>>, socket_pa
         match listener.accept() {
             Ok((stream, _)) => {
                 let mut stream = stream;
+                // accept(2) inherits O_NONBLOCK from the listener on macOS and the
+                // BSDs, where Linux's accept4(2) does not. Left non-blocking, a read
+                // that runs before the client's request lands returns WouldBlock,
+                // which reads as a dead connection and drops it mid-write.
+                let _ = stream.set_nonblocking(false);
                 #[cfg(unix)]
                 if let Err(err) = authorize_control_peer(&stream) {
                     let _ = write_response(
@@ -1509,6 +1514,32 @@ mod tests {
 
         drop(handle);
         wait_for_socket_removed(&sock_path);
+    }
+
+    /// A client that connects before it writes must still be served: the server
+    /// has to block on the read rather than treat an empty socket as a dead peer.
+    #[test]
+    fn control_socket_serves_a_client_that_pauses_before_writing() {
+        use std::io::{BufRead, BufReader, Write};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("slow.sock");
+        let handle = start_control_socket(&sock_path, test_live_policy()).expect("start socket");
+        wait_for_socket_ready(&sock_path);
+
+        let mut stream = std::os::unix::net::UnixStream::connect(&sock_path).expect("connect");
+        std::thread::sleep(std::time::Duration::from_millis(250));
+
+        let request = serde_json::to_string(&ControlMessage::QueryPolicy).expect("encode");
+        writeln!(stream, "{request}").expect("the server must not have hung up on an idle client");
+        stream.flush().expect("flush");
+
+        let mut line = String::new();
+        BufReader::new(&stream).read_line(&mut line).expect("read response");
+        assert!(!line.trim().is_empty(), "expected a response, got nothing");
+
+        drop(stream);
+        drop(handle);
     }
 
     #[test]


### PR DESCRIPTION
`accept(2)` inherits `O_NONBLOCK` from the listener on macOS and the BSDs, where
Linux's `accept4(2)` does not. The listener is non-blocking so the accept loop
can poll for shutdown, so accepted connections on macOS were non-blocking too —
a read that ran before the client's request landed returned `WouldBlock`, the
loop read that as a dead connection and dropped it, and the client's write
failed with `EPIPE`.

Not test-only: any `shadictl policy patch` against a running sandbox could fail
this way on macOS. This is what turned #131's CI red.

Reproduced at roughly 1 in 40 full-suite runs locally, 0 in 40 after the fix.
The regression test connects, waits, then writes; without the fix it fails with
the same `BrokenPipe`.