### PR TITLE
fix(renovate): group the OpenTelemetry crates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,17 @@
   },
   "packageRules": [
     {
+      "description": "The OpenTelemetry crates must move together: bumping one leaves two opentelemetry versions in the tree and the KeyValue types stop matching. tracing-opentelemetry tracks its own number (0.33 pairs with otel 0.32).",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
+        "/^opentelemetry/",
+        "tracing-opentelemetry"
+      ],
+      "groupName": "opentelemetry"
+    },
+    {
       "description": "agntcy-slim* are pinned with = to match the root lockfile; bumping them here breaks resolution.",
       "matchManagers": [
         "cargo"


### PR DESCRIPTION
#167 bumped `opentelemetry_sdk` 0.24 → 0.32 on its own, which left two
`opentelemetry` versions in the tree and broke the build on `KeyValue` type
mismatches. The family has to move together, and `tracing-opentelemetry` tracks
its own number (0.33 pairs with otel 0.32).

Scope, to be clear: this fixes **routine** updates. Renovate still proposes the
minimal bump for a security advisory, so #167 stays unbuildable — that needs the
actual family upgrade plus code changes in `shadi_telemetry`, which is separate
work.