### PR TITLE
ci: publish crates via crates.io Trusted Publishing, not a static token

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -22,7 +22,6 @@ jobs:
       pull-requests: read
       id-token: write
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       PYO3_PYTHON: python
     steps:
       - name: Checkout repository
@@ -52,13 +51,6 @@ jobs:
         # without publishing; it warns (doesn't fail) if the version already
         # shipped, so this is safe to run on every push.
         run: cargo publish --dry-run -p agntcy-shadi-agent-secrets
-
-      - name: Require crates.io publish token
-        run: |
-          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
-            echo "::error::CARGO_REGISTRY_TOKEN is not configured. Set the repository secret to allow release-plz to publish crates."
-            exit 1
-          fi
 
       - name: Run release-plz publish
         id: release-plz


### PR DESCRIPTION
crates.io now requires Trusted Publishing for `agntcy-shadi-agent-transport-slim`, which broke the last release. All 13 published crates are registered as Trusted Publishers now (repo owner confirmed).

release-plz already does the OIDC exchange itself when no `CARGO_REGISTRY_TOKEN` is set — no new workflow logic needed, just delete the secret and the step that checked for it. `agntcy/slim` already runs this way on the same release-plz version.

Delete the `CARGO_REGISTRY_TOKEN` repo secret once a real release confirms this works.