### PR TITLE
fix(winget): push the manifests and hand the PR to a human

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           echo "user_id=$(gh api '/users/${{ steps.app-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
 
-      - name: Open or update winget-pkgs PR
+      - name: Push manifests to the winget-pkgs fork
         env:
           WINGET_PKGS_TOKEN: ${{ steps.app-token.outputs.token }}
           FORK_OWNER: ${{ github.repository_owner }}
@@ -232,26 +232,24 @@ jobs:
           git commit -m "release: add WinGet manifest for $CLI v$PACKAGE_VERSION"
           git push --force --set-upstream origin "$branch"
 
-          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
-          if [ -n "$pr_number" ]; then
-            echo "Updated existing PR #$pr_number"
-            exit 0
-          fi
+          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""' 2>/dev/null || true)
 
-          cat > /tmp/winget-pr-body.md <<EOF
-          Add WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION.
-
-          - publishes the Windows portable ZIP for $CLI
-          - points WinGet at the SHADI GitHub release asset and checksum-backed digest
-          - generated from the SHADI CLI release automation
-
-          Upstream release: $RELEASE_URL
-          Refs agntcy/shadi#69
-          EOF
-
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
-            --repo microsoft/winget-pkgs \
-            --base master \
-            --head "$fork_owner:$branch" \
-            --title "Add WinGet manifest for $PACKAGE_IDENTIFIER version $PACKAGE_VERSION" \
-            --body-file /tmp/winget-pr-body.md
+          {
+            echo "### WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION"
+            echo
+            if [ -n "$pr_number" ]; then
+              echo "Pushed to \`$branch\`, which updates the open PR:"
+              echo
+              echo "https://github.com/microsoft/winget-pkgs/pull/$pr_number"
+            else
+              echo "Pushed to \`$branch\`. Open the upstream PR to publish it:"
+              echo
+              echo "https://github.com/microsoft/winget-pkgs/compare/master...$fork_owner:$branch?expand=1"
+              echo
+              echo "The GitHub App can push to the fork but cannot open the PR:"
+              echo "an App token only acts on repositories the App is installed on,"
+              echo "and microsoft/winget-pkgs is not one of them."
+            fi
+            echo
+            echo "Upstream release: $RELEASE_URL"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`gh pr create` against microsoft/winget-pkgs fails with `Resource not accessible
by integration`: a GitHub App token only acts on repositories the App is
installed on, and that is not one of them. No workflow arrangement fixes it —
it needs either a user PAT with `public_repo` scope or a person clicking the
button.

The push to our fork does work, so the job now pushes the branch and writes the
compare link to the run summary instead of failing on a step that cannot
succeed. Re-running still updates an already-open PR, since it force-pushes the
same branch.

Adding a PAT would automate the last step; I left that out rather than put a
long-lived public-repo token in CI without a decision.