### PR TITLE
refactor(sandbox): move the control-socket client into shadi_sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,8 +362,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "uds_windows",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/shadi_sandbox/Cargo.toml
+++ b/crates/shadi_sandbox/Cargo.toml
@@ -26,6 +26,8 @@ libc = "0.2"
 landlock = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+# AF_UNIX on Windows 10 1803+, for the control-socket client.
+uds_windows = "1.2"
 hmac = "0.12"
 sha2 = "0.10"
 rand = "0.9"
@@ -41,3 +43,6 @@ windows-sys = { version = "0.61", features = [
 	"Win32_System_Memory",
 	"Win32_System_WindowsProgramming"
 ] }
+
+[dev-dependencies]
+tempfile = "3.27"

--- a/crates/shadi_sandbox/src/control.rs
+++ b/crates/shadi_sandbox/src/control.rs
@@ -21,6 +21,9 @@ use crate::policy_patch::{
     ControlMessage, ControlResponse, PolicyPatch, PolicyPatchResponse, ProcessResources,
 };
 
+#[cfg(test)]
+use crate::policy_patch::PatchAxisStatus;
+
 /// Directory holding control sockets.
 ///
 /// Discovery and path construction both go through this, so a session can
@@ -308,6 +311,115 @@ mod tests {
         let live = prune_unreachable(vec![dead.clone()]);
         assert!(live.is_empty());
         assert!(!dead.exists(), "prune must remove the stale endpoint");
+    }
+
+    /// A listener that answers `replies.len()` connections with canned
+    /// responses, so the client half can be exercised without a real sandbox.
+    fn stub_server(replies: Vec<ControlResponse>) -> (tempfile::TempDir, PathBuf) {
+        #[cfg(unix)]
+        use std::os::unix::net::UnixListener;
+        #[cfg(windows)]
+        use uds_windows::UnixListener;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shadi-ctl-stub.sock");
+        let listener = UnixListener::bind(&path).expect("bind stub listener");
+
+        std::thread::spawn(move || {
+            for reply in replies {
+                let Ok((mut stream, _)) = listener.accept() else { return };
+                // Drain the request so the client's write half completes.
+                let mut request = String::new();
+                let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+                let _ = reader.read_line(&mut request);
+                let body = serde_json::to_string(&reply).expect("serialize reply");
+                let _ = writeln!(stream, "{}", body);
+                let _ = stream.flush();
+            }
+        });
+
+        (dir, path)
+    }
+
+    #[test]
+    fn each_client_call_returns_its_own_response_variant() {
+        let (_dir, sock) = stub_server(vec![
+            ControlResponse::Policy { policy: serde_json::json!({"net_block": true}) },
+            ControlResponse::Ack { message: "terminating".to_string() },
+            ControlResponse::PatchResult(PolicyPatchResponse {
+                accepted: true,
+                filesystem: PatchAxisStatus::Unchanged,
+                commands: PatchAxisStatus::Applied,
+                network: PatchAxisStatus::Unchanged,
+                message: "applied".to_string(),
+                pending_restart: Vec::new(),
+            }),
+        ]);
+
+        assert_eq!(query_policy(&sock).expect("policy")["net_block"], true);
+        assert_eq!(send_terminate(&sock).expect("ack"), "terminating");
+        let patched = send_patch(&sock, &PolicyPatch::default()).expect("patch result");
+        assert!(patched.accepted);
+        assert_eq!(patched.commands, PatchAxisStatus::Applied);
+    }
+
+    #[test]
+    fn an_error_response_becomes_the_error_message() {
+        let (_dir, sock) = stub_server(vec![ControlResponse::Error {
+            message: "policy is frozen".to_string(),
+        }]);
+
+        assert_eq!(query_policy(&sock).unwrap_err(), "policy is frozen");
+    }
+
+    #[test]
+    fn a_mismatched_response_is_rejected_rather_than_misread() {
+        // Terminate answered with a policy: the wrong variant must not be
+        // silently accepted as success.
+        let (_dir, sock) = stub_server(vec![ControlResponse::Policy {
+            policy: serde_json::json!({}),
+        }]);
+
+        assert_eq!(send_terminate(&sock).unwrap_err(), "unexpected response type");
+    }
+
+    #[test]
+    fn every_client_call_surfaces_a_server_error() {
+        // One Error reply per call, so each function's Error arm is exercised
+        // rather than only the one that happens to be tested elsewhere.
+        let err = || ControlResponse::Error { message: "denied".to_string() };
+        let (_dir, sock) = stub_server(vec![err(), err(), err(), err()]);
+
+        assert_eq!(query_policy(&sock).unwrap_err(), "denied");
+        assert_eq!(query_resources(&sock).unwrap_err(), "denied");
+        assert_eq!(send_terminate(&sock).unwrap_err(), "denied");
+        assert_eq!(send_patch(&sock, &PolicyPatch::default()).unwrap_err(), "denied");
+    }
+
+    #[test]
+    fn every_client_call_rejects_the_wrong_response_variant() {
+        // An Ack answers all four; only send_terminate should accept it.
+        let ack = || ControlResponse::Ack { message: "ok".to_string() };
+        let (_dir, sock) = stub_server(vec![ack(), ack(), ack()]);
+
+        assert_eq!(query_policy(&sock).unwrap_err(), "unexpected response type");
+        assert_eq!(query_resources(&sock).unwrap_err(), "unexpected response type");
+        assert_eq!(
+            send_patch(&sock, &PolicyPatch::default()).unwrap_err(),
+            "unexpected response type"
+        );
+    }
+
+    #[test]
+    fn a_reachable_socket_survives_pruning() {
+        let (_dir, sock) = stub_server(vec![
+            ControlResponse::Policy { policy: serde_json::json!({}) },
+            ControlResponse::Policy { policy: serde_json::json!({}) },
+        ]);
+
+        assert!(is_reachable(&sock));
+        assert_eq!(prune_unreachable(vec![sock.clone()]), vec![sock.clone()]);
+        assert!(sock.exists(), "a live endpoint must not be deleted");
     }
 
     #[test]

