### PR TITLE
fix(brew): install the prebuilt binary on Linux too

### DIFF
--- a/Formula/agentbridge.rb
+++ b/Formula/agentbridge.rb
@@ -21,29 +21,19 @@ class Agentbridge < Formula
   end
 
   on_linux do
-    # The Linux build links libcrypto.so.3 with no rpath, so it resolves
-    # against the system loader path rather than a Homebrew prefix. Built
-    # from source here until the released binary carries its own rpath.
-    url "https://github.com/agntcy/shadi/archive/refs/tags/agntcy-agentbridge-cli-v0.1.3.tar.gz"
-    sha256 "0decd71c02d385025594eaddc39a47aa6927a088067583ba56b5fa04859ea919"
+    on_arm do
+      url "https://github.com/agntcy/shadi/releases/download/agntcy-agentbridge-cli-v0.1.3/agentbridge-v0.1.3-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "bfc5fa331bb7ec001d8467155f9ba14036177c507b229a9184967f41d22d3c29"
+    end
 
-    depends_on "pkgconf" => :build
-    depends_on "rust" => :build
-    depends_on "nettle"
-    depends_on "openssl@3"
-    depends_on "python@3.12"
+    on_intel do
+      url "https://github.com/agntcy/shadi/releases/download/agntcy-agentbridge-cli-v0.1.3/agentbridge-v0.1.3-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "bb1695e96f8a88255524c1a0d0698f9cb32b27a7fd9286291601b661466f7a9d"
+    end
   end
 
   def install
-    if OS.mac?
-      bin.install "agentbridge"
-    else
-      ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-      ENV["PYO3_PYTHON"] = Formula["python@3.12"].opt_bin/"python3.12"
-
-      # std_cargo_args already passes --locked and --path.
-      system "cargo", "install", *std_cargo_args(path: "crates/agentbridge_cli")
-    end
+    bin.install "agentbridge"
   end
 
   test do

--- a/Formula/shadictl.rb
+++ b/Formula/shadictl.rb
@@ -21,29 +21,26 @@ class Shadictl < Formula
   end
 
   on_linux do
-    # The Linux build links libcrypto.so.3 with no rpath, so it resolves
-    # against the system loader path rather than a Homebrew prefix. Built
-    # from source here until the released binary carries its own rpath.
-    url "https://github.com/agntcy/shadi/archive/refs/tags/agntcy-shadi-cli-v0.1.5.tar.gz"
-    sha256 "f98042226f148c1267fe929f5b7669e35c9df4b82786bfd0bd02a062061f92fe"
+    on_arm do
+      url "https://github.com/agntcy/shadi/releases/download/agntcy-shadi-cli-v0.1.5/shadictl-v0.1.5-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "47693a6d84c90b67a08ca962ff09b6cb29f32f0acba55044618cd56077a80972"
+    end
 
-    depends_on "pkgconf" => :build
-    depends_on "rust" => :build
-    depends_on "nettle"
+    on_intel do
+      url "https://github.com/agntcy/shadi/releases/download/agntcy-shadi-cli-v0.1.5/shadictl-v0.1.5-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "6c6100554dc70e3fb008ee3b10b96f247e9478826b04d667482d907bad6966e5"
+    end
+
+    depends_on "patchelf" => :build
     depends_on "openssl@3"
-    depends_on "python@3.12"
   end
 
   def install
-    if OS.mac?
-      bin.install "shadictl"
-    else
-      ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-      ENV["PYO3_PYTHON"] = Formula["python@3.12"].opt_bin/"python3.12"
+    bin.install "shadictl"
 
-      # std_cargo_args already passes --locked and --path.
-      system "cargo", "install", *std_cargo_args(path: "crates/shadictl")
-    end
+    return unless OS.linux?
+
+    system "patchelf", "--set-rpath", Formula["openssl@3"].opt_lib, bin/"shadictl"
   end
 
   test do

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -24,6 +24,7 @@ CLI_CONFIGS = {
         "class_name": "Shadictl",
         "crate_path": "crates/shadictl",
         "binary_name": "shadictl",
+        "linux_needs_openssl": True,
     },
     "agentbridge": {
         "manifest": ROOT / "crates" / "agentbridge_cli" / "Cargo.toml",
@@ -34,6 +35,7 @@ CLI_CONFIGS = {
         "class_name": "Agentbridge",
         "crate_path": "crates/agentbridge_cli",
         "binary_name": "agentbridge",
+        "linux_needs_openssl": False,
     },
 }
 
