### PR TITLE
feat(desktop): live policy query and patch panel

### DIFF
--- a/apps/shadi_desktop/src-tauri/src/commands/policy.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/policy.rs
@@ -3,16 +3,61 @@
 
 //! Policy inspector and editor (agntcy/shadi#116) — replaces `shadictl
 //! shell`'s `/policy query|patch|explain|diff` and the `--profile` presets.
+//!
+//! `query` and `patch` reach a live session over its control socket, the
+//! same client `shadi_sandbox::control` gives the sandbox panel. `explain`
+//! and `diff` stay stubs: their shadictl equivalents resolve a policy file,
+//! a named profile and CLI flags against shadictl's own `Cli` type
+//! (`policy_helpers::resolve_policy`), which is private to that binary and
+//! not yet factored into a form this app can call. That factoring is its
+//! own piece of work, not something to rush alongside the live-session half.
+
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use shadi_sandbox::{control, PolicyPatch, PolicyPatchResponse};
 
 use super::not_implemented;
 
 const PANEL_ISSUE: u32 = 116;
 
-/// Serde-friendly mirror of `shadi_sandbox::SandboxPolicy` — the desktop app
-/// doesn't link `shadi_sandbox` yet (that lands with #116's implementation),
-/// so this is an independent shape with the same fields, not a re-export.
+/// Blocking round trip to a session's control socket, off the async runtime
+/// — same reasoning as the sandbox panel's commands: the client is blocking
+/// socket I/O, so this must not tie up a Tauri async worker.
+async fn blocking<T, F>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(f)
+        .await
+        .map_err(|err| format!("policy task failed: {err}"))?
+}
+
+/// Mirrors the JSON `handle_query` sends over the control socket
+/// (`crates/shadictl/src/policy_watch.rs`) — the live effective policy of an
+/// attached session, not shadictl's own private `SandboxPolicy` type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LivePolicySnapshot {
+    pub allow_read: Vec<String>,
+    pub allow_write: Vec<String>,
+    pub net_allow: Vec<String>,
+    pub net_blocked: bool,
+    pub allow_command: Vec<String>,
+    pub block_command: Vec<String>,
+    /// Filesystem and command changes staged by a prior patch, pending the
+    /// restart that applies them.
+    pub staged_read: Vec<String>,
+    pub staged_write: Vec<String>,
+    pub staged_allow: Vec<String>,
+    /// The live network allowlist, when the session's proxy applied a
+    /// network patch immediately rather than staging it.
+    pub net_allow_live: Option<Vec<String>>,
+}
+
+/// The policy a sandbox is launched with (`sandbox_launch`'s
+/// `LaunchSandboxRequest`) — a config to build a fresh `SandboxPolicy` from,
+/// not the live, already-resolved shape `LivePolicySnapshot` reads back.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PolicyConfig {
     pub allow: Vec<String>,
