### PR TITLE
feat(ci): add Renovate for dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,39 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report what would change without opening PRs
+        type: boolean
+        default: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Authenticate with GitHub App Bot
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Updating .github/workflows needs a token carrying the workflows
+          # permission, which GITHUB_TOKEN does not have.
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run && 'full' || 'null' }}
+          LOG_LEVEL: info

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommits"],
+  "semanticCommitType": "chore",
+  "labels": ["dependencies"],
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "agntcy-slim* are pinned with = to match the root lockfile; bumping them here breaks resolution.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["/^agntcy-slim/"],
+      "enabled": false
+    },
+    {
+      "description": "Our own crates are released by release-plz, not Renovate.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["/^agntcy-shadi/", "/^agntcy-agentbridge/"],
+      "enabled": false
+    },
+    {
+      "description": "Low-risk bumps in one PR to keep the review load down.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "patch and minor"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #164.

Covers cargo across both workspaces, the desktop pnpm project and the 17
SHA-pinned actions. Weekly, with a dry run available via dispatch.

Skips `agntcy-slim*` (pinned with `=` to match the root lockfile) and our own
crates (release-plz handles those).

Uses the existing GitHub App rather than a PAT. Note it needs the **workflows**
permission to update `.github/workflows`; without it the actions manager will be
skipped.

Config validated with `renovate-config-validator` against the latest Renovate.