@@ -135,21 +137,41 @@ def render_formula(cli: str, tag: str) -> str:
     binary_name = config["binary_name"]
 
     version = match.group("version")
-    macos_targets = {
-        "arm": f"aarch64-apple-darwin",
-        "intel": f"x86_64-apple-darwin",
-    }
-    macos_blocks = []
-    for cpu, target in macos_targets.items():
-        asset = f"{binary_name}-v{version}-{target}.tar.gz"
-        url = f"{homepage}/releases/download/{tag}/{asset}"
-        macos_blocks.append(
-            f'    on_{cpu} do\n'
-            f'      url "{ruby_string(url)}"\n'
-            f'      sha256 "{released_sha256(url)}"\n'
-            f'    end'
+    needs_openssl = config["linux_needs_openssl"]
+
+    def arch_blocks(targets: dict[str, str], indent: str) -> str:
+        blocks = []
+        for cpu, target in targets.items():
+            asset = f"{binary_name}-v{version}-{target}.tar.gz"
+            url = f"{homepage}/releases/download/{tag}/{asset}"
+            blocks.append(
+                f"{indent}on_{cpu} do\n"
+                f'{indent}  url "{ruby_string(url)}"\n'
+                f'{indent}  sha256 "{released_sha256(url)}"\n'
+                f"{indent}end"
+            )
+        return "\n\n".join(blocks)
+
+    macos_block = arch_blocks(
+        {"arm": "aarch64-apple-darwin", "intel": "x86_64-apple-darwin"}, "    "
+    )
+    linux_block = arch_blocks(
+        {"arm": "aarch64-unknown-linux-gnu", "intel": "x86_64-unknown-linux-gnu"}, "    "
+    )
+    if needs_openssl:
+        linux_block += (
+            '\n\n    depends_on "patchelf" => :build'
+            '\n    depends_on "openssl@3"'
         )
-    macos_block = "\n\n".join(macos_blocks)
+        # The released binary carries no DT_RUNPATH, so the loader would look for
+        # libcrypto.so.3 on the system path and miss Homebrew's copy.
+        rpath = (
+            '\n\n    return unless OS.linux?\n\n'
+            '    system "patchelf", "--set-rpath", Formula["openssl@3"].opt_lib,'
+            f' bin/"{binary_name}"'
+        )
+    else:
+        rpath = ""
 
     formula_body = textwrap.dedent(
         f"""\
@@ -162,30 +184,10 @@ def render_formula(cli: str, tag: str) -> str:
 
         MACOS_BLOCK
 
-          on_linux do
-            # The Linux build links libcrypto.so.3 with no rpath, so it resolves
-            # against the system loader path rather than a Homebrew prefix. Built
-            # from source here until the released binary carries its own rpath.
-            url \"{ruby_string(source_url)}\"
-            sha256 \"{source_sha256}\"
-
-            depends_on \"pkgconf\" => :build
-            depends_on \"rust\" => :build
-            depends_on \"nettle\"
-            depends_on \"openssl@3\"
-            depends_on \"python@3.12\"
-          end
+        LINUX_BLOCK
 
           def install
-            if OS.mac?
-              bin.install \"{binary_name}\"
-            else
-              ENV[\"OPENSSL_DIR\"] = Formula[\"openssl@3\"].opt_prefix
-              ENV[\"PYO3_PYTHON\"] = Formula[\"python@3.12\"].opt_bin/\"python3.12\"
-
-              # std_cargo_args already passes --locked and --path.
-              system \"cargo\", \"install\", *std_cargo_args(path: \"{crate_path}\")
-            end
+            bin.install \"{binary_name}\"RPATH
           end
 
           test do
@@ -193,7 +195,12 @@ def render_formula(cli: str, tag: str) -> str:
           end
         end
         """
-    ).replace("MACOS_BLOCK", f"  on_macos do\n{macos_block}\n  end")
+    )
+    formula_body = (
+        formula_body.replace("MACOS_BLOCK", f"  on_macos do\n{macos_block}\n  end")
+        .replace("LINUX_BLOCK", f"  on_linux do\n{linux_block}\n  end")
+        .replace("RPATH", rpath)
+    )
 
     return f"{FORMULA_HEADER}{formula_body}"
 


### PR DESCRIPTION
agentbridge needs nothing beyond libc on Linux. shadictl needs `libcrypto.so.3`
and the release binary carries no rpath, so the formula points it at Homebrew's
OpenSSL with `patchelf`.

Verified in a container: with libcrypto only in a Homebrew-like prefix the binary
fails, and runs once the rpath is set. macOS re-checked, no deps, both install in
1s.