@@ -40,16 +85,22 @@ pub struct PolicyDiff {
 
 /// Show the effective policy of the attached session (`/policy query`).
 #[tauri::command]
-pub async fn policy_query(socket_path: String) -> Result<PolicyConfig, String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+pub async fn policy_query(socket_path: String) -> Result<LivePolicySnapshot, String> {
+    blocking(move || {
+        let value = control::query_policy(&PathBuf::from(socket_path))?;
+        serde_json::from_value(value)
+            .map_err(|err| format!("session returned an unexpected policy shape: {err}"))
+    })
+    .await
 }
 
 /// Patch the policy of the attached session live (`/policy patch`).
 #[tauri::command]
-pub async fn policy_patch(socket_path: String, patch: PolicyConfig) -> Result<PolicyConfig, String> {
-    let _ = (socket_path, patch);
-    not_implemented(PANEL_ISSUE)
+pub async fn policy_patch(
+    socket_path: String,
+    patch: PolicyPatch,
+) -> Result<PolicyPatchResponse, String> {
+    blocking(move || control::send_patch(&PathBuf::from(socket_path), &patch)).await
 }
 
 /// Resolved policy plus source inputs (`/policy explain`).

--- a/apps/shadi_desktop/src/App.tsx
+++ b/apps/shadi_desktop/src/App.tsx
@@ -4,12 +4,14 @@ import { AgentBridgePanel } from "./panels/AgentBridgePanel";
 import { SlimRoomsPanel } from "./panels/SlimRoomsPanel";
 import { OnboardingPanel } from "./panels/OnboardingPanel";
 import { SandboxPanel } from "./panels/SandboxPanel";
+import { PolicyPanel } from "./panels/PolicyPanel";
 import { RoomsProvider } from "./shared/rooms";
 
 // Identity first: nothing else works until onboarding has run.
 const TABS = [
   { id: "identity", label: "Identity", render: () => <OnboardingPanel /> },
   { id: "sandbox", label: "Sandbox", render: () => <SandboxPanel /> },
+  { id: "policy", label: "Policy", render: () => <PolicyPanel /> },
   { id: "rooms", label: "Rooms", render: () => <SlimRoomsPanel /> },
   { id: "agentbridge", label: "agentbridge", render: () => <AgentBridgePanel /> },
 ] as const;

--- a/apps/shadi_desktop/src/panels/PolicyPanel.css
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.css
@@ -1,0 +1,142 @@
+.pl-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pl-card {
+  background: var(--panel-bg, #ffffff);
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pl-card h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.pl-card h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--error-fg, #b3261e);
+}
+
+.pl-row {
+  display: flex;
+  gap: 8px;
+}
+
+.pl-row input {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.pl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pl-field span {
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-field input {
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.pl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.pl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.pl-list-label {
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pl-list li {
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.pl-empty {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-staged {
+  border-top: 1px solid var(--panel-border, #d9dee2);
+  padding-top: 12px;
+}
+
+.pl-accepted {
+  margin: 0;
+  color: var(--ok-fg, #2e7d5b);
+  font-weight: 600;
+}
+
+.pl-rejected {
+  margin: 0;
+  color: var(--error-fg, #b3261e);
+  font-weight: 600;
+}
+
+.pl-axes {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.pl-axes dt {
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-axes dd {
+  margin: 0;
+}

--- a/apps/shadi_desktop/src/panels/PolicyPanel.tsx
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.tsx
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "./PolicyPanel.css";
+
+interface LivePolicySnapshot {
+  allow_read: string[];
+  allow_write: string[];
+  net_allow: string[];
+  net_blocked: boolean;
+  allow_command: string[];
+  block_command: string[];
+  staged_read: string[];
+  staged_write: string[];
+  staged_allow: string[];
+  net_allow_live: string[] | null;
+}
+
+interface PolicyPatch {
+  add_allow: string[];
+  add_read: string[];
+  add_write: string[];
+  add_allow_command: string[];
+  remove_allow_command: string[];
+  add_block_command: string[];
+  remove_block_command: string[];
+  add_net_allow: string[];
+  remove_net_allow: string[];
+}
+
+interface PatchAxisStatus {
+  // "applied" | "unchanged" | "pending_restart" | "rejected", but the panel
+  // only needs to display it, never branch on a specific value.
+  [key: string]: unknown;
+}
+
+interface PolicyPatchResponse {
+  accepted: boolean;
+  filesystem: PatchAxisStatus;
+  commands: PatchAxisStatus;
+  network: PatchAxisStatus;
+  message: string;
+  pending_restart: string[];
+}
+
+const EMPTY_PATCH: PolicyPatch = {
+  add_allow: [],
+  add_read: [],
+  add_write: [],
+  add_allow_command: [],
+  remove_allow_command: [],
+  add_block_command: [],
+  remove_block_command: [],
+  add_net_allow: [],
+  remove_net_allow: [],
+};
+
+function splitList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function axisLabel(status: PatchAxisStatus | undefined): string {
+  if (!status) return "—";
+  const value = Object.values(status)[0] ?? status;
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function ErrorText({ message }: { message: string | null }) {
+  if (!message) return null;
+  return <p className="pl-error">{message}</p>;
+}
+
+function PolicyList({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="pl-list">
+      <span className="pl-list-label">{label}</span>
+      {items.length === 0 ? (
+        <span className="pl-empty">none</span>
+      ) : (
+        <ul>
+          {items.map((item) => (
+            <li key={item}>
+              <code>{item}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SnapshotView({ snapshot }: { snapshot: LivePolicySnapshot }) {
+  return (
+    <section className="pl-card">
+      <h2>Effective policy</h2>
+      <div className="pl-grid">
+        <PolicyList label="Read" items={snapshot.allow_read} />
+        <PolicyList label="Write" items={snapshot.allow_write} />
+        <PolicyList label="Allowed commands" items={snapshot.allow_command} />
+        <PolicyList label="Blocked commands" items={snapshot.block_command} />
+        <PolicyList
+          label={`Network allow (${snapshot.net_blocked ? "blocked by default" : "open by default"})`}
+          items={snapshot.net_allow}
+        />
+        {snapshot.net_allow_live !== null && (
+          <PolicyList label="Network allow (live proxy)" items={snapshot.net_allow_live} />
+        )}
+      </div>
+      {(snapshot.staged_read.length > 0 ||
+        snapshot.staged_write.length > 0 ||
+        snapshot.staged_allow.length > 0) && (
+        <div className="pl-staged">
+          <h3>Staged, pending restart</h3>
+          <div className="pl-grid">
+            <PolicyList label="Read" items={snapshot.staged_read} />
+            <PolicyList label="Write" items={snapshot.staged_write} />
+            <PolicyList label="Allow" items={snapshot.staged_allow} />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PatchForm({
+  onSubmit,
+  busy,
+}: {
+  onSubmit: (patch: PolicyPatch) => void;
+  busy: boolean;
+}) {
+  const [addAllow, setAddAllow] = useState("");
+  const [addRead, setAddRead] = useState("");
+  const [addWrite, setAddWrite] = useState("");
+  const [addNetAllow, setAddNetAllow] = useState("");
+  const [addAllowCommand, setAddAllowCommand] = useState("");
+  const [addBlockCommand, setAddBlockCommand] = useState("");
+
+  function submit() {
+    onSubmit({
+      ...EMPTY_PATCH,
+      add_allow: splitList(addAllow),
+      add_read: splitList(addRead),
+      add_write: splitList(addWrite),
+      add_net_allow: splitList(addNetAllow),
+      add_allow_command: splitList(addAllowCommand),
+      add_block_command: splitList(addBlockCommand),
+    });
+    setAddAllow("");
+    setAddRead("");
+    setAddWrite("");
+    setAddNetAllow("");
+    setAddAllowCommand("");
+    setAddBlockCommand("");
+  }
+
+  const hasInput =
+    [addAllow, addRead, addWrite, addNetAllow, addAllowCommand, addBlockCommand].some(
+      (s) => s.trim().length > 0,
+    );
+
+  return (
+    <section className="pl-card">
+      <h2>Patch</h2>
+      <p className="pl-hint">
+        Adds to the running session's policy. Filesystem changes here are usually staged until
+        the sandboxed process restarts; network and command changes can take effect immediately —
+        the response below says which.
+      </p>
+      <div className="pl-grid">
+        <label className="pl-field">
+          <span>Add read+write paths</span>
+          <input value={addAllow} onChange={(e) => setAddAllow(e.target.value)} placeholder="/tmp/work" />
+        </label>
+        <label className="pl-field">
+          <span>Add read-only paths</span>
+          <input value={addRead} onChange={(e) => setAddRead(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add write-only paths</span>
+          <input value={addWrite} onChange={(e) => setAddWrite(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add network allow (hosts)</span>
+          <input
+            value={addNetAllow}
+            onChange={(e) => setAddNetAllow(e.target.value)}
+            placeholder="api.example.com"
+          />
+        </label>
+        <label className="pl-field">
+          <span>Add allowed commands</span>
+          <input value={addAllowCommand} onChange={(e) => setAddAllowCommand(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add blocked commands</span>
+          <input value={addBlockCommand} onChange={(e) => setAddBlockCommand(e.target.value)} />
+        </label>
+      </div>
+      <button onClick={submit} disabled={busy || !hasInput}>
+        {busy ? "Applying…" : "Apply patch"}
+      </button>
+    </section>
+  );
+}
+
+function PatchResultView({ result }: { result: PolicyPatchResponse }) {
+  return (
+    <section className="pl-card">
+      <h2>Patch result</h2>
+      <p className={result.accepted ? "pl-accepted" : "pl-rejected"}>
+        {result.accepted ? "Accepted" : "Rejected"}
+        {result.message ? ` — ${result.message}` : ""}
+      </p>
+      <dl className="pl-axes">
+        <dt>Filesystem</dt>
+        <dd>{axisLabel(result.filesystem)}</dd>
+        <dt>Commands</dt>
+        <dd>{axisLabel(result.commands)}</dd>
+        <dt>Network</dt>
+        <dd>{axisLabel(result.network)}</dd>
+      </dl>
+      {result.pending_restart.length > 0 && (
+        <p className="pl-hint">Needs a restart to take effect: {result.pending_restart.join(", ")}</p>
+      )}
+    </section>
+  );
+}
+
+export function PolicyPanel() {
+  const [sessionId, setSessionId] = useState("");
+  const [attached, setAttached] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<LivePolicySnapshot | null>(null);
+  const [patchResult, setPatchResult] = useState<PolicyPatchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async (socketPath: string) => {
+    try {
+      setSnapshot(await invoke<LivePolicySnapshot>("policy_query", { socketPath }));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (attached === null) return;
+    refresh(attached);
+    const timer = setInterval(() => refresh(attached), 4000);
+    return () => clearInterval(timer);
+  }, [attached, refresh]);
+
+  async function onAttach() {
+    const trimmed = sessionId.trim();
+    if (!trimmed) {
+      setError("Enter a session name or socket path.");
+      return;
+    }
+    setError(null);
+    setPatchResult(null);
+    setAttached(trimmed);
+  }
+
+  async function onPatch(patch: PolicyPatch) {
+    if (attached === null) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await invoke<PolicyPatchResponse>("policy_patch", {
+        socketPath: attached,
+        patch,
+      });
+      setPatchResult(result);
+      await refresh(attached);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="pl-panel">
+      <section className="pl-card">
+        <h2>Attach</h2>
+        <p className="pl-hint">
+          Same session name or socket path as the Sandbox tab — a session started with{" "}
+          <code>shadictl --watch-policy</code> exposes one; a session launched from the Sandbox
+          tab does not, since serving a control socket is shadictl's job.
+        </p>
+        <div className="pl-row">
+          <input
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+            placeholder="myagent, or /tmp/shadi-ctl-myagent.sock"
+          />
+          <button onClick={onAttach}>Attach</button>
+        </div>
+        <ErrorText message={error} />
+      </section>
+
+      {snapshot !== null && <SnapshotView snapshot={snapshot} />}
+      {attached !== null && <PatchForm onSubmit={onPatch} busy={busy} />}
+      {patchResult !== null && <PatchResultView result={patchResult} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements the live-session half of #116 — `policy_query` and `policy_patch` — and the panel that drives them.

`policy_explain` and `policy_diff` stay stubs. shadictl's versions resolve a policy file, a named profile and CLI flags against its own `Cli` type (`policy_helpers::resolve_policy`), which is private to that binary crate — the same shape of problem the control-socket client was before #200. Factoring that out is its own scoped piece of work; bolting a rushed version onto the live-session commands, which need none of it, isn't worth doing just to close the issue in one PR.

`query`/`patch` reach a session through `shadi_sandbox::control` — the same client the sandbox panel (#201) uses, so no new extraction was needed for these two.

Two things worth calling out:

- `LivePolicySnapshot` mirrors the exact JSON `handle_query` sends over the control socket (`policy_watch.rs`), not shadictl's internal `SandboxPolicy` type — read directly from the server's own construction rather than guessed.
- `PolicyPatch`/`PolicyPatchResponse` are used straight from `shadi_sandbox`, not re-shaped into the desktop's own `PolicyConfig`. The wire protocol is an additive patch (`add_allow`, `add_net_allow`, …), while `PolicyConfig` is a full-replacement config for launching a *new* sandbox — same-sounding but genuinely different shapes, so keeping them separate avoids a lossy mapping between them.

## Verification

- `cargo check`/`clippy` clean on the new code
- **1152 workspace tests** and **35 desktop tests** pass, unchanged
- `pnpm build` (tsc + vite) clean, which type-checks the panel against the command signatures
- `cargo metadata --locked` passes

Same limitation as the sandbox panel: verified by type-checking and backend tests, not by clicking through a running app.