### PR TITLE
feat(desktop): sandbox session management panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8081,6 +8081,7 @@ dependencies = [
  "agntcy-shadi-agent-secrets",
  "agntcy-shadi-identity",
  "agntcy-shadi-mas",
+ "agntcy-shadi-sandbox",
  "agntcy-slim",
  "agntcy-slim-bindings",
  "agntcy-slim-config",
@@ -8098,6 +8099,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/apps/shadi_desktop/src-tauri/Cargo.toml
+++ b/apps/shadi_desktop/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ slim_bindings = { package = "agntcy-slim-bindings", version = "2.3.0" }
 slim_proto = { package = "agntcy-slim-proto", version = "0.6.0" }
 slim_config = { package = "agntcy-slim-config", version = "0.16.0" }
 shadi_identity = { package = "agntcy-shadi-identity", version = "0.1.0", path = "../../../crates/shadi_identity" }
+shadi_sandbox = { package = "agntcy-shadi-sandbox", version = "0.1.2", path = "../../../crates/shadi_sandbox" }
 agent_secrets = { package = "agntcy-shadi-agent-secrets", version = "0.2.0", path = "../../../crates/agent_secrets" }
 # mTLS bootstrap without an openssl binary — the desktop app has to work on a
 # clean Windows install too (agntcy/shadi#123).
@@ -58,6 +59,7 @@ tauri-plugin-dialog = "2.7.2"
 
 
 [dev-dependencies]
+tempfile = "3.27"
 # Building an ssh-ed25519 public-key line for the GitHub-handle tests.
 base64 = "0.22"
 ed25519-dalek = "2.2"

--- a/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
@@ -3,29 +3,58 @@
 
 //! Sandbox session management (agntcy/shadi#115) — replaces `shadictl shell`'s
 //! `/status`, `/attach`, `/detach`, `/kill`, `/sessions`.
+//!
+//! Two kinds of session appear here. **Discovered** ones were started by
+//! `shadictl --watch-policy` somewhere else and are reached through their
+//! control socket, using the client in `shadi_sandbox::control` that shadictl
+//! itself uses. **Launched** ones this app started with `spawn_sandboxed`;
+//! they have no control socket, because serving one is shadictl's job, so the
+//! app keeps the child handle and answers from it. `session_id` tells them
+//! apart: a socket path for the first, `pid:<n>` for the second.
+//!
+//! Every command hops onto a blocking thread. The control client is blocking
+//! socket I/O, and listing probes each endpoint in turn, so leaving it on a
+//! Tauri async worker would stall unrelated commands behind a dead socket.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
+use shadi_sandbox::{control, spawn_sandboxed, SandboxPolicy, SandboxProfile, SandboxedChild};
 
-use super::not_implemented;
 use super::policy::PolicyConfig;
 
-const PANEL_ISSUE: u32 = 115;
+/// Prefix marking a session this app launched rather than discovered.
+const LAUNCHED_PREFIX: &str = "pid:";
 
-/// A discovered or attached SHADI sandbox control socket.
+/// A discovered or launched SHADI sandbox session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxSession {
     pub name: String,
-    pub socket_path: String,
+    /// Control socket path for a discovered session, `pid:<n>` for one this
+    /// app launched.
+    pub session_id: String,
     pub pid: Option<u32>,
+    /// Whether this app owns the process, and so can report its command line
+    /// and uptime.
+    pub launched_here: bool,
 }
 
-/// Live status of an attached session.
+/// Live status of a session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxStatus {
     pub session: SandboxSession,
     pub running: bool,
+    /// Only known for sessions this app launched; a control socket does not
+    /// report when its process started.
     pub uptime_secs: Option<u64>,
+    /// Likewise only known for sessions this app launched.
     pub command: Vec<String>,
+    /// Resident set size, when the session answers a resource query.
+    pub rss_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,43 +64,357 @@ pub struct LaunchSandboxRequest {
     pub session_name: Option<String>,
 }
 
