### PR TITLE
feat(telemetry): move to OpenTelemetry 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,12 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "protoc-bin-vendored",
  "serde",
  "serde_json",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -70,7 +70,7 @@ dependencies = [
  "a2a-lf",
  "a2a-pb",
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "axum-server",
  "chrono",
  "futures",
@@ -81,7 +81,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -104,7 +104,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "futures",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "serde_json",
  "tokio",
@@ -277,7 +277,7 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "tokio",
- "tonic 0.14.5",
+ "tonic",
  "tracing",
  "uds_windows",
  "unicode-width",
@@ -379,12 +379,13 @@ dependencies = [
 name = "agntcy-shadi-telemetry"
 version = "0.1.0"
 dependencies = [
- "opentelemetry 0.24.0",
- "opentelemetry-otlp 0.17.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "tokio",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry 0.25.0",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
 ]
 
@@ -402,7 +403,7 @@ dependencies = [
  "anyhow",
  "clap",
  "duration-string",
- "indexmap 2.14.0",
+ "indexmap",
  "jemallocator",
  "lazy_static",
  "num_cpus",
@@ -451,7 +452,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -515,7 +516,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "percent-encoding",
- "prost 0.14.3",
+ "prost",
  "protoc-bin-vendored",
  "regex",
  "rustls",
@@ -532,11 +533,11 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "tonic-tls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-layer",
  "tower-service",
@@ -564,7 +565,7 @@ dependencies = [
  "futures",
  "h2",
  "parking_lot",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -572,7 +573,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "tracing",
  "uuid",
@@ -604,7 +605,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "parking_lot",
- "prost 0.14.3",
+ "prost",
  "semver",
  "serde",
  "serde_json",
@@ -614,7 +615,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tokio_with_wasm",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "tracing",
  "trait-variant",
@@ -654,12 +655,12 @@ checksum = "f30847ae9f69167f24e549368ef6dfe537068866215e20e0b8faea1eb35d07d7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "protoc-bin-vendored",
  "rand 0.9.2",
  "thiserror 2.0.18",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "twox-hash",
@@ -734,7 +735,7 @@ dependencies = [
  "lru",
  "maybe-async",
  "parking_lot",
- "prost 0.14.3",
+ "prost",
  "rand 0.9.2",
  "serde",
  "serde_json",
@@ -743,7 +744,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tokio_with_wasm",
- "tonic 0.14.5",
+ "tonic",
  "tracing",
  "trait-variant",
  "twox-hash",
@@ -1115,38 +1116,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
@@ -1157,7 +1131,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1168,30 +1142,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -2775,18 +2729,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3037,7 +2985,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3190,16 +3138,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3539,7 +3477,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -3735,12 +3673,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -4219,20 +4151,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -4246,16 +4164,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.13.0"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry 0.24.0",
- "reqwest 0.12.28",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -4272,23 +4191,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.17.0"
+name = "opentelemetry-http"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
- "futures-core",
+ "bytes",
  "http",
- "opentelemetry 0.24.0",
- "opentelemetry-http 0.13.0",
- "opentelemetry-proto 0.7.0",
- "opentelemetry_sdk 0.24.1",
- "prost 0.13.5",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.12.3",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -4302,24 +4214,28 @@ dependencies = [
  "opentelemetry-http 0.31.0",
  "opentelemetry-proto 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
+ "prost",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.5",
+ "tonic",
  "tracing",
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.7.0"
+name = "opentelemetry-otlp"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
- "prost 0.13.5",
- "tonic 0.12.3",
+ "http",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4330,9 +4246,20 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
  "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost",
 ]
 
 [[package]]
@@ -4354,25 +4281,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.24.0",
- "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
@@ -4386,6 +4294,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4493,7 +4417,7 @@ checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck",
  "itertools 0.14.0",
- "prost 0.14.3",
+ "prost",
  "prost-types",
 ]
 
@@ -4507,7 +4431,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.14.3",
+ "prost",
  "prost-build",
  "serde",
 ]
@@ -4595,7 +4519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -4606,7 +4530,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -4784,22 +4708,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4814,26 +4728,13 @@ dependencies = [
  "multimap",
  "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4855,7 +4756,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -5022,7 +4923,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5060,7 +4961,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5283,7 +5184,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5302,6 +5203,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -5327,7 +5229,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5873,7 +5775,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -6054,16 +5956,6 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -6085,7 +5977,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "pkcs8",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -6093,9 +5985,9 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
- "tower 0.5.3",
+ "tower",
  "url",
  "x509-parser",
  "zeroize",
@@ -6419,7 +6311,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6523,7 +6415,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -6556,7 +6448,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -6580,42 +6472,12 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6627,11 +6489,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.5",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6656,8 +6518,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -6686,31 +6548,11 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-util",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tokio-rustls",
- "tonic 0.14.5",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
+ "tonic",
+ "tower",
  "tracing",
 ]
 
@@ -6722,7 +6564,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6748,7 +6590,7 @@ dependencies = [
  "iri-string",
  "mime",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6824,14 +6666,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.25.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -6842,12 +6682,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -7040,7 +6880,7 @@ dependencies = [
  "glob",
  "goblin",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "once_cell",
  "serde",
  "tempfile",
@@ -7082,7 +6922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn",
@@ -7125,7 +6965,7 @@ checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "tempfile",
  "uniffi_internal_macros",
 ]
@@ -7350,7 +7190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7376,7 +7216,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -7746,7 +7586,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -7777,7 +7617,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -7796,7 +7636,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/crates/shadi_telemetry/Cargo.toml
+++ b/crates/shadi_telemetry/Cargo.toml
@@ -10,10 +10,13 @@ repository.workspace = true
 name = "shadi_telemetry"
 
 [dependencies]
-opentelemetry = "0.24"
-opentelemetry_sdk = "0.24"
-opentelemetry-otlp = { version = "0.17", features = ["http-proto", "reqwest-client"] }
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-blocking-client"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.25"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["json"] }
 tracing-appender = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/shadi_telemetry/examples/otel_smoke.rs
+++ b/crates/shadi_telemetry/examples/otel_smoke.rs
@@ -1,0 +1,15 @@
+fn main() {
+    shadi_telemetry::init("otel-smoke");
+
+    tracing::info_span!("outside_runtime").in_scope(|| tracing::info!("sync path"));
+
+    // shadictl runs async work after init; a span ending in that context must
+    // not blow up the exporter.
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        tracing::info_span!("inside_runtime").in_scope(|| tracing::info!("async path"));
+    });
+
+    shadi_telemetry::shutdown();
+    println!("SMOKE OK");
+}

