### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       PYO3_PYTHON: python


### PR DESCRIPTION
By adding id-token:write permission to release workflow.