-/// Launch a new sandboxed process (mirrors `shadictl <flags> -- <command>`).
-#[tauri::command]
-pub async fn sandbox_launch(request: LaunchSandboxRequest) -> Result<SandboxSession, String> {
-    let _ = request;
-    not_implemented(PANEL_ISSUE)
+struct Launched {
+    child: SandboxedChild,
+    command: Vec<String>,
+    started: Instant,
+    name: String,
 }
 
-/// Discover running SHADI sandbox control sockets (`/sessions`).
-#[tauri::command]
-pub async fn sandbox_list_sessions() -> Result<Vec<SandboxSession>, String> {
-    not_implemented(PANEL_ISSUE)
+/// Sandboxed processes this app started, keyed by `pid:<n>`.
+#[derive(Default)]
+pub struct SandboxState(Arc<Mutex<HashMap<String, Launched>>>);
+
+impl SandboxState {
+    fn handle(&self) -> Arc<Mutex<HashMap<String, Launched>>> {
+        Arc::clone(&self.0)
+    }
 }
 
-/// Attach to a running session by name or socket path (`/attach`).
-#[tauri::command]
-pub async fn sandbox_attach(socket_path: String) -> Result<SandboxStatus, String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+/// Run blocking sandbox work off the async runtime.
+async fn blocking<T, F>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(f)
+        .await
+        .map_err(|err| format!("sandbox task failed: {err}"))?
 }
 
-/// Detach from the current session without terminating it (`/detach`).
-#[tauri::command]
-pub async fn sandbox_detach(socket_path: String) -> Result<(), String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+/// Build a [`SandboxPolicy`] the way `shadictl` does: network first, then the
+/// profile's paths, then the caller's own on top, so an explicit path can only
+/// widen what the profile granted.
+fn policy_from_config(config: &PolicyConfig) -> Result<SandboxPolicy, String> {
+    let profile = match config.profile.as_deref() {
+        Some(name) => Some(SandboxProfile::from_name(name).ok_or_else(|| {
+            format!("unknown profile '{name}'; expected strict, balanced or connected")
+        })?),
+        None => None,
+    };
+    let defaults = profile.map(|p| p.defaults());
+
+    let net_block = config.net_block || defaults.as_ref().map(|d| d.net_block).unwrap_or(false);
+    let mut policy = SandboxPolicy::new().block_network(net_block);
+
+    for destination in &config.net_allow {
+        policy = policy.allow_network_destination(destination.clone());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        policy = policy.use_minimal_platform_profile();
+    }
+
+    if let Some(defaults) = defaults.as_ref() {
+        policy = apply_paths(policy, &defaults.read, PathMode::Read)?;
+        policy = apply_paths(policy, &defaults.write, PathMode::Write)?;
+        policy = apply_paths(policy, &defaults.allow, PathMode::Allow)?;
+    }
+
+    policy = apply_paths(policy, &config.read, PathMode::Read)?;
+    policy = apply_paths(policy, &config.write, PathMode::Write)?;
+    policy = apply_paths(policy, &config.allow, PathMode::Allow)?;
+
+    Ok(policy)
 }
 
-/// Terminate the attached sandboxed process (`/kill`).
-#[tauri::command]
-pub async fn sandbox_kill(socket_path: String) -> Result<(), String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+enum PathMode {
+    Read,
+    Write,
+    Allow,
 }
 
-/// Live status of an attached session (`/status`).
+fn apply_paths(
+    mut policy: SandboxPolicy,
+    paths: &[String],
+    mode: PathMode,
+) -> Result<SandboxPolicy, String> {
+    let label = match mode {
+        PathMode::Read => "read",
+        PathMode::Write => "write",
+        PathMode::Allow => "allow",
+    };
+    for path in paths {
+        let resolved = std::fs::canonicalize(path)
+            .map_err(|err| format!("invalid {label} path {path}: {err}"))?;
+        policy = match mode {
+            PathMode::Read => policy.allow_read_path(&resolved),
+            PathMode::Write => policy.allow_write_path(&resolved),
+            PathMode::Allow => policy.allow_read_path(&resolved).allow_write_path(&resolved),
+        };
+    }
+    Ok(policy)
+}
+
+/// Launch a sandboxed process (mirrors `shadictl <flags> -- <command>`).
 #[tauri::command]
-pub async fn sandbox_status(socket_path: String) -> Result<SandboxStatus, String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+pub async fn sandbox_launch(
+    request: LaunchSandboxRequest,
+    state: tauri::State<'_, SandboxState>,
+) -> Result<SandboxSession, String> {
+    let sessions = state.handle();
+    blocking(move || {
+        let (program, args) = request
+            .command
+            .split_first()
+            .ok_or_else(|| "command is empty".to_string())?;
+
+        let policy = policy_from_config(&request.policy)?;
+        let mut cmd = Command::new(program);
+        cmd.args(args);
+
+        let child = spawn_sandboxed(&mut cmd, &policy)
+            .map_err(|err| format!("failed to launch sandboxed process: {err}"))?;
+
+        let pid = child.id();
+        let session_id = format!("{LAUNCHED_PREFIX}{pid}");
+        let name = request
+            .session_name
+            .map(|n| control::sanitize_session_name(&n))
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| pid.to_string());
+
+        let session = SandboxSession {
+            name: name.clone(),
+            session_id: session_id.clone(),
+            pid: Some(pid),
+            launched_here: true,
+        };
+
+        sessions.lock().map_err(lock_poisoned)?.insert(
+            session_id,
+            Launched {
+                child,
+                command: request.command,
+                started: Instant::now(),
+                name,
+            },
+        );
+
+        Ok(session)
+    })
+    .await
+}
+
+/// Discover running sandbox sessions (`/sessions`), plus any this app launched.
+#[tauri::command]
+pub async fn sandbox_list_sessions(
+    state: tauri::State<'_, SandboxState>,
+) -> Result<Vec<SandboxSession>, String> {
+    let sessions = state.handle();
+    blocking(move || {
+        // classify rather than prune: this list refreshes on a timer, and
+        // deleting endpoints as a side effect of looking at them would be a
+        // surprise from a panel.
+        let dir = control::socket_dir();
+        let mut found: Vec<SandboxSession> = control::classify_sockets(control::discover_sockets(&dir))
+            .into_iter()
+            .filter(|(_, reachable)| *reachable)
+            .map(|(path, _)| SandboxSession {
+                name: control::session_name_from_path(&path),
+                session_id: path.to_string_lossy().into_owned(),
+                pid: None,
+                launched_here: false,
+            })
+            .collect();
+
+        let mut owned = sessions.lock().map_err(lock_poisoned)?;
+        owned.retain(|_, launched| launched.child.try_wait().ok().flatten().is_none());
+        for (session_id, launched) in owned.iter() {
+            found.push(SandboxSession {
+                name: launched.name.clone(),
+                session_id: session_id.clone(),
+                pid: session_pid(session_id),
+                launched_here: true,
+            });
+        }
+
+        found.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(found)
+    })
+    .await
+}
+
+/// Attach to a session by name or socket path (`/attach`).
+///
+/// The control client is stateless, so attaching is a reachability check that
+/// hands back the first status; the panel holds the selection.
+#[tauri::command]
+pub async fn sandbox_attach(
+    session_id: String,
+    state: tauri::State<'_, SandboxState>,
+) -> Result<SandboxStatus, String> {
+    let resolved = if session_id.starts_with(LAUNCHED_PREFIX) {
+        session_id
+    } else {
+        control::resolve_session_socket(&session_id)
+            .to_string_lossy()
+            .into_owned()
+    };
+    sandbox_status(resolved, state).await
+}
+
+/// Detach from a session without terminating it (`/detach`).
+///
+/// Nothing to tear down: the client opens a connection per request and the
+/// panel drops its selection. A session this app launched keeps running, and
+/// stays listed so it can be killed later.
+#[tauri::command]
+pub async fn sandbox_detach(session_id: String) -> Result<(), String> {
+    let _ = session_id;
+    Ok(())
+}
+
+/// Terminate a session's sandboxed process (`/kill`).
+#[tauri::command]
+pub async fn sandbox_kill(
+    session_id: String,
+    state: tauri::State<'_, SandboxState>,
+) -> Result<(), String> {
+    let sessions = state.handle();
+    blocking(move || {
+        if session_id.starts_with(LAUNCHED_PREFIX) {
+            let mut owned = sessions.lock().map_err(lock_poisoned)?;
+            let mut launched = owned
+                .remove(&session_id)
+                .ok_or_else(|| format!("no launched session {session_id}"))?;
+            return launched
+                .child
+                .kill()
+                .map_err(|err| format!("failed to terminate {session_id}: {err}"));
+        }
+
+        control::send_terminate(&PathBuf::from(&session_id)).map(|_| ())
+    })
+    .await
+}
+
+/// Live status of a session (`/status`).
+#[tauri::command]
+pub async fn sandbox_status(
+    session_id: String,
+    state: tauri::State<'_, SandboxState>,
+) -> Result<SandboxStatus, String> {
+    let sessions = state.handle();
+    blocking(move || {
+        if session_id.starts_with(LAUNCHED_PREFIX) {
+            let mut owned = sessions.lock().map_err(lock_poisoned)?;
+            let launched = owned
+                .get_mut(&session_id)
+                .ok_or_else(|| format!("no launched session {session_id}"))?;
+            let running = launched.child.try_wait().ok().flatten().is_none();
+            return Ok(SandboxStatus {
+                session: SandboxSession {
+                    name: launched.name.clone(),
+                    session_id: session_id.clone(),
+                    pid: session_pid(&session_id),
+                    launched_here: true,
+                },
+                running,
+                uptime_secs: Some(launched.started.elapsed().as_secs()),
+                command: launched.command.clone(),
+                rss_bytes: None,
+            });
+        }
+
+        let path = PathBuf::from(&session_id);
+        // A policy query is the reachability check; resources are a bonus the
+        // session may decline to answer.
+        control::query_policy(&path)?;
+        let resources = control::query_resources(&path).ok();
+
+        Ok(SandboxStatus {
+            session: SandboxSession {
+                name: control::session_name_from_path(&path),
+                session_id: session_id.clone(),
+                pid: resources.as_ref().map(|r| r.pid),
+                launched_here: false,
+            },
+            running: true,
+            uptime_secs: None,
+            command: Vec::new(),
+            rss_bytes: resources.and_then(|r| r.rss_bytes),
+        })
+    })
+    .await
+}
+
+fn session_pid(session_id: &str) -> Option<u32> {
+    session_id.strip_prefix(LAUNCHED_PREFIX)?.parse().ok()
+}
+
+fn lock_poisoned<T>(_: T) -> String {
+    "sandbox session registry is poisoned".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> PolicyConfig {
+        PolicyConfig {
+            allow: Vec::new(),
+            read: Vec::new(),
+            write: Vec::new(),
+            net_block: false,
+            net_allow: Vec::new(),
+            profile: None,
+        }
+    }
+
+    #[test]
+    fn an_unknown_profile_is_rejected_by_name() {
+        let mut c = config();
+        c.profile = Some("paranoid".to_string());
+        let err = policy_from_config(&c).unwrap_err();
+        assert!(err.contains("unknown profile 'paranoid'"), "{err}");
+        assert!(err.contains("strict, balanced or connected"), "{err}");
+    }
+
+    #[test]
+    fn every_documented_profile_resolves() {
+        for name in ["strict", "balanced", "connected", "STRICT"] {
+            let mut c = config();
+            c.profile = Some(name.to_string());
+            assert!(policy_from_config(&c).is_ok(), "{name} should resolve");
+        }
+    }
+
+    #[test]
+    fn a_nonexistent_path_names_the_axis_that_rejected_it() {
+        let mut c = config();
+        c.write = vec!["/nonexistent-shadi-path".to_string()];
+        let err = policy_from_config(&c).unwrap_err();
+        assert!(err.starts_with("invalid write path /nonexistent-shadi-path"), "{err}");
+    }
+
+    #[test]
+    fn session_pid_reads_back_only_launched_ids() {
+        assert_eq!(session_pid("pid:4321"), Some(4321));
+        assert_eq!(session_pid("/tmp/shadi-ctl-agent.sock"), None);
+        assert_eq!(session_pid("pid:not-a-number"), None);
+    }
+
+    #[test]
+    fn explicit_paths_layer_on_top_of_a_profile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut c = config();
+        c.profile = Some("strict".to_string());
+        c.write = vec![dir.path().to_string_lossy().into_owned()];
+
+        // Strict blocks the network; an explicit writable path must not undo
+        // that, and must not fail to resolve either.
+        assert!(policy_from_config(&c).is_ok());
+    }
 }

