### PR TITLE
fix(agentbridge): Ctrl-C hang and orphaned child process on listener shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ name = "agntcy-agentbridge"
 version = "0.1.4"
 dependencies = [
  "agntcy-shadi-mas",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/agentbridge/Cargo.toml
+++ b/crates/agentbridge/Cargo.toml
@@ -19,6 +19,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 thiserror = "2.0"
 tracing = "0.1"
 time = { version = "0.3", features = ["formatting"] }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/crates/agentbridge/Cargo.toml
+++ b/crates/agentbridge/Cargo.toml
@@ -19,7 +19,16 @@ uuid = { version = "1", features = ["v4", "serde"] }
 thiserror = "2.0"
 tracing = "0.1"
 time = { version = "0.3", features = ["formatting"] }
+
+# Killing a tracked child by pid: signals on unix, TerminateProcess on windows.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/crates/agentbridge/src/adapter.rs
+++ b/crates/agentbridge/src/adapter.rs
@@ -39,6 +39,14 @@ pub trait CliAdapter: Send + Sync {
     /// Send a free-form prompt to the CLI tool and return its text response.
     /// Used by `CliToolAdapter` to drive the development coordination loop.
     fn execute_prompt(&self, prompt: &str) -> Result<String, CliAdapterError>;
+
+    /// Best-effort: terminate whatever child process this adapter's most
+    /// recent `execute_prompt` call spawned, if it's still running. Called
+    /// during listener shutdown so an in-flight message doesn't leave an
+    /// orphaned process behind after the listener itself has exited.
+    /// Default no-op — adapters that don't track a live child don't need
+    /// to implement this.
+    fn kill_in_flight(&self) {}
 }
 
 /// Wraps any [`CliAdapter`] as a `shadi_mas::ToolAdapter` so it can be

--- a/crates/agentbridge/src/adapters/claude_code.rs
+++ b/crates/agentbridge/src/adapters/claude_code.rs
@@ -9,6 +9,7 @@ use std::{
 use crate::{
     adapter::{CliAdapter, CliAdapterError},
     context::{ArtifactPayload, ConversationMessage, ContextPacket},
+    subprocess::TrackedSubprocess,
 };
 
 // --- Claude CLI output schema -----------------------------------------------
@@ -31,10 +32,6 @@ struct State {
     /// Session ID from the last successful `claude --print` call.
     /// Passed as `--session-id` to maintain conversation continuity.
     session_id: Option<String>,
-    /// PID of the currently in-flight `claude` child, if any — set right
-    /// after spawn, cleared right after it exits. Lets `kill_in_flight`
-    /// reach a child that's still running when shutdown is requested.
-    active_child_pid: Option<u32>,
 }
 
 /// Adapter for the Claude Code CLI (`claude`).
@@ -48,6 +45,7 @@ pub struct ClaudeCodeAdapter {
     id: AgentId,
     work_dir: PathBuf,
     state: Mutex<State>,
+    subprocess: TrackedSubprocess,
 }
 
 impl ClaudeCodeAdapter {
@@ -57,7 +55,8 @@ impl ClaudeCodeAdapter {
         Self {
             id: AgentId(id.into()),
             work_dir: work_dir.into(),
-            state: Mutex::new(State { session_id: None, active_child_pid: None }),
+            state: Mutex::new(State { session_id: None }),
+            subprocess: TrackedSubprocess::new(),
         }
     }
 
@@ -113,21 +112,9 @@ impl ClaudeCodeAdapter {
         }
         cmd.arg(&effective_prompt);
 
-        let child = cmd
-            .spawn()
-            .map_err(|e| CliAdapterError::Subprocess(format!("failed to run claude: {e}")))?;
-
-        if let Ok(mut state) = self.state.lock() {
-            state.active_child_pid = Some(child.id());
-        }
-
-        let output = child.wait_with_output();
-
-        if let Ok(mut state) = self.state.lock() {
-            state.active_child_pid = None;
-        }
-
-        let output = output
+        let output = self
+            .subprocess
+            .output(&mut cmd)
             .map_err(|e| CliAdapterError::Subprocess(format!("failed to run claude: {e}")))?;
 
         if !output.status.success() && output.stdout.is_empty() {
@@ -269,19 +256,7 @@ impl CliAdapter for ClaudeCodeAdapter {
     }
 
     fn kill_in_flight(&self) {
-        let pid = match self.state.lock() {
-            Ok(state) => state.active_child_pid,
-            Err(_) => None,
-        };
-        if let Some(pid) = pid {
-            // SAFETY: `pid` is a plain integer we recorded from `Child::id()`
-            // moments ago; passing it to `kill(2)` cannot violate memory
-            // safety even if the process has since exited (that just makes
-            // the call a harmless no-op, reported as ESRCH).
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-            }
-        }
+        self.subprocess.kill();
     }
 }
 

--- a/crates/agentbridge/src/adapters/claude_code.rs
+++ b/crates/agentbridge/src/adapters/claude_code.rs
@@ -31,6 +31,10 @@ struct State {
     /// Session ID from the last successful `claude --print` call.
     /// Passed as `--session-id` to maintain conversation continuity.
     session_id: Option<String>,
+    /// PID of the currently in-flight `claude` child, if any — set right
+    /// after spawn, cleared right after it exits. Lets `kill_in_flight`
+    /// reach a child that's still running when shutdown is requested.
+    active_child_pid: Option<u32>,
 }
 
 /// Adapter for the Claude Code CLI (`claude`).
@@ -53,7 +57,7 @@ impl ClaudeCodeAdapter {
         Self {
             id: AgentId(id.into()),
             work_dir: work_dir.into(),
-            state: Mutex::new(State { session_id: None }),
+            state: Mutex::new(State { session_id: None, active_child_pid: None }),
         }
     }
 
@@ -109,8 +113,21 @@ impl ClaudeCodeAdapter {
         }
         cmd.arg(&effective_prompt);
 
-        let output = cmd
-            .output()
+        let child = cmd
+            .spawn()
+            .map_err(|e| CliAdapterError::Subprocess(format!("failed to run claude: {e}")))?;
+
+        if let Ok(mut state) = self.state.lock() {
+            state.active_child_pid = Some(child.id());
+        }
+
+        let output = child.wait_with_output();
+
+        if let Ok(mut state) = self.state.lock() {
+            state.active_child_pid = None;
+        }
+
+        let output = output
             .map_err(|e| CliAdapterError::Subprocess(format!("failed to run claude: {e}")))?;
 
         if !output.status.success() && output.stdout.is_empty() {
@@ -249,6 +266,22 @@ impl CliAdapter for ClaudeCodeAdapter {
         }
 
         Ok(out.result.unwrap_or_default())
+    }
+
+    fn kill_in_flight(&self) {
+        let pid = match self.state.lock() {
+            Ok(state) => state.active_child_pid,
+            Err(_) => None,
+        };
+        if let Some(pid) = pid {
+            // SAFETY: `pid` is a plain integer we recorded from `Child::id()`
+            // moments ago; passing it to `kill(2)` cannot violate memory
+            // safety even if the process has since exited (that just makes
+            // the call a harmless no-op, reported as ESRCH).
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+        }
     }
 }
 

--- a/crates/agentbridge/src/adapters/codex.rs
+++ b/crates/agentbridge/src/adapters/codex.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::{
     adapter::{CliAdapter, CliAdapterError},
     context::{ArtifactPayload, ConversationMessage, ContextPacket},
+    subprocess::TrackedSubprocess,
 };
 
 /// Adapter for the OpenAI Codex CLI (`codex`).
@@ -21,6 +22,7 @@ pub struct CodexAdapter {
     id: AgentId,
     work_dir: PathBuf,
     extra_args: Vec<String>,
+    subprocess: TrackedSubprocess,
 }
 
 impl CodexAdapter {
@@ -36,6 +38,7 @@ impl CodexAdapter {
             id: AgentId(id.into()),
             work_dir: work_dir.into(),
             extra_args,
+            subprocess: TrackedSubprocess::new(),
         }
     }
 
@@ -57,8 +60,9 @@ impl CodexAdapter {
             .stdout(Stdio::piped())
             .stderr(Stdio::null());
 
-        let output = cmd
-            .output()
+        let output = self
+            .subprocess
+            .output(&mut cmd)
             .map_err(|e| CliAdapterError::Subprocess(format!("failed to run codex: {e}")))?;
 
         if output.stdout.is_empty() && !output.status.success() {
@@ -140,6 +144,10 @@ impl CliAdapter for CodexAdapter {
 
     fn execute_prompt(&self, prompt: &str) -> Result<String, CliAdapterError> {
         self.run_exec(prompt)
+    }
+
+    fn kill_in_flight(&self) {
+        self.subprocess.kill();
     }
 }
 

--- a/crates/agentbridge/src/adapters/copilot.rs
+++ b/crates/agentbridge/src/adapters/copilot.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::{
     adapter::{CliAdapter, CliAdapterError},
     context::{ArtifactPayload, ConversationMessage, ContextPacket},
+    subprocess::TrackedSubprocess,
 };
 
 /// Adapter for the GitHub Copilot CLI (`copilot`).
@@ -17,6 +18,7 @@ use crate::{
 pub struct CopilotAdapter {
     id: AgentId,
     work_dir: PathBuf,
+    subprocess: TrackedSubprocess,
 }
 
 impl CopilotAdapter {
@@ -24,6 +26,7 @@ impl CopilotAdapter {
         Self {
             id: AgentId(id.into()),
             work_dir: work_dir.into(),
+            subprocess: TrackedSubprocess::new(),
         }
     }
 
@@ -47,8 +50,9 @@ impl CopilotAdapter {
             cmd.arg("--system-prompt").arg(sp);
         }
 
-        let output = cmd
-            .output()
+        let output = self
+            .subprocess
+            .output(&mut cmd)
             .map_err(|e| CliAdapterError::Subprocess(format!("failed to run copilot: {e}")))?;
 
         if !output.status.success() && output.stdout.is_empty() {
@@ -130,6 +134,10 @@ impl CliAdapter for CopilotAdapter {
 
     fn execute_prompt(&self, prompt: &str) -> Result<String, CliAdapterError> {
         self.run_prompt(prompt, None)
+    }
+
+    fn kill_in_flight(&self) {
+        self.subprocess.kill();
     }
 }
 

--- a/crates/agentbridge/src/lib.rs
+++ b/crates/agentbridge/src/lib.rs
@@ -6,11 +6,13 @@ pub mod adapters;
 pub mod context;
 pub mod dir_registry;
 pub mod member_source;
+pub mod subprocess;
 
 pub use shadi_mas;
 
 pub use adapter::{CliAdapter, CliAdapterError, CliToolAdapter, prompt_tool_call};
 pub use context::{ArtifactPayload, CodeContext, ContextPacket, ConversationMessage, FileSnapshot};
+pub use subprocess::TrackedSubprocess;
 
 /// Re-export the shadi_mas coordination primitives most commonly used with
 /// agentbridge so callers have a single dependency.

--- a/crates/agentbridge/src/subprocess.rs
+++ b/crates/agentbridge/src/subprocess.rs
@@ -1,0 +1,100 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared subprocess-tracking helper for `CliAdapter` implementations.
+//!
+//! Every adapter that shells out to a CLI tool via `std::process::Command`
+//! (Claude Code, Copilot, Codex, ...) needs the same thing: know the PID of
+//! whatever child is currently running so `CliAdapter::kill_in_flight` can
+//! reach it during shutdown, instead of leaving it orphaned when the
+//! listener process exits out from under it. `TrackedSubprocess` is that
+//! logic, written once, so each adapter wires it in with one field and a
+//! one-line `kill_in_flight` override instead of duplicating PID-tracking
+//! per adapter.
+
+use std::io;
+use std::process::{Command, Output};
+use std::sync::Mutex;
+
+/// Tracks the PID of a subprocess for as long as it's running, so it can be
+/// killed on demand from anywhere holding a reference to this struct.
+#[derive(Default)]
+pub struct TrackedSubprocess {
+    active_pid: Mutex<Option<u32>>,
+}
+
+impl TrackedSubprocess {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Spawn `cmd`, remember its PID for the duration of the call, run it to
+    /// completion, and return its output — same shape as `Command::output()`,
+    /// but with the child's PID reachable via `kill()` while it's running.
+    pub fn output(&self, cmd: &mut Command) -> io::Result<Output> {
+        let child = cmd.spawn()?;
+
+        if let Ok(mut active) = self.active_pid.lock() {
+            *active = Some(child.id());
+        }
+
+        let result = child.wait_with_output();
+
+        if let Ok(mut active) = self.active_pid.lock() {
+            *active = None;
+        }
+
+        result
+    }
+
+    /// Best-effort: send SIGTERM to whatever child is currently tracked, if
+    /// any. A no-op if nothing is running right now.
+    pub fn kill(&self) {
+        let pid = match self.active_pid.lock() {
+            Ok(active) => *active,
+            Err(_) => None,
+        };
+        if let Some(pid) = pid {
+            // SAFETY: `pid` is a plain integer recorded from `Child::id()`
+            // moments ago; passing it to `kill(2)` cannot violate memory
+            // safety even if the process has since exited (that just makes
+            // the call a harmless no-op, reported as ESRCH).
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_runs_command_and_clears_pid_after() {
+        let tracked = TrackedSubprocess::new();
+        let mut cmd = Command::new("true");
+        let output = tracked.output(&mut cmd).expect("spawn should succeed");
+        assert!(output.status.success());
+        assert!(tracked.active_pid.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn kill_on_idle_tracker_is_a_harmless_no_op() {
+        let tracked = TrackedSubprocess::new();
+        tracked.kill(); // must not panic
+    }
+
+    #[test]
+    fn kill_terminates_a_running_child() {
+        let tracked = TrackedSubprocess::new();
+        let mut child = Command::new("sleep").arg("30").spawn().expect("spawn sleep");
+        let pid = child.id();
+        if let Ok(mut active) = tracked.active_pid.lock() {
+            *active = Some(pid);
+        }
+        tracked.kill();
+        let status = child.wait().expect("wait after kill");
+        assert!(!status.success());
+    }
+}

--- a/crates/agentbridge/src/subprocess.rs
+++ b/crates/agentbridge/src/subprocess.rs
@@ -94,29 +94,34 @@ fn terminate(pid: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     /// Exits successfully straight away.
+    #[cfg(unix)]
     fn exits_now() -> Command {
-        if cfg!(windows) {
-            let mut cmd = Command::new("cmd");
-            cmd.args(["/C", "exit", "0"]);
-            cmd
-        } else {
-            Command::new("true")
-        }
+        Command::new("true")
+    }
+
+    #[cfg(windows)]
+    fn exits_now() -> Command {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "exit", "0"]);
+        cmd
     }
 
     /// Stays alive long enough to be killed out from under the test.
+    #[cfg(unix)]
     fn stays_alive() -> Command {
-        if cfg!(windows) {
-            let mut cmd = Command::new("ping");
-            cmd.args(["-n", "31", "127.0.0.1"]);
-            cmd
-        } else {
-            let mut cmd = Command::new("sleep");
-            cmd.arg("30");
-            cmd
-        }
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        cmd
+    }
+
+    #[cfg(windows)]
+    fn stays_alive() -> Command {
+        let mut cmd = Command::new("ping");
+        cmd.args(["-n", "31", "127.0.0.1"]);
+        cmd
     }
 
     #[test]
@@ -147,11 +152,28 @@ mod tests {
         let tracked = TrackedSubprocess::new();
         let mut child = stays_alive().spawn().expect("spawn long-running child");
         let pid = child.id();
-        if let Ok(mut active) = tracked.active_pid.lock() {
-            *active = Some(pid);
-        }
+        *tracked.active_pid.lock().expect("fresh tracker is not poisoned") = Some(pid);
         tracked.kill();
         let status = child.wait().expect("wait after kill");
         assert!(!status.success());
+    }
+
+    #[test]
+    fn a_poisoned_tracker_still_runs_and_still_shuts_down() {
+        let tracked = Arc::new(TrackedSubprocess::new());
+        let poisoner = Arc::clone(&tracked);
+        let _ = std::thread::spawn(move || {
+            let _held = poisoner.active_pid.lock().unwrap();
+            panic!("poison the tracker's lock");
+        })
+        .join();
+        assert!(tracked.active_pid.lock().is_err(), "lock should be poisoned");
+
+        // Both paths skip the pid bookkeeping rather than propagating the
+        // poison: the command still runs, and shutdown still returns.
+        let mut cmd = exits_now();
+        let output = tracked.output(&mut cmd).expect("command still runs");
+        assert!(output.status.success());
+        tracked.kill();
     }
 }

--- a/crates/agentbridge/src/subprocess.rs
+++ b/crates/agentbridge/src/subprocess.rs
@@ -129,6 +129,14 @@ mod tests {
     }
 
     #[test]
+    fn output_surfaces_spawn_failure_without_stranding_a_pid() {
+        let tracked = TrackedSubprocess::new();
+        let mut cmd = Command::new("agentbridge-no-such-binary");
+        assert!(tracked.output(&mut cmd).is_err());
+        assert!(tracked.active_pid.lock().unwrap().is_none());
+    }
+
+    #[test]
     fn kill_on_idle_tracker_is_a_harmless_no_op() {
         let tracked = TrackedSubprocess::new();
         tracked.kill(); // must not panic

--- a/crates/agentbridge/src/subprocess.rs
+++ b/crates/agentbridge/src/subprocess.rs
@@ -47,21 +47,46 @@ impl TrackedSubprocess {
         result
     }
 
-    /// Best-effort: send SIGTERM to whatever child is currently tracked, if
-    /// any. A no-op if nothing is running right now.
+    /// Best-effort: terminate whatever child is currently tracked, if any. A
+    /// no-op if nothing is running right now.
     pub fn kill(&self) {
         let pid = match self.active_pid.lock() {
             Ok(active) => *active,
             Err(_) => None,
         };
         if let Some(pid) = pid {
-            // SAFETY: `pid` is a plain integer recorded from `Child::id()`
-            // moments ago; passing it to `kill(2)` cannot violate memory
-            // safety even if the process has since exited (that just makes
-            // the call a harmless no-op, reported as ESRCH).
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-            }
+            terminate(pid);
+        }
+    }
+}
+
+/// SIGTERM, so the child still gets to run its own shutdown path.
+#[cfg(unix)]
+fn terminate(pid: u32) {
+    // SAFETY: `pid` is a plain integer recorded from `Child::id()` moments
+    // ago; passing it to `kill(2)` cannot violate memory safety even if the
+    // process has since exited (that just makes the call a harmless no-op,
+    // reported as ESRCH).
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+    }
+}
+
+/// Windows has no signals reachable from another process, so the equivalent
+/// is `TerminateProcess` — abrupt, with no shutdown path for the child.
+#[cfg(windows)]
+fn terminate(pid: u32) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+    // SAFETY: `OpenProcess` returns null rather than a bogus handle when the
+    // process has already exited, which is what the check below covers; the
+    // handle is used only while open and closed exactly once.
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if !handle.is_null() {
+            TerminateProcess(handle, 1);
+            CloseHandle(handle);
         }
     }
 }
@@ -70,10 +95,34 @@ impl TrackedSubprocess {
 mod tests {
     use super::*;
 
+    /// Exits successfully straight away.
+    fn exits_now() -> Command {
+        if cfg!(windows) {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "exit", "0"]);
+            cmd
+        } else {
+            Command::new("true")
+        }
+    }
+
+    /// Stays alive long enough to be killed out from under the test.
+    fn stays_alive() -> Command {
+        if cfg!(windows) {
+            let mut cmd = Command::new("ping");
+            cmd.args(["-n", "31", "127.0.0.1"]);
+            cmd
+        } else {
+            let mut cmd = Command::new("sleep");
+            cmd.arg("30");
+            cmd
+        }
+    }
+
     #[test]
     fn output_runs_command_and_clears_pid_after() {
         let tracked = TrackedSubprocess::new();
-        let mut cmd = Command::new("true");
+        let mut cmd = exits_now();
         let output = tracked.output(&mut cmd).expect("spawn should succeed");
         assert!(output.status.success());
         assert!(tracked.active_pid.lock().unwrap().is_none());
@@ -88,7 +137,7 @@ mod tests {
     #[test]
     fn kill_terminates_a_running_child() {
         let tracked = TrackedSubprocess::new();
-        let mut child = Command::new("sleep").arg("30").spawn().expect("spawn sleep");
+        let mut child = stays_alive().spawn().expect("spawn long-running child");
         let pid = child.id();
         if let Ok(mut active) = tracked.active_pid.lock() {
             *active = Some(pid);

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -20,6 +20,7 @@ use agentbridge::{
 };
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use futures::StreamExt;
 use shadi_a2a::SlimRpcHandler;
 use slim_bindings::{
     CaSource, ClientConfig, Name, Service, TlsClientConfig, TlsSource,
@@ -185,56 +186,66 @@ impl AgentExecutor for AgentBridgeExecutor {
         println!("│  {}", preview(&prompt, 120));
         println!("└─────────────────────────────────────────────────────────");
 
-        let started = std::time::Instant::now();
-        let response_text = match self.adapter.execute_prompt(&prompt) {
-            Ok(text) => text,
-            Err(e) => format!("agentbridge error: {e}"),
-        };
-        let elapsed_ms = started.elapsed().as_millis();
-
-        println!(
-            "\n┌─ A2A send [{agent_id}] ({} ms)",
-            elapsed_ms
-        );
-        println!("│  {}", preview(&response_text, 120));
-        println!("└─────────────────────────────────────────────────────────\n");
-
-        let response = Message {
-            message_id: new_message_id(),
-            context_id: Some(ctx.context_id.clone()),
-            task_id: Some(ctx.task_id.clone()),
-            role: Role::Agent,
-            parts: vec![Part::text(response_text)],
-            metadata: None,
-            extensions: None,
-            reference_task_ids: None,
-        };
+        let adapter = Arc::clone(&self.adapter);
+        let task_id = ctx.task_id.clone();
+        let context_id = ctx.context_id.clone();
         let history = ctx.message.clone().map(|m| vec![m]);
 
-        Box::pin(futures::stream::iter(vec![
-            Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
-                task_id: ctx.task_id.clone(),
-                context_id: ctx.context_id.clone(),
-                status: TaskStatus {
-                    state: TaskState::Working,
-                    message: None,
-                    timestamp: None,
-                },
+        let respond = async move {
+            let started = std::time::Instant::now();
+            let response_text =
+                match tokio::task::spawn_blocking(move || adapter.execute_prompt(&prompt)).await {
+                    Ok(Ok(text)) => text,
+                    Ok(Err(e)) => format!("agentbridge error: {e}"),
+                    Err(join_err) => format!("agentbridge error: adapter task panicked: {join_err}"),
+                };
+            let elapsed_ms = started.elapsed().as_millis();
+
+            println!(
+                "\n┌─ A2A send [{agent_id}] ({} ms)",
+                elapsed_ms
+            );
+            println!("│  {}", preview(&response_text, 120));
+            println!("└─────────────────────────────────────────────────────────\n");
+
+            let response = Message {
+                message_id: new_message_id(),
+                context_id: Some(context_id.clone()),
+                task_id: Some(task_id.clone()),
+                role: Role::Agent,
+                parts: vec![Part::text(response_text)],
                 metadata: None,
-            })),
-            Ok(StreamResponse::Task(Task {
-                id: ctx.task_id,
-                context_id: ctx.context_id,
-                status: TaskStatus {
-                    state: TaskState::Completed,
-                    message: Some(response),
-                    timestamp: None,
-                },
-                artifacts: None,
-                history,
-                metadata: None,
-            })),
-        ]))
+                extensions: None,
+                reference_task_ids: None,
+            };
+
+            vec![
+                Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                    task_id: task_id.clone(),
+                    context_id: context_id.clone(),
+                    status: TaskStatus {
+                        state: TaskState::Working,
+                        message: None,
+                        timestamp: None,
+                    },
+                    metadata: None,
+                })),
+                Ok(StreamResponse::Task(Task {
+                    id: task_id,
+                    context_id,
+                    status: TaskStatus {
+                        state: TaskState::Completed,
+                        message: Some(response),
+                        timestamp: None,
+                    },
+                    artifacts: None,
+                    history,
+                    metadata: None,
+                })),
+            ]
+        };
+
+        Box::pin(futures::stream::once(respond).flat_map(futures::stream::iter))
     }
 
     fn cancel(

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -540,6 +540,9 @@ fn run_slim_listener(
         Some(slim_bindings::get_runtime()),
     ));
     let ready = Arc::new(Notify::new());
+    // Cloned before the move below so shutdown can still reach the adapter
+    // to kill whatever child process its current message is running.
+    let adapter_for_shutdown = Arc::clone(&adapter);
     let handler = Arc::new(AgentBridgeRequestHandler::new(
         adapter,
         agent_id,
@@ -570,6 +573,13 @@ fn run_slim_listener(
             .map_err(|e| format!("ctrl_c error: {e}"))?;
 
         println!("\n[agentbridge] shutting down...");
+        // Proactively kill whatever child process the adapter's current
+        // message is running, if any. Without this, a `claude` call still
+        // in flight when Ctrl-C arrives is left orphaned: the listener
+        // itself exits promptly (see the spawn_blocking fix above), but
+        // nothing ever tells the child to stop, so it just keeps running
+        // on its own after the parent that owned it is gone.
+        adapter_for_shutdown.kill_in_flight();
         server.shutdown().await;
         let _ = server_task.await;
         Ok::<(), String>(())


### PR DESCRIPTION
## Summary

Ctrl-C on a running `agentbridge register` listener had two separate bugs, both fixed here.

**1. Ctrl-C appears to hang while a message is in flight.**

`register.rs`'s SLIM A2A listener runs on a single-threaded Tokio runtime (`new_current_thread`), and `AgentBridgeExecutor::execute()` called `CliAdapter::execute_prompt()` — a synchronous, blocking subprocess call (`Command::output()`) — directly in its synchronous body, on whatever thread was driving that task.

Since the runtime has exactly one thread, that blocking call monopolized it entirely: `tokio::signal::ctrl_c()` (awaited in `run_slim_listener` to catch shutdown) is scheduled on the same thread and can't be polled until the blocking call returns. In practice this means Ctrl-C during an in-flight message appears to hang — sometimes for minutes, for as long as the underlying CLI tool (e.g. `claude`) takes to respond — instead of shutting the listener down.

- Move the `execute_prompt` call onto Tokio's dedicated blocking-thread pool via `spawn_blocking`, restructuring `execute()`'s stream construction to be async so it can `.await` that call.
- Behavior and output are unchanged — same two-event `StatusUpdate`+`Task` sequence, same recv/send console logging — only the blocking call now runs off the runtime's async worker thread, so Ctrl-C (and anything else scheduled on the runtime) stays responsive while a message is in flight.

**2. The in-flight child process is left orphaned after Ctrl-C.**

Even with (1) fixed, the listener process would exit cleanly on Ctrl-C, but whatever CLI subprocess (`claude`, `copilot`, `codex`, ...) it had spawned to handle the current message kept running independently — nothing ever told it to stop.

- Add `CliAdapter::kill_in_flight()` (default no-op) to the trait, and a shared `TrackedSubprocess` helper (`crates/agentbridge/src/subprocess.rs`) that records a spawned child's PID for the duration of the call and sends it `SIGTERM` on demand.
- Wire `ClaudeCodeAdapter`, `CopilotAdapter`, and `CodexAdapter` through `TrackedSubprocess` instead of each tracking a PID by hand, and call `kill_in_flight()` from `run_slim_listener` right when Ctrl-C fires, before waiting for the server to shut down.
- `GenericStdioAdapter` is out of scope: it holds one long-lived subprocess for the adapter's whole lifetime, not a fresh spawn per message, so the same fix doesn't apply there.

## Test plan

- [x] `cargo build --release -p agntcy-agentbridge-cli` — clean build
- [x] `cargo test --release -p agntcy-agentbridge -p agntcy-agentbridge-cli` — all tests pass, including 3 new `TrackedSubprocess` unit tests
- [x] Manually verified against a live SLIM node + registered `claude-code` adapter: Ctrl-C during an in-flight message now returns control immediately instead of hanging
- [x] Manually verified the orphan fix: sent a deliberately slow prompt, sent `SIGINT` to the listener's whole process group (replicating a terminal Ctrl-C) while the `claude` child was still running — both listener and child processes were gone within seconds, instead of the child continuing to run after the listener exited