--- a/crates/shadi_telemetry/src/lib.rs
+++ b/crates/shadi_telemetry/src/lib.rs
@@ -37,19 +37,7 @@ pub fn init(service_name: &str) {
             .build();
 
         let otel_layer = if !config.otlp_endpoint.is_empty() {
-            let exporter = opentelemetry_otlp::SpanExporter::builder()
-                .with_http()
-                .with_endpoint(traces_endpoint(&config.otlp_endpoint))
-                .build();
-
-            exporter.ok().map(|exporter| {
-                // Batched, not simple: export runs on its own thread, so it
-                // neither needs a reactor at startup nor blocks inside one when
-                // a span ends in async code.
-                let provider = trace::SdkTracerProvider::builder()
-                    .with_batch_exporter(exporter)
-                    .with_resource(resource)
-                    .build();
+            build_provider(&config.otlp_endpoint, resource).map(|provider| {
                 let _ = PROVIDER.set(provider);
                 let tracer = PROVIDER
                     .get()
@@ -95,6 +83,26 @@ pub fn init(service_name: &str) {
 /// OTEL_EXPORTER_OTLP_ENDPOINT is a base URL per the OpenTelemetry spec, and
 /// 0.24 appended the signal path itself. 0.32 takes the full URL, so a base
 /// endpoint has to be completed here or spans go nowhere.
+/// Build the OTLP provider for an endpoint.
+///
+/// Batched, not simple: export runs on its own thread, so it neither needs a
+/// reactor at startup nor blocks inside one when a span ends in async code.
+/// Nothing here touches the network — that starts when spans are exported.
+fn build_provider(endpoint: &str, resource: Resource) -> Option<trace::SdkTracerProvider> {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(traces_endpoint(endpoint))
+        .build()
+        .ok()?;
+
+    Some(
+        trace::SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(resource)
+            .build(),
+    )
+}
+
 /// Flush and stop the exporter.
 ///
 /// Batched export means spans still in the queue are lost if the process just
@@ -298,5 +306,36 @@ mod tests {
             traces_endpoint("http://collector.example:4318/v1/traces/"),
             "http://collector.example:4318/v1/traces"
         );
+    }
+
+    fn test_resource() -> Resource {
+        Resource::builder()
+            .with_attributes([KeyValue::new("service.name", "coverage-test")])
+            .build()
+    }
+
+    /// Building the provider must not need a collector: the exporter only
+    /// starts talking to one when spans are exported.
+    #[test]
+    fn build_provider_succeeds_without_a_collector() {
+        let provider = build_provider("http://127.0.0.1:9/", test_resource())
+            .expect("provider builds offline");
+        let _ = provider.shutdown();
+    }
+
+    /// A base endpoint is completed on the way into the exporter, so the same
+    /// value that worked before the 0.32 move still works.
+    #[test]
+    fn build_provider_accepts_a_base_endpoint() {
+        let provider =
+            build_provider("http://127.0.0.1:9", test_resource()).expect("provider builds");
+        let _ = provider.shutdown();
+    }
+
+    /// Shutting down before anything was initialised must be a no-op, since
+    /// shadictl calls it unconditionally on the way out.
+    #[test]
+    fn shutdown_without_init_is_harmless() {
+        shutdown();
     }
 }

--- a/crates/shadi_telemetry/src/lib.rs
+++ b/crates/shadi_telemetry/src/lib.rs
@@ -12,7 +12,7 @@ use opentelemetry_sdk::{trace, Resource};
 use tracing_subscriber::layer::SubscriberExt;
 
 static INIT: Once = Once::new();
-static PROVIDER: OnceLock<trace::TracerProvider> = OnceLock::new();
+static PROVIDER: OnceLock<trace::SdkTracerProvider> = OnceLock::new();
 static FILE_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 
 pub fn init(service_name: &str) {
@@ -27,24 +27,29 @@ pub fn init(service_name: &str) {
             return;
         }
 
-        let resource = Resource::new(vec![
-            KeyValue::new("service.name", config.service_name),
-            KeyValue::new("service.namespace", "shadi"),
-            KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
-            KeyValue::new("telemetry.sdk.language", "rust"),
-        ]);
+        let resource = Resource::builder()
+            .with_attributes([
+                KeyValue::new("service.name", config.service_name),
+                KeyValue::new("service.namespace", "shadi"),
+                KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+                KeyValue::new("telemetry.sdk.language", "rust"),
+            ])
+            .build();
 
         let otel_layer = if !config.otlp_endpoint.is_empty() {
-            let exporter = opentelemetry_otlp::new_exporter()
-                .http()
-            .with_endpoint(config.otlp_endpoint);
-            let provider = opentelemetry_otlp::new_pipeline()
-                .tracing()
-                .with_exporter(exporter)
-                .with_trace_config(trace::Config::default().with_resource(resource))
-                .install_simple();
+            let exporter = opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(traces_endpoint(&config.otlp_endpoint))
+                .build();
 
-            provider.ok().map(|provider| {
+            exporter.ok().map(|exporter| {
+                // Batched, not simple: export runs on its own thread, so it
+                // neither needs a reactor at startup nor blocks inside one when
+                // a span ends in async code.
+                let provider = trace::SdkTracerProvider::builder()
+                    .with_batch_exporter(exporter)
+                    .with_resource(resource)
+                    .build();
                 let _ = PROVIDER.set(provider);
                 let tracer = PROVIDER
                     .get()
@@ -85,6 +90,30 @@ pub fn init(service_name: &str) {
 
         let _ = tracing::subscriber::set_global_default(subscriber);
     });
+}
+
+/// OTEL_EXPORTER_OTLP_ENDPOINT is a base URL per the OpenTelemetry spec, and
+/// 0.24 appended the signal path itself. 0.32 takes the full URL, so a base
+/// endpoint has to be completed here or spans go nowhere.
+/// Flush and stop the exporter.
+///
+/// Batched export means spans still in the queue are lost if the process just
+/// exits, so anything that calls [`init`] should call this on the way out.
+pub fn shutdown() {
+    if let Some(provider) = PROVIDER.get() {
+        if let Err(err) = provider.shutdown() {
+            tracing::debug!(%err, "telemetry shutdown failed");
+        }
+    }
+}
+
+fn traces_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.ends_with("/v1/traces") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1/traces")
+    }
 }
 
 fn parse_bool_env(key: &str) -> bool {
@@ -247,5 +276,27 @@ mod tests {
         std::env::remove_var("SHADI_OTEL_CONSOLE");
         std::env::remove_var("SHADI_OTEL_FILE");
         std::env::remove_var("OTEL_SERVICE_NAME");
+    }
+
+    /// A base endpoint has to gain the signal path, or 0.32 exports nowhere.
+    #[test]
+    fn traces_endpoint_completes_a_base_url() {
+        assert_eq!(
+            traces_endpoint("http://localhost:4318"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("http://localhost:4318/"),
+            "http://localhost:4318/v1/traces"
+        );
+        // Already complete, including a trailing slash, is left as it is.
+        assert_eq!(
+            traces_endpoint("http://localhost:4318/v1/traces"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("http://collector.example:4318/v1/traces/"),
+            "http://collector.example:4318/v1/traces"
+        );
     }
 }

--- a/crates/shadictl/src/main.rs
+++ b/crates/shadictl/src/main.rs
@@ -193,7 +193,10 @@ pub(crate) fn scrub_test_secret_backend_env(command: &mut Command) {
 fn main() -> ExitCode {
     shadi_telemetry::init("shadi-core");
     let cli = Cli::parse();
-    run_cli(cli)
+    let code = run_cli(cli);
+    // Export is batched, so queued spans need flushing before we exit.
+    shadi_telemetry::shutdown();
+    code
 }
 
 fn run_named_command(command: Commands) -> ExitCode {


### PR DESCRIPTION
Supersedes #167, which bumped `opentelemetry_sdk` alone and could not build: the
family has to move together, and the 0.24 API is gone.

| crate | before | after |
|---|---|---|
| opentelemetry | 0.24 | 0.32 |
| opentelemetry_sdk | 0.24 | 0.32 |
| opentelemetry-otlp | 0.17 | 0.32 |
| tracing-opentelemetry | 0.25 | 0.33 |

Two problems appeared only at runtime, against a real collector:

- **Threading model.** The async reqwest client needs a reactor, and `shadictl`
  calls `init` from a plain `fn main`, so anyone with
  `OTEL_EXPORTER_OTLP_ENDPOINT` set would panic at startup. The blocking client
  panics the other way when a span ends inside a Tokio runtime. Batched export
  runs on its own thread and is safe in both; it needs a flush on exit, so
  `shutdown()` was added and `shadictl` calls it.
- **Endpoint form.** 0.32 takes the full signal URL where 0.24 appended
  `/v1/traces` itself, so a base endpoint exported nothing. Normalised, with a
  unit test.

`examples/otel_smoke.rs` reproduces both: it emits one span on the sync path and
one inside a Tokio runtime, and needs a collector on :4318.

- [x] spans from both paths reach a live collector with the right `service.name`
- [x] 12 unit tests, no new clippy warnings in the changed files