### PR TITLE
fix: clear the CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build-test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PYO3_PYTHON: python
     steps:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -16,6 +16,8 @@ jobs:
   check:
     name: Check (frontend + src-tauri)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/shadi_desktop

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -63,6 +63,7 @@ jobs:
     needs: release-crates
     if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-shadi-cli"') }}
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       release_tag: ${{ steps.release.outputs.release_tag }}
     steps:
@@ -239,6 +240,7 @@ jobs:
     needs: release-crates
     if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"agntcy-agentbridge-cli"') }}
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       release_tag: ${{ steps.release.outputs.release_tag }}
     steps:

--- a/.github/workflows/shadictl-binaries.yml
+++ b/.github/workflows/shadictl-binaries.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-shadictl-release-artifacts:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/apps/shadi_desktop/src-tauri/Cargo.lock
+++ b/apps/shadi_desktop/src-tauri/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-agentbridge"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agntcy-shadi-mas",
  "serde",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-a2a"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-agent-secrets"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-agent-transport-slim"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-identity",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-identity"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agntcy-slim-bindings",
  "base64 0.22.1",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "agntcy-shadi-mas"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2198,7 +2198,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2515,7 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4554,7 +4554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5525,7 +5525,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5709,7 +5709,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6097,7 +6097,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6156,7 +6156,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7417,7 +7417,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8194,7 +8194,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.8.2",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -8250,7 +8250,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.119",
- "toml 0.8.2",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
 
@@ -8675,7 +8675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/content/javascripts/external-links.js
+++ b/docs/content/javascripts/external-links.js
@@ -2,7 +2,7 @@
 document$.subscribe(function () {
   document.querySelectorAll("a[href]").forEach(function (link) {
     var href = link.getAttribute("href");
-    if (!href || href.charAt(0) === "#" || href.indexOf("javascript:") === 0) {
+    if (!href) {
       return;
     }
 
@@ -13,7 +13,9 @@ document$.subscribe(function () {
       return;
     }
 
-    if (url.protocol === "mailto:" || url.protocol === "tel:") {
+    /* Allowlisted rather than denylisted: mailto:, tel:, javascript: and data:
+       are all left alone without having to be named. */
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
       return;
     }
 


### PR DESCRIPTION
Six jobs ran with the default token permissions; they now declare what they
need. The two release-plz resolve jobs declare nothing — they only parse JSON,
with no checkout or API call.

The external-link script tested for `javascript:` by string prefix, so it missed
`data:`, `vbscript:` and any mixed-case spelling. Inverted to an http/https
allowlist, which leaves unknown schemes alone by construction.