--- a/crates/shadi_sandbox/src/control.rs
+++ b/crates/shadi_sandbox/src/control.rs
@@ -1,0 +1,322 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client side of a sandbox's control socket.
+//!
+//! `shadictl --watch-policy` serves a local `AF_UNIX` control socket; the
+//! server half lives with it. This is the caller's half, so everything outside
+//! that process — `shadictl policy patch`, the shell's session commands, SHADI
+//! Desktop — reaches a running session through one implementation instead of
+//! restating the protocol.
+//!
+//! Sockets are named `shadi-ctl-<pid>.sock` for the PID-based default and
+//! `shadi-ctl-<name>.sock` when the session was given a name, both inside
+//! [`socket_dir`]. A caller connects, writes one JSON [`ControlMessage`] line,
+//! and reads one JSON [`ControlResponse`] line back.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use crate::policy_patch::{
+    ControlMessage, ControlResponse, PolicyPatch, PolicyPatchResponse, ProcessResources,
+};
+
+/// Directory holding control sockets.
+///
+/// Discovery and path construction both go through this, so a session can
+/// never be created somewhere the listing does not look.
+#[cfg(unix)]
+pub fn socket_dir() -> PathBuf {
+    PathBuf::from(std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string()))
+}
+
+/// Directory holding control sockets (Windows).
+#[cfg(windows)]
+pub fn socket_dir() -> PathBuf {
+    PathBuf::from(std::env::var("TEMP").unwrap_or_else(|_| ".".to_string()))
+}
+
+/// Resolve the default control socket path for a given PID.
+pub fn default_socket_path(pid: u32) -> PathBuf {
+    socket_dir().join(format!("shadi-ctl-{}.sock", pid))
+}
+
+/// Resolve a named control socket path.
+///
+/// Named sockets use `shadi-ctl-<name>.sock` instead of the PID-based path,
+/// making them stable and human-addressable: any tool can connect by name
+/// without needing to discover the PID.
+///
+/// Only alphanumeric characters, hyphens, and underscores survive in the name;
+/// other characters become `-` to keep the filename safe.
+pub fn named_socket_path(name: &str) -> PathBuf {
+    socket_dir().join(format!("shadi-ctl-{}.sock", sanitize_session_name(name)))
+}
+
+/// Resolve the control socket path for a session name or socket path.
+///
+/// A value that looks like a path is used as-is; anything else is treated as a
+/// session name and resolved via [`named_socket_path`].
+pub fn resolve_session_socket(name_or_path: &str) -> PathBuf {
+    if looks_like_path(name_or_path) {
+        PathBuf::from(name_or_path)
+    } else {
+        named_socket_path(name_or_path)
+    }
+}
+
+#[cfg(unix)]
+fn looks_like_path(value: &str) -> bool {
+    value.contains('/') || value.ends_with(".sock")
+}
+
+#[cfg(windows)]
+fn looks_like_path(value: &str) -> bool {
+    value.contains('\\') || value.contains('/') || value.ends_with(".sock")
+}
+
+/// Extract the human-readable session name from a socket path.
+///
+/// `shadi-ctl-myagent.sock` → `"myagent"`, and `shadi-ctl-12345.sock` →
+/// `"12345"` for the PID-based fallback.
+pub fn session_name_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("shadi-ctl-"))
+        .unwrap_or_else(|| path.file_stem().and_then(|s| s.to_str()).unwrap_or("session"))
+        .to_string()
+}
+
+/// Sanitize a session name: keep only alphanumerics, hyphens and underscores,
+/// replace everything else with `-`, and truncate to 48 characters.
+pub fn sanitize_session_name(name: &str) -> String {
+    let slug: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .collect();
+    let slug = slug.trim_matches('-');
+    slug.chars().take(48).collect()
+}
+
+/// Every control socket endpoint file in `dir`, reachable or not.
+///
+/// A socket file outliving its process is left on disk, so a path from here is
+/// a candidate, not a live session — [`is_reachable`] settles that.
+pub fn discover_sockets(dir: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("shadi-ctl-") && name_str.ends_with(".sock") {
+                found.push(entry.path());
+            }
+        }
+    }
+    found
+}
+
+/// Whether a socket answers, i.e. its session is still alive.
+pub fn is_reachable(socket_path: &Path) -> bool {
+    query_policy(socket_path).is_ok()
+}
+
+/// Pair every socket with whether it answers, touching nothing on disk.
+///
+/// This is what a repeatedly refreshed listing wants: deleting files as a side
+/// effect of looking at them is a surprise when the caller is a UI.
+pub fn classify_sockets(sockets: Vec<PathBuf>) -> Vec<(PathBuf, bool)> {
+    sockets
+        .into_iter()
+        .map(|sock| {
+            let reachable = is_reachable(&sock);
+            (sock, reachable)
+        })
+        .collect()
+}
+
+/// Return the sockets that answer, deleting the endpoint files that do not.
+///
+/// Prefer [`classify_sockets`] unless the caller genuinely wants the cleanup.
+pub fn prune_unreachable(sockets: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut live = Vec::new();
+    for sock in sockets {
+        if is_reachable(&sock) {
+            live.push(sock);
+        } else {
+            let _ = std::fs::remove_file(&sock);
+        }
+    }
+    live
+}
+
+/// Send a patch to a running control endpoint and return the response.
+pub fn send_patch(
+    socket_path: &Path,
+    patch: &PolicyPatch,
+) -> Result<PolicyPatchResponse, String> {
+    match send_message(socket_path, &ControlMessage::Patch(patch.clone()))? {
+        ControlResponse::PatchResult(r) => Ok(r),
+        ControlResponse::Error { message } => Err(message),
+        _ => Err("unexpected response type".to_string()),
+    }
+}
+
+/// Query the current effective policy from a running control endpoint.
+pub fn query_policy(socket_path: &Path) -> Result<serde_json::Value, String> {
+    match send_message(socket_path, &ControlMessage::QueryPolicy)? {
+        ControlResponse::Policy { policy } => Ok(policy),
+        ControlResponse::Error { message } => Err(message),
+        _ => Err("unexpected response type".to_string()),
+    }
+}
+
+/// Ask a session to terminate its sandboxed child.
+pub fn send_terminate(socket_path: &Path) -> Result<String, String> {
+    match send_message(socket_path, &ControlMessage::Terminate)? {
+        ControlResponse::Ack { message } => Ok(message),
+        ControlResponse::Error { message } => Err(message),
+        _ => Err("unexpected response type".to_string()),
+    }
+}
+
+/// Query resource usage of the sandboxed child process.
+pub fn query_resources(socket_path: &Path) -> Result<ProcessResources, String> {
+    match send_message(socket_path, &ControlMessage::QueryResources)? {
+        ControlResponse::Resources(r) => Ok(r),
+        ControlResponse::Error { message } => Err(message),
+        _ => Err("unexpected response type".to_string()),
+    }
+}
+
+fn send_message(socket_path: &Path, msg: &ControlMessage) -> Result<ControlResponse, String> {
+    #[cfg(unix)]
+    use std::os::unix::net::UnixStream;
+    #[cfg(windows)]
+    use uds_windows::UnixStream;
+
+    let mut stream =
+        UnixStream::connect(socket_path).map_err(|e| format!("failed to connect: {}", e))?;
+
+    let json =
+        serde_json::to_string(msg).map_err(|e| format!("failed to serialize message: {}", e))?;
+    let payload = format!("{}\n", json);
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|e| format!("failed to write: {}", e))?;
+    stream
+        .flush()
+        .map_err(|e| format!("failed to flush: {}", e))?;
+
+    // Shutdown write half so the server sees EOF on our request.
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .map_err(|e| format!("failed to shutdown write: {}", e))?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| format!("failed to read response: {}", e))?;
+
+    serde_json::from_str(&line).map_err(|e| format!("invalid response: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_socket_path_contains_pid() {
+        let path = default_socket_path(42);
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert_eq!(name, "shadi-ctl-42.sock");
+        assert_eq!(path.parent().unwrap(), socket_dir());
+    }
+
+    #[test]
+    fn named_socket_path_slugs_unsafe_characters() {
+        let path = named_socket_path("my agent/../v2");
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert_eq!(name, "shadi-ctl-my-agent----v2.sock");
+        assert!(!name.contains('/'));
+    }
+
+    #[test]
+    fn sanitize_session_name_trims_and_truncates() {
+        assert_eq!(sanitize_session_name("--edgy--"), "edgy");
+        assert_eq!(sanitize_session_name("a/b c"), "a-b-c");
+        assert_eq!(sanitize_session_name(&"x".repeat(60)).len(), 48);
+    }
+
+    #[test]
+    fn session_name_round_trips_through_the_socket_path() {
+        for name in ["myagent", "12345", "with-dash", "with_underscore"] {
+            assert_eq!(session_name_from_path(&named_socket_path(name)), name);
+        }
+    }
+
+    #[test]
+    fn session_name_falls_back_for_unrelated_paths() {
+        assert_eq!(session_name_from_path(Path::new("/tmp/other.sock")), "other");
+        assert_eq!(session_name_from_path(Path::new("/")), "session");
+    }
+
+    #[test]
+    fn resolve_session_socket_distinguishes_names_from_paths() {
+        let by_name = resolve_session_socket("myagent");
+        assert_eq!(by_name, named_socket_path("myagent"));
+
+        let explicit = resolve_session_socket("relative.sock");
+        assert_eq!(explicit, PathBuf::from("relative.sock"));
+    }
+
+    #[test]
+    fn discover_sockets_matches_only_control_endpoints() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for name in ["shadi-ctl-1.sock", "shadi-ctl-agent.sock"] {
+            std::fs::write(dir.path().join(name), b"").expect("write");
+        }
+        for name in ["shadi-ctl-1.txt", "other.sock", "shadi-1.sock"] {
+            std::fs::write(dir.path().join(name), b"").expect("write");
+        }
+
+        let mut found: Vec<String> = discover_sockets(dir.path())
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        found.sort();
+        assert_eq!(found, vec!["shadi-ctl-1.sock", "shadi-ctl-agent.sock"]);
+    }
+
+    #[test]
+    fn discover_sockets_on_a_missing_directory_is_empty() {
+        assert!(discover_sockets(Path::new("/nonexistent-shadi-control-dir")).is_empty());
+    }
+
+    #[test]
+    fn unreachable_sockets_are_pruned_but_classification_leaves_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dead = dir.path().join("shadi-ctl-dead.sock");
+        std::fs::write(&dead, b"").expect("write");
+
+        // Not a live listener, so it cannot answer.
+        let classified = classify_sockets(vec![dead.clone()]);
+        assert_eq!(classified, vec![(dead.clone(), false)]);
+        assert!(dead.exists(), "classify must not delete anything");
+
+        let live = prune_unreachable(vec![dead.clone()]);
+        assert!(live.is_empty());
+        assert!(!dead.exists(), "prune must remove the stale endpoint");
+    }
+
+    #[test]
+    fn client_calls_against_a_dead_socket_error_rather_than_panic() {
+        let missing = Path::new("/nonexistent-shadi-control-dir/shadi-ctl-x.sock");
+        assert!(query_policy(missing).is_err());
+        assert!(query_resources(missing).is_err());
+        assert!(send_terminate(missing).is_err());
+        assert!(send_patch(missing, &PolicyPatch::default()).is_err());
+        assert!(!is_reachable(missing));
+    }
+}

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod control;
 pub mod net_proxy;
 pub mod policy;
 pub mod policy_patch;

