### PR TITLE
ci: add a cargo publish dry-run check

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
+      - name: Verify crate packaging
+        # cargo dry-run validates packaging (Cargo.toml metadata, build, etc.)
+        # without publishing; it warns (doesn't fail) if the version already
+        # shipped, so this is safe to run on every push.
+        run: cargo publish --dry-run -p agntcy-shadi-agent-secrets
+
       - name: Require crates.io publish token
         run: |
           if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then


### PR DESCRIPTION


## the real publish step is invisible to the check

Scorecard's Packaging check is a static pattern-matcher, not an interpreter — for each ecosystem it looks for one of a fixed set of `uses:`/`run:` signatures in workflow YAML ([`fileparser.IsPackagingWorkflow`](https://github.com/ossf/scorecard/blob/main/checks/fileparser/github_workflow.go)). For Rust, the only recognized signature is a step whose `run:` text matches `cargo.*publish`.

shadi already publishes to crates.io — `release-crates` in `release-rust.yml` runs `release-plz/action` with `command: release`. But that's a `uses:` step; the actual `cargo publish` happens inside the action's own Rust code, which the parser never reads. There is no literal `run: cargo publish` anywhere in the repo for the check to match.

## agntcy/slim has the identical gap, closed the same way

Compared the two workflows directly. `agntcy/slim` scores 10 on this check because [`release-rust.yaml:65`](https://github.com/agntcy/slim/blob/main/.github/workflows/release-rust.yaml#L65) carries an extra step their real publish (also via `release-plz/action`) doesn't need:

```yaml
- name: Verify crate packaging
  # cargo dry-run validates packaging (Cargo.toml metadata, build, etc.)
  # without publishing; it warns (doesn't fail) if the version already
  # shipped, so this is safe to run on every push.
  run: cargo publish --dry-run -p agntcy-slim-version
```

This PR adds the same step, same reasoning, targeting `agntcy-shadi-agent-secrets` — the workspace's lightest already-published crate (three dependencies, no internal path deps to resolve).

## Verified locally before committing

```
cargo publish --dry-run -p agntcy-shadi-agent-secrets
```

Packages, builds the packaged tarball in isolation (~3s), and aborts the upload with a warning that the version already exists — **exit code 0**. Confirmed directly rather than assumed, since a step that silently starts failing every non-release push would be worse than the missing check.