--- a/apps/shadi_desktop/src-tauri/src/lib.rs
+++ b/apps/shadi_desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub fn run() {
         // Native file picker, so a key outside ~/.ssh can be chosen.
         .plugin(tauri_plugin_dialog::init())
         .manage(commands::slim::SlimState::default())
+        .manage(commands::sandbox::SandboxState::default())
         .setup(|app| {
             // Known rooms are persisted (agntcy/shadi#138); the app data dir is
             // only resolvable once the app exists. A failure here is reported

--- a/apps/shadi_desktop/src/App.tsx
+++ b/apps/shadi_desktop/src/App.tsx
@@ -3,11 +3,13 @@ import "./App.css";
 import { AgentBridgePanel } from "./panels/AgentBridgePanel";
 import { SlimRoomsPanel } from "./panels/SlimRoomsPanel";
 import { OnboardingPanel } from "./panels/OnboardingPanel";
+import { SandboxPanel } from "./panels/SandboxPanel";
 import { RoomsProvider } from "./shared/rooms";
 
 // Identity first: nothing else works until onboarding has run.
 const TABS = [
   { id: "identity", label: "Identity", render: () => <OnboardingPanel /> },
+  { id: "sandbox", label: "Sandbox", render: () => <SandboxPanel /> },
   { id: "rooms", label: "Rooms", render: () => <SlimRoomsPanel /> },
   { id: "agentbridge", label: "agentbridge", render: () => <AgentBridgePanel /> },
 ] as const;

--- a/apps/shadi_desktop/src/panels/SandboxPanel.css
+++ b/apps/shadi_desktop/src/panels/SandboxPanel.css
@@ -1,0 +1,148 @@
+.sb-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sb-card {
+  background: var(--panel-bg, #ffffff);
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sb-card h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.sb-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.sb-field span {
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.sb-field input,
+.sb-field select {
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.sb-row {
+  display: flex;
+  gap: 12px;
+}
+
+.sb-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.sb-error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--error-fg, #b3261e);
+}
+
+.sb-sessions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sb-sessions li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+}
+
+.sb-sessions li.sb-selected {
+  border-color: var(--accent, #2f6feb);
+  box-shadow: inset 2px 0 0 var(--accent, #2f6feb);
+}
+
+.sb-session-id {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.sb-tag {
+  font-size: 11px;
+  color: var(--muted-fg, #5b6770);
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.sb-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sb-danger {
+  color: var(--error-fg, #b3261e);
+}
+
+.sb-status {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.sb-status dt {
+  color: var(--muted-fg, #5b6770);
+}
+
+.sb-status dd {
+  margin: 0;
+  min-width: 0;
+}
+
+/* A socket path can be long; let it scroll rather than widen the panel. */
+.sb-endpoint {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.sb-pill {
+  font-size: 11px;
+  border-radius: 999px;
+  padding: 1px 10px;
+}
+
+.sb-pill-live {
+  background: var(--ok-bg, #e4f0ea);
+  color: var(--ok-fg, #2e7d5b);
+}
+
+.sb-pill-stopped {
+  background: var(--muted-bg, #eceff1);
+  color: var(--muted-fg, #5b6770);
+}

--- a/apps/shadi_desktop/src/panels/SandboxPanel.tsx
+++ b/apps/shadi_desktop/src/panels/SandboxPanel.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "./SandboxPanel.css";
+
+interface SandboxSession {
+  name: string;
+  session_id: string;
+  pid: number | null;
+  launched_here: boolean;
+}
+
+interface SandboxStatus {
+  session: SandboxSession;
+  running: boolean;
+  uptime_secs: number | null;
+  command: string[];
+  rss_bytes: number | null;
+}
+
+const PROFILES = ["strict", "balanced", "connected"] as const;
+type Profile = (typeof PROFILES)[number];
+
+/// What each profile grants, shown next to the picker so the choice is not a
+/// guess. Mirrors SandboxProfile::defaults in shadi_sandbox.
+const PROFILE_SUMMARY: Record<Profile, string> = {
+  strict: "Working directory only, network off",
+  balanced: "Working directory writable, wider reads, network off",
+  connected: "Balanced, network on",
+};
+
+/// Sessions are polled rather than pushed: the control socket answers one
+/// request per connection and has no subscribe verb.
+const REFRESH_MS = 4000;
+
+function ErrorText({ message }: { message: string | null }) {
+  if (!message) return null;
+  return <p className="sb-error">{message}</p>;
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  if (m < 60) return `${m}m ${seconds % 60}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+function LaunchSection({ onLaunched }: { onLaunched: () => void }) {
+  const [command, setCommand] = useState("");
+  const [sessionName, setSessionName] = useState("");
+  const [profile, setProfile] = useState<Profile>("balanced");
+  const [allow, setAllow] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onLaunch() {
+    const argv = command.trim().split(/\s+/).filter(Boolean);
+    if (argv.length === 0) {
+      setError("Enter a command to run.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke<SandboxSession>("sandbox_launch", {
+        request: {
+          command: argv,
+          session_name: sessionName.trim() || null,
+          policy: {
+            allow: allow.trim() ? allow.split(",").map((p) => p.trim()).filter(Boolean) : [],
+            read: [],
+            write: [],
+            net_block: false,
+            net_allow: [],
+            profile,
+          },
+        },
+      });
+      setCommand("");
+      setSessionName("");
+      onLaunched();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="sb-card">
+      <h2>Launch a sandboxed process</h2>
+      <label className="sb-field">
+        <span>Command</span>
+        <input
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          placeholder="npm test"
+        />
+      </label>
+      <div className="sb-row">
+        <label className="sb-field">
+          <span>Profile</span>
+          <select value={profile} onChange={(e) => setProfile(e.target.value as Profile)}>
+            {PROFILES.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="sb-field">
+          <span>Session name (optional)</span>
+          <input
+            value={sessionName}
+            onChange={(e) => setSessionName(e.target.value)}
+            placeholder="derived from the pid"
+          />
+        </label>
+      </div>
+      <p className="sb-hint">{PROFILE_SUMMARY[profile]}</p>
+      <label className="sb-field">
+        <span>Extra read+write paths (comma separated)</span>
+        <input value={allow} onChange={(e) => setAllow(e.target.value)} placeholder="/tmp/work" />
+      </label>
+      <button onClick={onLaunch} disabled={busy}>
+        {busy ? "Launching…" : "Launch"}
+      </button>
+      <ErrorText message={error} />
+    </section>
+  );
+}
+
+function StatusSection({
+  status,
+  onDetach,
+  onKill,
+}: {
+  status: SandboxStatus;
+  onDetach: () => void;
+  onKill: () => void;
+}) {
+  const { session } = status;
+  return (
+    <section className="sb-card">
+      <h2>{session.name}</h2>
+      <dl className="sb-status">
+        <dt>State</dt>
+        <dd>
+          <span className={status.running ? "sb-pill sb-pill-live" : "sb-pill sb-pill-stopped"}>
+            {status.running ? "running" : "stopped"}
+          </span>
+        </dd>
+        <dt>Origin</dt>
+        <dd>{session.launched_here ? "launched here" : "discovered"}</dd>
+        {session.pid !== null && (
+          <>
+            <dt>PID</dt>
+            <dd>{session.pid}</dd>
+          </>
+        )}
+        {status.uptime_secs !== null && (
+          <>
+            <dt>Uptime</dt>
+            <dd>{formatUptime(status.uptime_secs)}</dd>
+          </>
+        )}
+        {status.rss_bytes !== null && (
+          <>
+            <dt>Memory</dt>
+            <dd>{formatBytes(status.rss_bytes)}</dd>
+          </>
+        )}
+        {status.command.length > 0 && (
+          <>
+            <dt>Command</dt>
+            <dd>
+              <code>{status.command.join(" ")}</code>
+            </dd>
+          </>
+        )}
+        <dt>Endpoint</dt>
+        <dd>
+          <code className="sb-endpoint">{session.session_id}</code>
+        </dd>
+      </dl>
+      {!session.launched_here && (
+        <p className="sb-hint">
+          Started outside this app, so its command line and uptime are not available — a control
+          socket does not report them.
+        </p>
+      )}
+      <div className="sb-actions">
+        <button onClick={onDetach}>Detach</button>
+        <button className="sb-danger" onClick={onKill}>
+          Kill
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export function SandboxPanel() {
+  const [sessions, setSessions] = useState<SandboxSession[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [status, setStatus] = useState<SandboxStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setSessions(await invoke<SandboxSession[]>("sandbox_list_sessions"));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const timer = setInterval(refresh, REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  // Keep the open session's status fresh, and drop the selection if it goes.
+  useEffect(() => {
+    if (selected === null) {
+      setStatus(null);
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const next = await invoke<SandboxStatus>("sandbox_status", { sessionId: selected });
+        if (!cancelled) setStatus(next);
+      } catch {
+        if (!cancelled) {
+          setStatus(null);
+          setSelected(null);
+        }
+      }
+    };
+    poll();
+    const timer = setInterval(poll, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [selected]);
+
+  async function onAttach(sessionId: string) {
+    setError(null);
+    try {
+      setStatus(await invoke<SandboxStatus>("sandbox_attach", { sessionId }));
+      setSelected(sessionId);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function onDetach() {
+    if (selected === null) return;
+    try {
+      await invoke("sandbox_detach", { sessionId: selected });
+    } catch (e) {
+      setError(String(e));
+    }
+    setSelected(null);
+  }
+
+  async function onKill(sessionId: string) {
+    setError(null);
+    try {
+      await invoke("sandbox_kill", { sessionId });
+      if (selected === sessionId) setSelected(null);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="sb-panel">
+      <LaunchSection onLaunched={refresh} />
+
+      <section className="sb-card">
+        <h2>Sessions</h2>
+        {sessions.length === 0 ? (
+          <p className="sb-hint">
+            No sandbox sessions running. Launch one above, or start one elsewhere with{" "}
+            <code>shadictl --watch-policy</code> and it will appear here.
+          </p>
+        ) : (
+          <ul className="sb-sessions">
+            {sessions.map((s) => (
+              <li key={s.session_id} className={s.session_id === selected ? "sb-selected" : ""}>
+                <div className="sb-session-id">
+                  <strong>{s.name}</strong>
+                  <span className="sb-tag">{s.launched_here ? "launched here" : "discovered"}</span>
+                  {s.pid !== null && <span className="sb-tag">pid {s.pid}</span>}
+                </div>
+                <div className="sb-actions">
+                  <button onClick={() => onAttach(s.session_id)}>Attach</button>
+                  <button className="sb-danger" onClick={() => onKill(s.session_id)}>
+                    Kill
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <ErrorText message={error} />
+      </section>
+
+      {status !== null && (
+        <StatusSection status={status} onDetach={onDetach} onKill={() => onKill(status.session.session_id)} />
+      )}
+    </div>
+  );
+}

--- a/crates/shadi_sandbox/src/control.rs
+++ b/crates/shadi_sandbox/src/control.rs
@@ -14,7 +14,7 @@
 //! [`socket_dir`]. A caller connects, writes one JSON [`ControlMessage`] line,
 //! and reads one JSON [`ControlResponse`] line back.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use crate::policy_patch::{
@@ -328,10 +328,13 @@ mod tests {
         std::thread::spawn(move || {
             for reply in replies {
                 let Ok((mut stream, _)) = listener.accept() else { return };
-                // Drain the request so the client's write half completes.
+                // Read to EOF before replying. The client writes its request,
+                // shuts down its write half, and only then reads; answering
+                // the moment the first line arrives can close this end before
+                // that shutdown lands, which fails it with ENOTCONN.
                 let mut request = String::new();
                 let mut reader = BufReader::new(stream.try_clone().expect("clone"));
-                let _ = reader.read_line(&mut request);
+                let _ = reader.read_to_string(&mut request);
                 let body = serde_json::to_string(&reply).expect("serialize reply");
                 let _ = writeln!(stream, "{}", body);
                 let _ = stream.flush();

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -8,7 +8,7 @@ pub mod policy_patch;
 mod platform;
 
 pub use net_proxy::{NetAllowlist, NetProxy};
-pub use policy::{PlatformSandboxProfile, SandboxPolicy};
+pub use policy::{PlatformSandboxProfile, ProfileDefaults, SandboxPolicy, SandboxProfile};
 pub use policy_patch::{
     ControlMessage, ControlResponse, PatchAxisStatus, PolicyPatch, PolicyPatchResponse,
     ProcessResources,

--- a/crates/shadi_sandbox/src/policy.rs
+++ b/crates/shadi_sandbox/src/policy.rs
@@ -23,6 +23,82 @@ pub struct SandboxPolicy {
     net_proxy_port: Option<u16>,
 }
 
+/// The named launch profiles offered by `shadictl --profile` and the desktop
+/// sandbox panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SandboxProfile {
+    /// Read and write confined to the working directory, network off.
+    Strict,
+    /// Working directory writable, wider reads where the platform sandbox
+    /// gives them for free, network off.
+    Balanced,
+    /// Balanced, with the network left on.
+    Connected,
+}
+
+/// The four axes a named profile fixes. A caller layers its own paths and
+/// allowlists on top; everything else a profile could set is empty in all of
+/// them, which is why only these four live here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileDefaults {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+}
+
+impl SandboxProfile {
+    /// Parse the profile names accepted on the command line.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "strict" => Some(Self::Strict),
+            "balanced" => Some(Self::Balanced),
+            "connected" => Some(Self::Connected),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::Balanced => "balanced",
+            Self::Connected => "connected",
+        }
+    }
+
+    pub fn defaults(self) -> ProfileDefaults {
+        // macOS Seatbelt and Linux Landlock both give a readable root without
+        // it costing anything, so only the platforms without that need "/"
+        // spelled out.
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        let wide_read: Vec<String> = Vec::new();
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        let wide_read: Vec<String> = vec!["/".to_string()];
+
+        match self {
+            Self::Strict => ProfileDefaults {
+                allow: vec![".".to_string()],
+                read: vec![".".to_string()],
+                write: Vec::new(),
+                net_block: true,
+            },
+            Self::Balanced => ProfileDefaults {
+                allow: vec![".".to_string()],
+                read: wide_read,
+                write: Vec::new(),
+                net_block: true,
+            },
+            Self::Connected => ProfileDefaults {
+                allow: vec![".".to_string()],
+                read: wide_read,
+                write: Vec::new(),
+                net_block: false,
+            },
+        }
+    }
+}
+
 impl SandboxPolicy {
     pub fn new() -> Self {
         Self {

--- a/crates/shadi_sandbox/src/policy.rs
+++ b/crates/shadi_sandbox/src/policy.rs
@@ -59,14 +59,6 @@ impl SandboxProfile {
         }
     }
 
-    pub fn name(self) -> &'static str {
-        match self {
-            Self::Strict => "strict",
-            Self::Balanced => "balanced",
-            Self::Connected => "connected",
-        }
-    }
-
     pub fn defaults(self) -> ProfileDefaults {
         // macOS Seatbelt and Linux Landlock both give a readable root without
         // it costing anything, so only the platforms without that need "/"
@@ -240,5 +232,52 @@ mod tests {
     fn policy_can_allow_local_unix_sockets() {
         let policy = SandboxPolicy::new().allow_local_unix_sockets();
         assert!(policy.local_unix_sockets_allowed());
+    }
+}
+
+#[cfg(test)]
+mod profile_tests {
+    use super::*;
+
+    #[test]
+    fn profile_names_round_trip_and_reject_the_rest() {
+        assert_eq!(SandboxProfile::from_name("strict"), Some(SandboxProfile::Strict));
+        assert_eq!(SandboxProfile::from_name("balanced"), Some(SandboxProfile::Balanced));
+        assert_eq!(SandboxProfile::from_name("connected"), Some(SandboxProfile::Connected));
+        // The CLI accepts these case-insensitively, so the library must too.
+        assert_eq!(SandboxProfile::from_name("STRICT"), Some(SandboxProfile::Strict));
+        assert_eq!(SandboxProfile::from_name("paranoid"), None);
+        assert_eq!(SandboxProfile::from_name(""), None);
+    }
+
+    #[test]
+    fn only_connected_leaves_the_network_on() {
+        assert!(SandboxProfile::Strict.defaults().net_block);
+        assert!(SandboxProfile::Balanced.defaults().net_block);
+        assert!(!SandboxProfile::Connected.defaults().net_block);
+    }
+
+    #[test]
+    fn every_profile_grants_the_working_directory_and_no_blanket_write() {
+        for profile in [
+            SandboxProfile::Strict,
+            SandboxProfile::Balanced,
+            SandboxProfile::Connected,
+        ] {
+            let d = profile.defaults();
+            assert_eq!(d.allow, vec![".".to_string()], "{profile:?}");
+            assert!(d.write.is_empty(), "{profile:?} must not grant a blanket write");
+        }
+    }
+
+    #[test]
+    fn strict_confines_reads_where_the_others_do_not() {
+        assert_eq!(SandboxProfile::Strict.defaults().read, vec![".".to_string()]);
+        // Seatbelt and Landlock give a readable root for free; elsewhere it is
+        // spelled out, so the two cases differ by platform, not by profile.
+        assert_eq!(
+            SandboxProfile::Balanced.defaults().read,
+            SandboxProfile::Connected.defaults().read
+        );
     }
 }

--- a/crates/shadictl/src/policy_helpers.rs
+++ b/crates/shadictl/src/policy_helpers.rs
@@ -1,5 +1,5 @@
 use super::*;
-use shadi_sandbox::PlatformSandboxProfile;
+use shadi_sandbox::{PlatformSandboxProfile, SandboxProfile};
 
 pub(crate) fn format_policy(
     policy: &SandboxPolicy,
@@ -133,52 +133,28 @@ pub(crate) fn resolve_policy(cli: &Cli, file_policy: &PolicyFile) -> Result<Reso
 }
 
 pub(crate) fn profile_defaults(profile: Option<LauncherProfile>) -> PolicyFile {
-    match profile.unwrap_or(LauncherProfile::Balanced) {
-        LauncherProfile::Strict => PolicyFile {
-            allow: vec![".".to_string()],
-            read: vec![".".to_string()],
-            write: Vec::new(),
-            net_block: Some(true),
-            net_allow: Vec::new(),
-            allow_command: Vec::new(),
-            block_command: Vec::new(),
-            env_remove: Vec::new(),
-            process_inject_keychain: Vec::new(),
-            process_trusted_secret: Vec::new(),
-            process_secret_policy: Vec::new(),
-        },
-        LauncherProfile::Balanced => PolicyFile {
-            allow: vec![".".to_string()],
-            #[cfg(any(target_os = "macos", target_os = "linux"))]
-            read: Vec::new(),
-            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-            read: vec!["/".to_string()],
-            write: Vec::new(),
-            net_block: Some(true),
-            net_allow: Vec::new(),
-            allow_command: Vec::new(),
-            block_command: Vec::new(),
-            env_remove: Vec::new(),
-            process_inject_keychain: Vec::new(),
-            process_trusted_secret: Vec::new(),
-            process_secret_policy: Vec::new(),
-        },
-        LauncherProfile::Connected => PolicyFile {
-            allow: vec![".".to_string()],
-            #[cfg(any(target_os = "macos", target_os = "linux"))]
-            read: Vec::new(),
-            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-            read: vec!["/".to_string()],
-            write: Vec::new(),
-            net_block: Some(false),
-            net_allow: Vec::new(),
-            allow_command: Vec::new(),
-            block_command: Vec::new(),
-            env_remove: Vec::new(),
-            process_inject_keychain: Vec::new(),
-            process_trusted_secret: Vec::new(),
-            process_secret_policy: Vec::new(),
-        },
+    // The sandbox axes live in shadi_sandbox so the desktop panel gets the same
+    // profiles without restating them; everything below them is empty in every
+    // profile and stays here with the rest of the policy-file schema.
+    let defaults = match profile.unwrap_or(LauncherProfile::Balanced) {
+        LauncherProfile::Strict => SandboxProfile::Strict,
+        LauncherProfile::Balanced => SandboxProfile::Balanced,
+        LauncherProfile::Connected => SandboxProfile::Connected,
+    }
+    .defaults();
+
+    PolicyFile {
+        allow: defaults.allow,
+        read: defaults.read,
+        write: defaults.write,
+        net_block: Some(defaults.net_block),
+        net_allow: Vec::new(),
+        allow_command: Vec::new(),
+        block_command: Vec::new(),
+        env_remove: Vec::new(),
+        process_inject_keychain: Vec::new(),
+        process_trusted_secret: Vec::new(),
+        process_secret_policy: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Closes #115. Builds on the control client extracted in #200.

The six sandbox commands were stubs returning `not_implemented`. They are now implemented, and the panel that drives them is wired in as a **Sandbox** tab.

## Two kinds of session

The issue assumed one. There are two, and conflating them would have meant showing empty fields with no explanation:

- **Discovered** — started by `shadictl --watch-policy` elsewhere, reached through its control socket using the same client shadictl uses.
- **Launched** — started by this app via `spawn_sandboxed`. Serving a control socket is shadictl's job, so these have none; the app keeps the child handle and answers status and kill from it.

`session_id` distinguishes them — a socket path, or `pid:<n>`. The panel labels each and explains why a discovered session reports no command line or uptime, rather than leaving blanks.

## Design notes

- **Listing classifies rather than prunes.** It refreshes on a timer, and deleting endpoints as a side effect of looking at them would be a surprise from a UI. `classify_sockets` exists for exactly this; the shell keeps `prune_unreachable`.
- **Every command hops onto a blocking thread.** The control client is blocking socket I/O and a listing probes each endpoint in turn, so leaving it on a Tauri async worker would stall unrelated commands behind one dead socket — the same reason `SlimState` does it.
- **Profiles moved to `shadi_sandbox`.** The panel offers the same strict/balanced/connected the CLI does instead of restating them, and `shadictl`'s `profile_defaults` now builds its `PolicyFile` from them. Only the four sandbox axes moved — every other field is empty in all three profiles, so the policy-file schema stayed put.
- **Policy construction follows the CLI's order** — network, then the profile's paths, then the caller's own — so an explicit path can only widen what the profile granted.

## Verification

- **1148 workspace tests pass** (up from 1142), plus **35 desktop tests** including 5 new ones for profile resolution, path-axis errors and session-id parsing
- the 7 existing profile tests still pass, so moving them changed no behaviour
- `pnpm build` (tsc + vite) is clean, which type-checks the panel against the command signatures
- `cargo metadata --locked` passes

## Not covered

`sandbox_detach` is a no-op by design: the control client opens a connection per request, so there is nothing to tear down and the panel simply drops its selection. A launched session keeps running and stays listed so it can be killed later.