### PR TITLE
fix(desktop): bump nanoid to patch GHSA-2v37-7h3g-55p8

### DIFF
--- a/apps/shadi_desktop/pnpm-lock.yaml
+++ b/apps/shadi_desktop/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: '>=3.3.18 <4'
+
 importers:
 
   .:
@@ -632,8 +635,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1201,7 +1204,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.51: {}
 
@@ -1211,7 +1214,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/apps/shadi_desktop/pnpm-workspace.yaml
+++ b/apps/shadi_desktop/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   esbuild: false
+
+overrides:
+  nanoid: ">=3.3.18 <4"


### PR DESCRIPTION
Bumps `nanoid` (transitive devDependency via postcss -> vite) to patch a real vulnerability flagged by OpenSSF Scorecard.

- GHSA-2v37-7h3g-55p8: infinite-loop DoS in `customAlphabet`/`customRandom` when called with size 0 (CVSS up to 8.2)
- Pinned via pnpm override to `>=3.3.18 <4` (same major, minimal risk) since it's not a direct dependency

Validation: `pnpm install` + `pnpm run build` both succeed.