### PR TITLE
fix(winget): resolve the manifest path from the workspace, not the clone

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -176,7 +176,7 @@ jobs:
           FORK_OWNER: ${{ github.repository_owner }}
           GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
-          MANIFEST_DIR: dist/winget/${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          MANIFEST_DIR: ${{ github.workspace }}/dist/winget/${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
           MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
           PACKAGE_IDENTIFIER: ${{ needs.render-winget-manifests.outputs.package_identifier }}
           PACKAGE_VERSION: ${{ needs.render-winget-manifests.outputs.package_version }}
@@ -213,6 +213,11 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
           git checkout -B "$branch" upstream/master
 
+          if [ ! -d "$MANIFEST_DIR" ]; then
+            echo "::error::rendered manifests are not at $MANIFEST_DIR"
+            exit 1
+          fi
+
           mkdir -p "$(dirname "$MANIFEST_REL_DIR")"
           rm -rf "$MANIFEST_REL_DIR"
           cp -R "$MANIFEST_DIR" "$(dirname "$MANIFEST_REL_DIR")/"
@@ -236,7 +241,7 @@ jobs:
           cat > /tmp/winget-pr-body.md <<EOF
           Add WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION.
 
-          - publishes the Windows portable ZIP for shadictl
+          - publishes the Windows portable ZIP for $CLI
           - points WinGet at the SHADI GitHub release asset and checksum-backed digest
           - generated from the SHADI CLI release automation
 
@@ -248,5 +253,5 @@ jobs:
             --repo microsoft/winget-pkgs \
             --base master \
             --head "$fork_owner:$branch" \
-            --title "Add WinGet manifest for AGNTCY.shadictl version $PACKAGE_VERSION" \
+            --title "Add WinGet manifest for $PACKAGE_IDENTIFIER version $PACKAGE_VERSION" \
             --body-file /tmp/winget-pr-body.md


### PR DESCRIPTION
Both 0.1.4 winget runs rendered and validated, then failed to publish:

```
cp: cannot stat 'dist/winget/manifests/a/AGNTCY/shadictl/0.1.4': No such file or directory
```

The step `cd`s into the winget-pkgs clone before copying, so the
workspace-relative `MANIFEST_DIR` resolved against `/tmp/winget-pkgs`. Anchored
to `github.workspace`, with a clear error if the directory is missing.

Also: the PR title and body hardcoded `shadictl`, so an agentbridge release
would open a winget-pkgs PR titled `AGNTCY.shadictl` containing agentbridge
manifests.

Validation is unaffected and already passed for 0.1.4 — shadictl pulled OpenSSL
4.0.1, `libcrypto-4-x64.dll` landed in System32, and the binary ran on a clean
`PATH`.