### PR TITLE
feat(release): sign release archives with cosign

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -102,6 +102,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+      # Needed for cosign's keyless signing: it exchanges this for a
+      # short-lived certificate tying the signature to this workflow run.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -177,6 +180,21 @@ jobs:
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless: the signature ties to this workflow run and repository via
+      # Sigstore's Fulcio CA, using the OIDC token id-token: write grants —
+      # no signing key for anyone to hold or rotate.
+      - name: Sign the release archive
+        id: sign
+        shell: bash
+        run: |
+          archive="${{ steps.package.outputs.archive_path }}"
+          bundle="$archive.sigstore.json"
+          cosign sign-blob --yes --bundle "$bundle" "$archive"
+          echo "bundle_path=$bundle" >> "$GITHUB_OUTPUT"
+
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -185,6 +203,7 @@ jobs:
           gh release upload "${{ steps.metadata.outputs.release_tag }}" \
             "${{ steps.package.outputs.archive_path }}" \
             "${{ steps.package.outputs.checksum_path }}" \
+            "${{ steps.sign.outputs.bundle_path }}" \
             --repo "${{ github.repository }}" \
             --clobber
 
@@ -272,6 +291,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
+      # Needed for cosign's keyless signing: it exchanges this for a
+      # short-lived certificate tying the signature to this workflow run.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -347,6 +369,21 @@ jobs:
             --output-dir dist \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless: the signature ties to this workflow run and repository via
+      # Sigstore's Fulcio CA, using the OIDC token id-token: write grants —
+      # no signing key for anyone to hold or rotate.
+      - name: Sign the release archive
+        id: sign
+        shell: bash
+        run: |
+          archive="${{ steps.package.outputs.archive_path }}"
+          bundle="$archive.sigstore.json"
+          cosign sign-blob --yes --bundle "$bundle" "$archive"
+          echo "bundle_path=$bundle" >> "$GITHUB_OUTPUT"
+
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -355,6 +392,7 @@ jobs:
           gh release upload "${{ steps.metadata.outputs.release_tag }}" \
             "${{ steps.package.outputs.archive_path }}" \
             "${{ steps.package.outputs.checksum_path }}" \
+            "${{ steps.sign.outputs.bundle_path }}" \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -53,6 +53,25 @@ curl -fsSL https://agntcy.github.io/shadi/install.sh | env SHADI_VERSION=0.1.1 b
 The installer replaces the existing `shadictl` binary in place. If the archive
 download or checksum validation fails, the existing binary is left untouched.
 
+## Verifying release signatures
+
+Every release archive is signed keylessly with [cosign](https://docs.sigstore.dev/)
+during the release workflow, producing a `<archive>.sigstore.json` bundle
+alongside the `.sha256` checksum. The install script only checks the
+checksum; the signature is for anyone who wants to confirm the archive was
+actually built by this repository's release workflow, not just that the
+bytes match what the release page lists.
+
+```bash
+cosign verify-blob \
+  --bundle shadictl-vX.Y.Z-<target>.zip.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/agntcy/shadi/\.github/workflows/release-rust\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  shadictl-vX.Y.Z-<target>.zip
+```
+
+A successful verification prints `Verified OK`.
+
 ## Environment Overrides
 
 These environment variables are supported by the installer:


### PR DESCRIPTION


Releases carried a `.sha256` checksum only, which proves the download was not corrupted but nothing about who built it. Both `release-shadictl-binaries` and `release-agentbridge-binaries` now sign each archive keylessly with cosign, uploading a `<archive>.sigstore.json` bundle alongside the archive and checksum.

## How it works

Keyless: cosign exchanges the job's OIDC token for a short-lived certificate from Sigstore's Fulcio CA binding the signature to this exact workflow run and repository. No signing key for anyone to hold, rotate, or leak. Needs `id-token: write`, added to both jobs alongside their existing `contents: write`.

`sigstore/cosign-installer` is pinned to a commit SHA matching this repo's convention for every other third-party action. Its own README confirms Windows support, and `windows-2025` is already running several `shell: bash` steps in this same job, so the new step follows established precedent rather than introducing one.

## Verified before opening this PR

- both workflow files parse and the two jobs' `permissions` blocks carry `id-token: write`
- confirmed `cosign sign-blob`'s `--bundle` and `--yes` flags directly against cosign's own source (`cmd/cosign/cli/options/signblob.go`) rather than assuming the syntax
- checked every consumer of release assets: `render_winget_manifests.py` matches by exact filename (inert to the new file), and the Homebrew formula script doesn't enumerate assets at all
- `docs/content/install.md` builds cleanly with `mkdocs build`, and the new section renders

I deliberately stopped short of running a real `cosign sign-blob` locally — without an ambient CI OIDC token it falls back to an interactive browser flow, and completing that against Sigstore's actual Fulcio CA would create a permanent, public Rekor transparency-log entry under my own identity for a throwaway test file. Not something to do just to check a flag works.

## Documentation, not automation

Added a "Verifying release signatures" section to `install.md` with the `cosign verify-blob` command. The install script's own checksum verification is unchanged — wiring cosign into it is a separate, heavier decision (a new dependency for every end user installing the CLI) that this PR does not make.