### PR TITLE
feat(slim): move to SLIM 2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "a2a-client-lf"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a06a40df172bb5ae0f25e3d49e922f0d33f8af49d0b1276307857dbd28ad2"
+checksum = "fa4f2a7d545935d105977030023071f6c4aa85f09969c5639cbb53392329a5be"
 dependencies = [
  "a2a-lf",
  "a2a-pb",
@@ -89,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27ea4381d43e12a146d7851883c7ca36f4f9241bb5471f7d0ff79e501a7881a"
+checksum = "fd59ba9b08bf249c18d3cb660b39a3092549b4cc798e8751a4008c6695f17d2e"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
  "a2a-pb",
  "a2a-server-lf",
- "agntcy-slim-auth 0.14.0",
+ "agntcy-slim-auth",
  "agntcy-slim-datapath",
  "agntcy-slim-rpc",
  "agntcy-slim-service",
@@ -122,7 +122,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -255,7 +255,7 @@ dependencies = [
  "agntcy-shadi-slim-mas",
  "agntcy-shadi-telemetry",
  "agntcy-slim-bindings",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-proto",
  "agntcy-slim-rpc",
  "async-trait",
@@ -289,15 +289,15 @@ dependencies = [
 name = "agntcy-shadi-identity"
 version = "0.1.2"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
+ "agntcy-slim-auth",
  "agntcy-slim-bindings",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "base64 0.22.1",
  "bs58",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hkdf",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde_json",
  "sha2",
  "ssh-key",
@@ -372,7 +372,7 @@ dependencies = [
  "agntcy-shadi-agent-secrets",
  "serde",
  "tempfile",
- "toml 0.8.2",
+ "toml",
 ]
 
 [[package]]
@@ -391,11 +391,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f43eb93679cf06953ce45b0e84a39af275ed578c50c88559aafa58dfd23ea1"
+checksum = "d8e8a8f0242ebe42a1c2e6380c96adf74adf4c4d79c8bc2e268f71fba07654a3"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-service",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
@@ -412,54 +412,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "agntcy-slim-auth"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654c8837097d60e5b743d78e0cbd9f6652c30c5eea1f9d2220ca0c0f03eaa5b2"
-dependencies = [
- "agntcy-slim-version",
- "aws-lc-rs",
- "base64 0.22.1",
- "cfg-if",
- "display-error-chain",
- "ed25519-dalek",
- "futures",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
- "headers",
- "hmac",
- "http",
- "itoa",
- "jsonwebtoken",
- "mls-rs-core",
- "mls-rs-crypto-awslc",
- "notify",
- "oauth2",
- "p256",
- "parking_lot",
- "pin-project",
- "prost-types",
- "rand 0.9.2",
- "reqwest 0.12.28",
- "schemars",
- "serde",
- "serde_json",
- "sha2",
- "spiffe",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "trait-variant",
- "url",
- "web-time",
- "wiremock",
 ]
 
 [[package]]
@@ -514,15 +466,16 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.9"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c573ad754afef57641c594094774fc2710752a49bb47f03f216f09c72db2b4f"
+checksum = "ebe7f7b54c3c11b192fd49d8e3f829dc2c6e482978f3f0e282a20b47d76aba95"
 dependencies = [
  "agntcy-slim",
- "agntcy-slim-auth 0.14.0",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
  "agntcy-slim-controller",
  "agntcy-slim-datapath",
+ "agntcy-slim-persistence",
  "agntcy-slim-service",
  "agntcy-slim-session",
  "agntcy-slim-signal",
@@ -531,69 +484,16 @@ dependencies = [
  "display-error-chain",
  "futures",
  "futures-timer",
+ "getrandom 0.4.2",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio_with_wasm",
  "tracing",
  "uniffi",
-]
-
-[[package]]
-name = "agntcy-slim-config"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d88023cb3c5531fe7d649a312038986830c5ea112e73e93ef464091e8f28a1"
-dependencies = [
- "agntcy-slim-auth 0.14.0",
- "agntcy-slim-version",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "display-error-chain",
- "drain",
- "duration-string",
- "fastwebsockets",
- "futures",
- "gloo-net",
- "http",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "lazy_static",
- "parking_lot",
- "percent-encoding",
- "prost",
- "protoc-bin-vendored",
- "regex",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "schemars",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha1",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tonic-tls",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-test",
- "uuid",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -602,7 +502,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "474e2b090eb508ccecb5d13e5ad21e1c67f7875777b5b44ccde37d5a7ac9e0d9"
 dependencies = [
- "agntcy-slim-auth 0.15.3",
+ "agntcy-slim-auth",
  "agntcy-slim-version",
  "async-trait",
  "base64 0.22.1",
@@ -656,12 +556,12 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6e6650f780c9c825df1bbe0b5dc4ffe8700da15a541a07c9c74e21a066ba8b"
+checksum = "70a93259468af1ba8b84353234e71e7a6daf82e081ed61ea3ca7f3f5ea47c367"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
  "agntcy-slim-datapath",
  "agntcy-slim-proto",
  "agntcy-slim-session",
@@ -689,11 +589,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.7"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ddc1f599b42926bf968c156b19ffb9424be8aa92899eff3d95e63b65fe8684"
+checksum = "62edabc21dae9664450a4aca60f0855fab034fb9cf1cc4557651c05d413912ed"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-proto",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
@@ -705,6 +605,7 @@ dependencies = [
  "fastwebsockets",
  "futures",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "gloo-net",
  "h2",
  "hkdf",
@@ -712,8 +613,10 @@ dependencies = [
  "http",
  "k8s-openapi",
  "kube",
+ "ml-kem",
  "parking_lot",
  "prost",
+ "rand_core 0.10.1",
  "semver",
  "serde",
  "serde_json",
@@ -735,11 +638,12 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df5215c5cd95bf4638eb6f60f2943602d30486a12e5d7bc7e9b3f7e7970cb30"
+checksum = "4f337c6ea3fb2705d589b3c284b272111e40501946b1d846a2bb106fb7d2d897"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
+ "agntcy-slim-auth",
+ "agntcy-slim-persistence",
  "agntcy-slim-version",
  "async-trait",
  "base64 0.22.1",
@@ -756,12 +660,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-slim-proto"
-version = "0.4.0"
+name = "agntcy-slim-persistence"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30847ae9f69167f24e549368ef6dfe537068866215e20e0b8faea1eb35d07d7"
+checksum = "27fa0805c1f62bb7a468949d263e099f456a3c03aeb4a0a3f347d690d7912ba2"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "async-trait",
+ "aws-lc-rs",
+ "hex",
+ "maybe-async",
+ "mls-rs",
+ "mls-rs-core",
+ "mls-rs-provider-sqlite",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "agntcy-slim-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61cd563e5858828f51075104bc4e10f7100e207942852ecbd52b71d7f2266ae"
+dependencies = [
+ "agntcy-slim-config",
  "agntcy-slim-version",
  "prost",
  "prost-types",
@@ -777,11 +700,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9fea60e5dd2ca3094dc0c64946cbcc1bfd0fd81d067fba650aea4e31cae75d"
+checksum = "d1c5345cff48572f59e1439e7fcefb68835a7d6c9db792d0caf6f266396a9efe"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
+ "agntcy-slim-auth",
  "agntcy-slim-datapath",
  "agntcy-slim-service",
  "agntcy-slim-session",
@@ -801,15 +724,16 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.6"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f69c52ac896b7843749153304946a7e3ab92a73507fd6e28fb3cf8c09fc416"
+checksum = "61ab07d80f58088894cca11e441d4350db8264d993b390d096878aab37c1fd8a"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
  "agntcy-slim-controller",
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
+ "agntcy-slim-persistence",
  "agntcy-slim-session",
  "agntcy-slim-version",
  "async-trait",
@@ -820,6 +744,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "twox-hash",
  "uuid",
@@ -827,13 +752,14 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.6.0"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419f8c615ed19d92ad0d12ef5a8b70b47becf926ee688fa869c3c09e8dd86e1"
+checksum = "33ab6aef0e29c87554aee204d3c057093617d68d259353782767de0d1a7f9949"
 dependencies = [
- "agntcy-slim-auth 0.14.0",
+ "agntcy-slim-auth",
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
+ "agntcy-slim-persistence",
  "agntcy-slim-version",
  "async-trait",
  "base64 0.22.1",
@@ -860,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.15"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966ba5a71aa51239bc0394dd01404c4a675ef41a7283cde057c1bf31ac0a6246"
+checksum = "4686e847b05d55ecfd2de42f2556a124932a926b21fed6270621e3fdb6231e64"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -875,7 +801,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903570b0082ed35b6840d1307727511ed4a4de5ebd300480210e1876576d0bed"
 dependencies = [
- "agntcy-slim-config 0.16.0",
+ "agntcy-slim-config",
  "agntcy-slim-version",
  "cfg-if",
  "getrandom 0.3.4",
@@ -1440,7 +1366,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1450,6 +1376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1738,7 +1673,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1811,7 +1746,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1822,6 +1757,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1986,6 +1927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +1957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,7 +1974,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2232,10 +2192,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2284,10 +2254,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-traits",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rfc6979",
  "sha2",
  "signature",
@@ -2344,11 +2314,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2357,7 +2327,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -2402,13 +2372,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -3004,15 +2974,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3044,11 +3005,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3111,7 +3072,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3178,6 +3139,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3718,6 +3689,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,7 +3834,7 @@ dependencies = [
  "petgraph 0.7.1",
  "regex",
  "regex-syntax",
- "sha3",
+ "sha3 0.10.8",
  "string_cache",
  "term",
  "unicode-xid",
@@ -3916,9 +3907,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4000,7 +3991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4062,6 +4053,20 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -4212,6 +4217,32 @@ dependencies = [
  "mls-rs-core",
  "thiserror 2.0.18",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "mls-rs-provider-sqlite"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796ab65c2c729b05aa1b901a42d9adabb183ccb10d9aa3e6a50ebfe11e5c10e"
+dependencies = [
+ "async-trait",
+ "hex",
+ "maybe-async",
+ "mls-rs-core",
+ "rusqlite",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -4451,7 +4482,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4761,7 +4792,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4918,8 +4949,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
- "pkcs8",
- "spki",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4929,7 +4960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -5669,7 +5710,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5679,24 +5720,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid 0.9.6",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
@@ -5932,7 +5973,7 @@ dependencies = [
  "base16ct",
  "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6002,7 +6043,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "block-padding",
  "blowfish",
  "buffered-reader",
@@ -6014,7 +6055,7 @@ dependencies = [
  "chrono",
  "cipher",
  "des",
- "digest",
+ "digest 0.10.7",
  "dsa",
  "dyn-clone",
  "eax",
@@ -6045,7 +6086,7 @@ dependencies = [
  "rsa",
  "sha1collisiondetection",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 2.0.18",
  "twofish",
  "typenum",
@@ -6149,15 +6190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6190,7 +6222,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6200,7 +6232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f606421e4a6012877e893c399822a4ed4b089164c5969424e1b9d1e66e6964b"
 dependencies = [
  "const-oid 0.9.6",
- "digest",
+ "digest 0.10.7",
  "generic-array 1.3.5",
 ]
 
@@ -6212,7 +6244,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6221,8 +6253,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.2",
 ]
 
 [[package]]
@@ -6292,7 +6334,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6376,7 +6418,7 @@ dependencies = [
  "futures",
  "hyper-util",
  "jsonwebtoken",
- "pkcs8",
+ "pkcs8 0.10.2",
  "prost",
  "prost-types",
  "serde",
@@ -6422,6 +6464,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -6810,24 +6862,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6840,15 +6877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6856,25 +6884,10 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "serde_spanned",
+ "toml_datetime",
  "winnow 0.5.40",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
-dependencies = [
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -7298,7 +7311,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -7354,7 +7367,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "uniffi_meta",
 ]
 
@@ -7401,7 +7414,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -7982,12 +7995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8204,18 +8211,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/shadi_desktop/src-tauri/Cargo.lock
+++ b/apps/shadi_desktop/src-tauri/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "a2a-client-lf"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a06a40df172bb5ae0f25e3d49e922f0d33f8af49d0b1276307857dbd28ad2"
+checksum = "fa4f2a7d545935d105977030023071f6c4aa85f09969c5639cbb53392329a5be"
 dependencies = [
  "a2a-lf",
  "a2a-pb",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27ea4381d43e12a146d7851883c7ca36f4f9241bb5471f7d0ff79e501a7881a"
+checksum = "fd59ba9b08bf249c18d3cb660b39a3092549b4cc798e8751a4008c6695f17d2e"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -122,7 +122,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -208,7 +208,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hkdf",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde_json",
  "sha2",
  "ssh-key",
@@ -233,11 +233,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f43eb93679cf06953ce45b0e84a39af275ed578c50c88559aafa58dfd23ea1"
+checksum = "d8e8a8f0242ebe42a1c2e6380c96adf74adf4c4d79c8bc2e268f71fba07654a3"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-service",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
@@ -258,13 +258,14 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.14.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bb128a295a2fb74f7088b5d3eedb63d2d2aa47e771f76094fd52dacd24949a"
+checksum = "62d59be77bf084103033ea23133cab57a4b646068ce16513358d3c922ae18cde"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
  "base64 0.22.1",
+ "cel",
  "cfg-if",
  "display-error-chain",
  "ed25519-dalek",
@@ -285,6 +286,7 @@ dependencies = [
  "pin-project",
  "prost-types",
  "rand 0.9.5",
+ "regorus",
  "reqwest 0.12.28",
  "schemars 1.2.2",
  "serde",
@@ -306,15 +308,16 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-bindings"
-version = "2.0.0-alpha.9"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c573ad754afef57641c594094774fc2710752a49bb47f03f216f09c72db2b4f"
+checksum = "ebe7f7b54c3c11b192fd49d8e3f829dc2c6e482978f3f0e282a20b47d76aba95"
 dependencies = [
  "agntcy-slim",
  "agntcy-slim-auth",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-controller",
  "agntcy-slim-datapath",
+ "agntcy-slim-persistence",
  "agntcy-slim-service",
  "agntcy-slim-session",
  "agntcy-slim-signal",
@@ -323,20 +326,23 @@ dependencies = [
  "display-error-chain",
  "futures",
  "futures-timer",
+ "getrandom 0.4.3",
  "parking_lot",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tokio_with_wasm",
  "tracing",
  "uniffi",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d88023cb3c5531fe7d649a312038986830c5ea112e73e93ef464091e8f28a1"
+checksum = "474e2b090eb508ccecb5d13e5ad21e1c67f7875777b5b44ccde37d5a7ac9e0d9"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -348,63 +354,9 @@ dependencies = [
  "drain",
  "duration-string",
  "fastwebsockets",
+ "fs2",
  "futures",
- "gloo-net",
- "http",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "lazy_static",
- "parking_lot",
- "percent-encoding",
- "prost",
- "protoc-bin-vendored",
- "regex",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "schemars 1.2.2",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha1",
- "thiserror 2.0.19",
- "tokio",
- "tokio-retry",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tonic-tls",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-test",
- "uuid",
-]
-
-[[package]]
-name = "agntcy-slim-config"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594dd1049a235687db481f31a9e60aeea55fc235d1ee110f911c6f48b3753cb6"
-dependencies = [
- "agntcy-slim-auth",
- "agntcy-slim-version",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "display-error-chain",
- "drain",
- "duration-string",
- "fastwebsockets",
- "futures",
+ "getrandom 0.4.3",
  "gloo-net",
  "http",
  "http-body-util",
@@ -446,12 +398,12 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6e6650f780c9c825df1bbe0b5dc4ffe8700da15a541a07c9c74e21a066ba8b"
+checksum = "70a93259468af1ba8b84353234e71e7a6daf82e081ed61ea3ca7f3f5ea47c367"
 dependencies = [
  "agntcy-slim-auth",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-datapath",
  "agntcy-slim-proto",
  "agntcy-slim-session",
@@ -479,11 +431,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.7"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ddc1f599b42926bf968c156b19ffb9424be8aa92899eff3d95e63b65fe8684"
+checksum = "62edabc21dae9664450a4aca60f0855fab034fb9cf1cc4557651c05d413912ed"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-proto",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
@@ -495,6 +447,7 @@ dependencies = [
  "fastwebsockets",
  "futures",
  "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "gloo-net",
  "h2",
  "hkdf",
@@ -502,8 +455,10 @@ dependencies = [
  "http",
  "k8s-openapi",
  "kube",
+ "ml-kem",
  "parking_lot",
  "prost",
+ "rand_core 0.10.1",
  "semver",
  "serde",
  "serde_json",
@@ -525,11 +480,12 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df5215c5cd95bf4638eb6f60f2943602d30486a12e5d7bc7e9b3f7e7970cb30"
+checksum = "4f337c6ea3fb2705d589b3c284b272111e40501946b1d846a2bb106fb7d2d897"
 dependencies = [
  "agntcy-slim-auth",
+ "agntcy-slim-persistence",
  "agntcy-slim-version",
  "async-trait",
  "base64 0.22.1",
@@ -546,12 +502,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-slim-proto"
-version = "0.4.0"
+name = "agntcy-slim-persistence"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30847ae9f69167f24e549368ef6dfe537068866215e20e0b8faea1eb35d07d7"
+checksum = "27fa0805c1f62bb7a468949d263e099f456a3c03aeb4a0a3f347d690d7912ba2"
 dependencies = [
- "agntcy-slim-config 0.12.6",
+ "async-trait",
+ "aws-lc-rs",
+ "hex",
+ "maybe-async",
+ "mls-rs",
+ "mls-rs-core",
+ "mls-rs-provider-sqlite",
+ "serde",
+ "thiserror 2.0.19",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "agntcy-slim-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61cd563e5858828f51075104bc4e10f7100e207942852ecbd52b71d7f2266ae"
+dependencies = [
+ "agntcy-slim-config",
  "agntcy-slim-version",
  "prost",
  "prost-types",
@@ -567,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.7"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9fea60e5dd2ca3094dc0c64946cbcc1bfd0fd81d067fba650aea4e31cae75d"
+checksum = "d1c5345cff48572f59e1439e7fcefb68835a7d6c9db792d0caf6f266396a9efe"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -591,15 +566,16 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.6"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f69c52ac896b7843749153304946a7e3ab92a73507fd6e28fb3cf8c09fc416"
+checksum = "61ab07d80f58088894cca11e441d4350db8264d993b390d096878aab37c1fd8a"
 dependencies = [
  "agntcy-slim-auth",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-controller",
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
+ "agntcy-slim-persistence",
  "agntcy-slim-session",
  "agntcy-slim-version",
  "async-trait",
@@ -610,6 +586,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "twox-hash",
  "uuid",
@@ -617,13 +594,14 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.6.0"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419f8c615ed19d92ad0d12ef5a8b70b47becf926ee688fa869c3c09e8dd86e1"
+checksum = "33ab6aef0e29c87554aee204d3c057093617d68d259353782767de0d1a7f9949"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
+ "agntcy-slim-persistence",
  "agntcy-slim-version",
  "async-trait",
  "base64 0.22.1",
@@ -650,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.16"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523f6c21575a78735c40e09053ad4a60d1c0ba721219c85b9995ee99d12068e8"
+checksum = "4686e847b05d55ecfd2de42f2556a124932a926b21fed6270621e3fdb6231e64"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -661,11 +639,11 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.9"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3be050abbf6892c15f35355d6f40ac38430ea7b9180c0deb63faaeaaf098a86"
+checksum = "903570b0082ed35b6840d1307727511ed4a4de5ebd300480210e1876576d0bed"
 dependencies = [
- "agntcy-slim-config 0.13.0",
+ "agntcy-slim-config",
  "agntcy-slim-version",
  "cfg-if",
  "getrandom 0.3.4",
@@ -686,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.8"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aebebf0d262078eb5f94f89c8d9f0298bc5f5ee9768418015f027bc6fb52245"
+checksum = "514e51224d27d4e8ccf56802b568cdfe6cf43fc6f724368c79306d6ec0651af0"
 
 [[package]]
 name = "ahash"
@@ -699,6 +677,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -790,6 +769,23 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antlr4rust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093d520274bfff7278d776f7ea12981a0a0a6f96db90964658e0f38fc6e9a6a6"
+dependencies = [
+ "better_any",
+ "bit-set",
+ "byteorder",
+ "lazy_static",
+ "murmur3",
+ "once_cell",
+ "parking_lot",
+ "typed-arena",
+ "uuid",
 ]
 
 [[package]]
@@ -1279,6 +1275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,10 +1435,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1533,6 +1566,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cel"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+dependencies = [
+ "antlr4rust",
+ "chrono",
+ "lazy_static",
+ "nom",
+ "pastey",
+ "regex",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,12 +1666,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -1684,6 +1743,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1873,6 +1947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,7 +1965,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -1921,6 +2005,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +2022,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2122,7 +2215,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2174,10 +2267,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2346,11 +2449,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2359,7 +2462,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -2404,15 +2507,24 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2434,6 +2546,18 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -2539,6 +2663,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2769,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2860,16 @@ checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3063,6 +3241,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,7 +3510,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3379,6 +3578,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3950,6 +4159,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,6 +4222,26 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4177,6 +4442,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4271,6 +4547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +4587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
 name = "mls-rs"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,7 +4622,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "spin",
+ "spin 0.10.1",
  "subtle",
  "thiserror 2.0.19",
  "wasm-bindgen",
@@ -4455,6 +4751,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mls-rs-provider-sqlite"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796ab65c2c729b05aa1b901a42d9adabb183ccb10d9aa3e6a50ebfe11e5c10e"
+dependencies = [
+ "async-trait",
+ "hex",
+ "maybe-async",
+ "mls-rs-core",
+ "rusqlite",
+ "thiserror 2.0.19",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,6 +4811,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmur3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "ndk"
@@ -4558,12 +4898,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -4579,6 +4958,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5003,6 +5403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5069,6 +5475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbjson"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,7 +5523,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5194,12 +5606,21 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -5210,7 +5631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5220,7 +5641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5230,10 +5651,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -5289,7 +5719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -5396,6 +5836,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -5899,6 +6351,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5928,6 +6397,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "regorus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "data-encoding",
+ "globset",
+ "indexmap 2.14.0",
+ "ipnet",
+ "jsonschema",
+ "lazy_static",
+ "lru",
+ "msvc_spectre_libs",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "parking_lot",
+ "postcard",
+ "rand 0.10.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "spin 0.12.3",
+ "thiserror 2.0.19",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5953,6 +6455,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6061,6 +6564,20 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6306,7 +6823,7 @@ dependencies = [
  "base16ct",
  "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6367,7 +6884,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -6619,7 +7136,7 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6630,7 +7147,17 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -6643,7 +7170,7 @@ dependencies = [
  "agntcy-shadi-mas",
  "agntcy-slim",
  "agntcy-slim-bindings",
- "agntcy-slim-config 0.12.6",
+ "agntcy-slim-config",
  "agntcy-slim-proto",
  "agntcy-slim-rpc",
  "base64 0.22.1",
@@ -6699,7 +7226,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6731,7 +7258,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.19",
  "time",
@@ -6831,7 +7358,7 @@ dependencies = [
  "futures",
  "hyper-util",
  "jsonwebtoken",
- "pkcs8",
+ "pkcs8 0.10.2",
  "prost",
  "prost-types",
  "serde",
@@ -6858,6 +7385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6865,6 +7398,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -6932,7 +7475,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -6943,7 +7486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -7376,7 +7919,7 @@ dependencies = [
  "json-patch 3.0.1",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -8071,6 +8614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8145,6 +8694,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -8297,7 +8852,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -8370,8 +8925,19 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -8379,6 +8945,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -8391,6 +8963,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"
@@ -8540,7 +9118,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",

--- a/apps/shadi_desktop/src-tauri/Cargo.toml
+++ b/apps/shadi_desktop/src-tauri/Cargo.toml
@@ -36,17 +36,14 @@ agentbridge = { package = "agntcy-agentbridge", version = "0.1.1", path = "../..
 shadi_mas = { package = "agntcy-shadi-mas", version = "0.1.1", path = "../../../crates/shadi_mas" }
 uuid = { version = "1", features = ["v4"] }
 
-# Pinned to exactly what the root SHADI workspace's Cargo.lock already
-# resolves. Without this, this independently-resolved workspace picks up
-# newer alpha releases of these two crates, whose transitive requirement on
-# agntcy-slim-service/agntcy-slim-proto conflicts with a2a-slimrpc's own
-# direct (older) requirement on those same crates — two incompatible
-# versions of each end up in the graph and the build fails to link types.
-slim = { package = "agntcy-slim", version = "=2.0.0-alpha.7" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "=2.0.0-alpha.7" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "=2.0.0-alpha.9" }
-slim_proto = { package = "agntcy-slim-proto", version = "0.4.0" }
-slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
+# Kept in step with the root SHADI workspace. The `=` pins these carried are
+# gone: they existed because a2a-slimrpc required older
+# agntcy-slim-service/agntcy-slim-proto, which 0.2.5 no longer does.
+slim = { package = "agntcy-slim", version = "2.3.0" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.3.0" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
+slim_proto = { package = "agntcy-slim-proto", version = "0.6.0" }
+slim_config = { package = "agntcy-slim-config", version = "0.16.0" }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../../../crates/shadi_identity" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.0", path = "../../../crates/agent_secrets" }
 # mTLS bootstrap without an openssl binary — the desktop app has to work on a

--- a/apps/shadi_desktop/src-tauri/src/commands/slim.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/slim.rs
@@ -378,8 +378,10 @@ impl Inner {
         let participants = session.participants_list().map_err(slim_err)?;
         Ok(participants
             .into_iter()
-            .map(|name| {
-                let name = name.to_string();
+            // 2.3 returns ParticipantInfo (name plus status) rather than the
+            // name alone; the status is not surfaced yet.
+            .map(|participant| {
+                let name = participant.name.to_string();
                 room.admitted.get(&name).cloned().unwrap_or(SlimGroupMember {
                     name,
                     did: String::new(),
@@ -1002,6 +1004,8 @@ fn build_core_client_config(endpoint: &str) -> Result<CoreClientConfig, String> 
                     include_system_ca_certs_pool: false,
                     tls_version: "tls1.3".to_string(),
                     reload_interval: None,
+                    // slim-config 0.16 added this; upstream defaults it off.
+                    enforce_pqc: false,
                 },
                 insecure: false,
                 insecure_skip_verify: false,

--- a/crates/agent_transport_slim/Cargo.toml
+++ b/crates/agent_transport_slim/Cargo.toml
@@ -16,4 +16,4 @@ slim = []
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.1", path = "../agent_secrets" }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.2", path = "../shadi_identity" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }

--- a/crates/agentbridge_cli/Cargo.toml
+++ b/crates/agentbridge_cli/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 agentbridge = { package = "agntcy-agentbridge", version = "0.1.3", path = "../agentbridge" }
 shadi_mas = { package = "agntcy-shadi-mas", version = "0.1.3", path = "../shadi_mas" }
 shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.3", path = "../shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.7" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.3.0" }
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.1", path = "../agent_secrets" }

--- a/crates/shadi_a2a/Cargo.toml
+++ b/crates/shadi_a2a/Cargo.toml
@@ -15,11 +15,11 @@ agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.1", pat
 a2a = { package = "a2a-lf", version = "0.3.0" }
 a2a-client = { package = "a2a-client-lf", version = "0.2.1" }
 a2a-server = { package = "a2a-server-lf", version = "0.4.1" }
-a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.3" }
+a2a-slimrpc = { package = "a2a-slimrpc", version = "0.2.5" }
 async-stream = "0.3"
 async-trait = "0.1"
 futures = "0.3"
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/shadi_identity/Cargo.toml
+++ b/crates/shadi_identity/Cargo.toml
@@ -18,12 +18,12 @@ base64 = "0.22"
 serde_json = "1.0"
 hkdf = "0.12"
 sha2 = "0.10"
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
 # OpenSSH key parsing for the SSH-rooted identity source (agntcy/shadi#140).
 # `encryption` brings bcrypt-pbkdf so passphrase-protected keys work.
 ssh-key = { version = "0.6", default-features = false, features = ["alloc", "ed25519", "encryption", "rand_core", "getrandom"] }
 
 [dev-dependencies]
-slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
-slim_auth = { package = "agntcy-slim-auth", version = "0.14.0" }
+slim_config = { package = "agntcy-slim-config", version = "0.16.0" }
+slim_auth = { package = "agntcy-slim-auth", version = "0.15.3" }
 tokio = { version = "1", features = ["full"] }

--- a/crates/shadi_mas/Cargo.toml
+++ b/crates/shadi_mas/Cargo.toml
@@ -19,7 +19,7 @@ agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.1", pat
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.2", path = "../shadi_identity" }
 agent_transport_slim = { package = "agntcy-shadi-agent-transport-slim", version = "0.2.2", path = "../agent_transport_slim" }
 shadi_a2a = { package = "agntcy-shadi-a2a", version = "0.1.3", path = "../shadi_a2a" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
 tokio = { version = "1", features = ["rt", "time"] }
 tracing = "0.1"
 

--- a/crates/shadi_memory/Cargo.toml
+++ b/crates/shadi_memory/Cargo.toml
@@ -11,7 +11,7 @@ name = "shadi_memory"
 
 [dependencies]
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.1", path = "../agent_secrets" }
-rusqlite = { version = "0.31", features = ["bundled-sqlcipher"] }
+rusqlite = { version = "0.37", features = ["bundled-sqlcipher"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/crates/shadictl/Cargo.toml
+++ b/crates/shadictl/Cargo.toml
@@ -26,10 +26,10 @@ shadi_memory = { package = "agntcy-shadi-memory", version = "0.1.3", path = "../
 shadi_telemetry = { package = "agntcy-shadi-telemetry", version = "0.1.0", path = "../shadi_telemetry" }
 slim_mas = { package = "agntcy-shadi-slim-mas", version = "0.1.3", path = "../slim_mas" }
 agentbridge = { package = "agntcy-agentbridge", version = "0.1.3", path = "../agentbridge" }
-slim_bindings = { package = "agntcy-slim-bindings", version = "2.0.0-alpha.8" }
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.7" }
-slim_proto = { package = "agntcy-slim-proto", version = "0.4.0" }
-slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
+slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.3.0" }
+slim_proto = { package = "agntcy-slim-proto", version = "0.6.0" }
+slim_config = { package = "agntcy-slim-config", version = "0.16.0" }
 tonic = { version = "0.14" }
 uuid = { version = "1", features = ["v4"] }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.2", path = "../shadi_identity" }

--- a/crates/shadictl/src/slim_controller.rs
+++ b/crates/shadictl/src/slim_controller.rs
@@ -199,6 +199,9 @@ fn build_core_client_config(endpoint: &str) -> Result<CoreClientConfig, String> 
             include_system_ca_certs_pool: false,
             tls_version: "tls1.3".to_string(),
             reload_interval: None,
+            // slim-config 0.16 added this; upstream defaults it off and drives
+            // it from dataplane.enforce_pqc rather than the tls settings.
+            enforce_pqc: false,
         },
         insecure: false,
         insecure_skip_verify: false,

--- a/renovate.json
+++ b/renovate.json
@@ -40,14 +40,14 @@
       "groupName": "opentelemetry"
     },
     {
-      "description": "agntcy-slim* are pinned with = to match the root lockfile; bumping them here breaks resolution.",
+      "description": "The SLIM crates must move together: slim_auth 0.14 caps below 0.15 while slim_rpc 2.3 requires it, which puts two versions in the tree and breaks the TokenProvider bounds.",
       "matchManagers": [
         "cargo"
       ],
       "matchPackageNames": [
         "/^agntcy-slim/"
       ],
-      "enabled": false
+      "groupName": "slim"
     },
     {
       "description": "Our own crates are released by release-plz, not Renovate.",


### PR DESCRIPTION
The alpha pins were held back by our own `rusqlite` 0.31: slim-bindings 2.3 pulls
`libsqlite3-sys` 0.35 through slim-persistence, and only one package may link
`sqlite3`. `rusqlite` 0.37 compiles unchanged. `a2a-slimrpc` 0.2.5 carries the
matching `slim-auth` 0.15, so the desktop `=` pins are gone and Renovate now
groups the SLIM crates instead of skipping them.

Two API changes: `slim-config` 0.16 added `Config::enforce_pqc` (defaulted off,
as upstream does) and `participants_list` returns `ParticipantInfo` rather than a
name.

Note the `rusqlite` bump changes the SQLCipher build, so the WinGet manifest's
OpenSSL dependency needs re-checking after release.