--- a/crates/shadictl/src/policy_watch.rs
+++ b/crates/shadictl/src/policy_watch.rs
@@ -36,7 +36,15 @@ use uds_windows::UnixListener;
 
 use shadi_sandbox::{
     ControlMessage, ControlResponse, NetAllowlist, PatchAxisStatus, PolicyPatch,
-    PolicyPatchResponse, ProcessResources, SandboxPolicy,
+    PolicyPatchResponse, SandboxPolicy,
+};
+
+// The caller's half of this protocol lives in the library, so `shadictl`, the
+// shell's session commands and SHADI Desktop all speak it through one
+// implementation. Only the listener below is shadictl's own.
+pub(crate) use shadi_sandbox::control::{
+    default_socket_path, named_socket_path, query_policy, query_resources, resolve_session_socket,
+    send_patch, send_terminate, session_name_from_path,
 };
 use tracing::info_span;
 
@@ -108,92 +116,6 @@ fn extract_host(dest: &str) -> String {
         host_port.split(':').next().unwrap_or(host_port)
     };
     host.to_ascii_lowercase()
-}
-
-/// Resolve the default control socket path for a given PID.
-#[cfg(unix)]
-pub(crate) fn default_socket_path(pid: u32) -> PathBuf {
-    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(dir).join(format!("shadi-ctl-{}.sock", pid))
-}
-
-/// Resolve a named control socket path.
-///
-/// Named sockets use `$TMPDIR/shadi-ctl-<name>.sock` instead of the PID-based
-/// path, making them stable and human-addressable: any tool can connect by name
-/// without needing to discover the PID.
-///
-/// Only alphanumeric characters, hyphens, and underscores are allowed in the
-/// name; other characters are replaced with `-` to keep the filename safe.
-#[cfg(unix)]
-pub(crate) fn named_socket_path(name: &str) -> PathBuf {
-    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    let slug = sanitize_session_name(name);
-    PathBuf::from(dir).join(format!("shadi-ctl-{}.sock", slug))
-}
-
-/// Resolve the control socket path for a given session name or socket path.
-///
-/// If `name_or_path` looks like a path (contains `/` or ends with `.sock`) it
-/// is used as-is; otherwise it is treated as a session name and resolved via
-/// `named_socket_path`.
-#[cfg(unix)]
-pub(crate) fn resolve_session_socket(name_or_path: &str) -> PathBuf {
-    if name_or_path.contains('/') || name_or_path.ends_with(".sock") {
-        PathBuf::from(name_or_path)
-    } else {
-        named_socket_path(name_or_path)
-    }
-}
-
-/// Extract the human-readable session name from a socket path.
-///
-/// `$TMPDIR/shadi-ctl-myagent.sock` → `"myagent"`
-/// `$TMPDIR/shadi-ctl-12345.sock`   → `"12345"` (PID-based fallback)
-pub(crate) fn session_name_from_path(path: &Path) -> String {
-    path.file_stem()
-        .and_then(|s| s.to_str())
-        .and_then(|s| s.strip_prefix("shadi-ctl-"))
-        .unwrap_or_else(|| path.file_stem().and_then(|s| s.to_str()).unwrap_or("session"))
-        .to_string()
-}
-
-/// Sanitize a session name: keep only alphanumerics, hyphens, and underscores;
-/// replace everything else with `-`; truncate to 48 characters.
-pub(crate) fn sanitize_session_name(name: &str) -> String {
-    let slug: String = name
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
-        .collect();
-    let slug = slug.trim_matches('-');
-    slug.chars().take(48).collect()
-}
-
-/// Resolve the default control socket path for a given PID.
-///
-/// On Windows this is an `AF_UNIX` socket file (requires Windows 10 1803+).
-#[cfg(windows)]
-pub(crate) fn default_socket_path(pid: u32) -> PathBuf {
-    let dir = std::env::var("TEMP").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(dir).join(format!("shadi-ctl-{}.sock", pid))
-}
-
-/// Resolve a named control socket path (Windows).
-#[cfg(windows)]
-pub(crate) fn named_socket_path(name: &str) -> PathBuf {
-    let dir = std::env::var("TEMP").unwrap_or_else(|_| ".".to_string());
-    let slug = sanitize_session_name(name);
-    PathBuf::from(dir).join(format!("shadi-ctl-{}.sock", slug))
-}
-
-/// Resolve the control socket path for a given session name or socket path (Windows).
-#[cfg(windows)]
-pub(crate) fn resolve_session_socket(name_or_path: &str) -> PathBuf {
-    if name_or_path.contains('\\') || name_or_path.contains('/') || name_or_path.ends_with(".sock") {
-        PathBuf::from(name_or_path)
-    } else {
-        named_socket_path(name_or_path)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -610,82 +532,6 @@ pub(crate) fn apply_staged_policy_updates(live: &Arc<Mutex<LivePolicy>>) -> Resu
 // Client helpers (cross-platform)
 // ---------------------------------------------------------------------------
 
-/// Send a patch to a running control endpoint and return the response.
-pub(crate) fn send_patch(socket_path: &Path, patch: &PolicyPatch) -> Result<PolicyPatchResponse, String> {
-    let msg = ControlMessage::Patch(patch.clone());
-    let resp = send_message(socket_path, &msg)?;
-    match resp {
-        ControlResponse::PatchResult(r) => Ok(r),
-        ControlResponse::Error { message } => Err(message),
-        _ => Err("unexpected response type".to_string()),
-    }
-}
-
-/// Query the current effective policy from a running control endpoint.
-pub(crate) fn query_policy(socket_path: &Path) -> Result<serde_json::Value, String> {
-    let msg = ControlMessage::QueryPolicy;
-    let resp = send_message(socket_path, &msg)?;
-    match resp {
-        ControlResponse::Policy { policy } => Ok(policy),
-        ControlResponse::Error { message } => Err(message),
-        _ => Err("unexpected response type".to_string()),
-    }
-}
-
-pub(crate) fn send_terminate(socket_path: &Path) -> Result<String, String> {
-    let msg = ControlMessage::Terminate;
-    let resp = send_message(socket_path, &msg)?;
-    match resp {
-        ControlResponse::Ack { message } => Ok(message),
-        ControlResponse::Error { message } => Err(message),
-        _ => Err("unexpected response type".to_string()),
-    }
-}
-
-/// Query resource usage of the sandboxed child process.
-pub(crate) fn query_resources(socket_path: &Path) -> Result<ProcessResources, String> {
-    let msg = ControlMessage::QueryResources;
-    let resp = send_message(socket_path, &msg)?;
-    match resp {
-        ControlResponse::Resources(r) => Ok(r),
-        ControlResponse::Error { message } => Err(message),
-        _ => Err("unexpected response type".to_string()),
-    }
-}
-
-fn send_message(socket_path: &Path, msg: &ControlMessage) -> Result<ControlResponse, String> {
-    #[cfg(unix)]
-    use std::os::unix::net::UnixStream;
-    #[cfg(windows)]
-    use uds_windows::UnixStream;
-
-    let mut stream =
-        UnixStream::connect(socket_path).map_err(|e| format!("failed to connect: {}", e))?;
-
-    let json =
-        serde_json::to_string(msg).map_err(|e| format!("failed to serialize message: {}", e))?;
-    let payload = format!("{}\n", json);
-    stream
-        .write_all(payload.as_bytes())
-        .map_err(|e| format!("failed to write: {}", e))?;
-    stream
-        .flush()
-        .map_err(|e| format!("failed to flush: {}", e))?;
-
-    // Shutdown write half so the server sees EOF on our request.
-    stream
-        .shutdown(std::net::Shutdown::Write)
-        .map_err(|e| format!("failed to shutdown write: {}", e))?;
-
-    let mut reader = BufReader::new(&stream);
-    let mut line = String::new();
-    reader
-        .read_line(&mut line)
-        .map_err(|e| format!("failed to read response: {}", e))?;
-
-    serde_json::from_str(&line).map_err(|e| format!("invalid response: {}", e))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -962,14 +808,6 @@ mod tests {
     }
 
     #[test]
-    fn default_socket_path_contains_pid() {
-        let path = default_socket_path(42);
-        let name = path.file_name().unwrap().to_str().unwrap();
-        assert!(name.contains("42"));
-        assert!(name.ends_with(".sock"));
-    }
-
-    #[test]
     fn handle_patch_removes_commands() {
         let live = test_live_policy();
         // "rm" and "sudo" are in the initial blocked set.
@@ -1102,14 +940,6 @@ mod tests {
         let input = b"\n   \n";
         let stream = Cursor::new(input.to_vec());
         handle_stream(stream, &live);
-    }
-
-    #[test]
-    fn send_message_fails_on_bad_path() {
-        let bad_path = Path::new("/tmp/shadi-nonexistent-test.sock");
-        let msg = ControlMessage::QueryPolicy;
-        let result = send_message(bad_path, &msg);
-        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/shadictl/src/shell_command.rs
+++ b/crates/shadictl/src/shell_command.rs
@@ -26,7 +26,7 @@ use crate::slim_a2a;
 use crate::slim_shell::SlimShellState;
 use crate::snapshot_command;
 use crate::trace_command::{resolve_trace_file, trace_list, trace_summary};
-use shadi_sandbox::PolicyPatch;
+use shadi_sandbox::{control, PolicyPatch};
 
 const COMMANDS: &[(&str, &str)] = &[
     ("/help", "Show available commands (alias: /h)"),
@@ -913,18 +913,15 @@ impl ShellSession {
     }
 
     fn cmd_sessions(&self) -> LoopAction {
-        let tmpdir = std::env::temp_dir();
-        let found = discover_control_sockets(&tmpdir);
-        let sessions = classify_and_prune_control_sockets(found);
+        let dir = control::socket_dir();
+        let sessions = control::prune_unreachable(control::discover_sockets(&dir));
 
         if sessions.is_empty() {
-            println!("no running SHADI sandbox sessions found in {}", tmpdir.display());
+            println!("no running SHADI sandbox sessions found in {}", dir.display());
         } else {
             println!("found {} session(s):", sessions.len());
-            for (sock, reachable) in &sessions {
-                let name = policy_watch::session_name_from_path(sock);
-                let marker = if *reachable { "reachable" } else { "stale" };
-                println!("  {} ({})", name, marker);
+            for sock in &sessions {
+                println!("  {} (reachable)", control::session_name_from_path(sock));
             }
         }
         LoopAction::Continue
@@ -1770,33 +1767,6 @@ fn short_socket_name(path: &Path) -> String {
     policy_watch::session_name_from_path(path)
 }
 
-fn discover_control_sockets(tmpdir: &Path) -> Vec<PathBuf> {
-    let mut found = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(tmpdir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str.starts_with("shadi-ctl-") && name_str.ends_with(".sock") {
-                found.push(entry.path());
-            }
-        }
-    }
-    found
-}
-
-fn classify_and_prune_control_sockets(sockets: Vec<PathBuf>) -> Vec<(PathBuf, bool)> {
-    let mut sessions = Vec::new();
-    for sock in sockets {
-        let reachable = policy_watch::query_policy(&sock).is_ok();
-        if reachable {
-            sessions.push((sock, true));
-        } else {
-            let _ = std::fs::remove_file(&sock);
-        }
-    }
-    sessions
-}
-
 fn dirs_history_path() -> Option<PathBuf> {
     let dir = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
@@ -2004,7 +1974,7 @@ mod tests {
         let stale_socket = tempdir.path().join("shadi-ctl-stale.sock");
         std::fs::write(&stale_socket, b"stale").expect("create stale socket marker");
 
-        let sessions = classify_and_prune_control_sockets(discover_control_sockets(tempdir.path()));
+        let sessions = control::prune_unreachable(control::discover_sockets(tempdir.path()));
 
         assert!(sessions.is_empty());
         assert!(!stale_socket.exists(), "stale socket should be removed");


### PR DESCRIPTION
Prerequisite for #115, and it unblocks #116 as well.

#115 asks for a panel that "links `shadi_sandbox` directly", but that only covers launch. `shadi_sandbox` exposes `spawn_sandboxed` and has no session concept — session discovery, status, patch and terminate all live in `shadictl`'s `pub(crate)` `policy_watch` and `shell_command`. `shadictl` is a binary, so nothing else can link them, and there is no machine-readable fallback either: those are interactive shell methods printing to stdout, and `introspection_command.rs` emits JSON only for config and policy.

Without this, the desktop panel would restate the socket protocol, and so would the policy inspector in #116.

## What moved

The wire types (`ControlMessage`, `ControlResponse`, `PolicyPatch`, `ProcessResources`) were **already** in `shadi_sandbox::policy_patch`, so only the caller's half needed a home — now `shadi_sandbox::control`:

- `send_patch`, `query_policy`, `send_terminate`, `query_resources` and their `send_message` transport
- `default_socket_path`, `named_socket_path`, `resolve_session_socket`, `session_name_from_path`, `sanitize_session_name` (the unix/windows cfg split preserved)
- endpoint discovery, previously two free functions in `shell_command.rs`

The **listener stays in shadictl**, which owns it. `policy_watch` re-exports the client, so its ~66 call sites are untouched, and `net -216/+16` lines in shadictl.

## Two changes beyond the move

- **Discovery and construction now share `socket_dir()`.** They previously disagreed: paths were built from `TMPDIR`/`TEMP` while the listing read `std::env::temp_dir()`. Identical on unix, but divergent on Windows with `TEMP` unset — a session could be created somewhere the listing never looked.
- **Pruning is separate from classification.** `prune_unreachable()` keeps the shell's behaviour of deleting endpoints that no longer answer; `classify_sockets()` reports reachability and touches nothing, which is what a panel refreshing on a timer needs — deleting files as a side effect of looking at them is a surprise in a UI. The shell's `"stale"` label went with it, since it pruned before printing and that arm could never appear.

## Verification

- **1142 tests pass** (up from 1134), including 12 new ones for the extracted module
- the **round-trip tests now drive the library client against shadictl's listener**, so the split is validated end to end rather than only unit-tested
- `cargo check --target x86_64-pc-windows-msvc` passes for the moved cfg-split code
- clippy reports **0 warnings** in the new module
- desktop workspace still passes `cargo check --locked`