### PR TITLE
feat(desktop): policy explain and diff

### DIFF
--- a/apps/shadi_desktop/src-tauri/src/commands/policy.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/policy.rs
@@ -4,22 +4,19 @@
 //! Policy inspector and editor (agntcy/shadi#116) — replaces `shadictl
 //! shell`'s `/policy query|patch|explain|diff` and the `--profile` presets.
 //!
-//! `query` and `patch` reach a live session over its control socket, the
-//! same client `shadi_sandbox::control` gives the sandbox panel. `explain`
-//! and `diff` stay stubs: their shadictl equivalents resolve a policy file,
-//! a named profile and CLI flags against shadictl's own `Cli` type
-//! (`policy_helpers::resolve_policy`), which is private to that binary and
-//! not yet factored into a form this app can call. That factoring is its
-//! own piece of work, not something to rush alongside the live-session half.
+//! `query` and `patch` reach a live session over its control socket;
+//! `explain` and `diff` resolve a policy from its inputs without one, so
+//! they answer what a set of flags *would* produce as well as what a running
+//! session currently has. Both halves go through `shadi_sandbox`, so the
+//! answers match what `shadictl` would give for the same inputs.
 
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use shadi_sandbox::{control, PolicyPatch, PolicyPatchResponse};
-
-use super::not_implemented;
-
-const PANEL_ISSUE: u32 = 116;
+use shadi_sandbox::{
+    control, PolicyDescription, PolicyFileValues, PolicyOverrides, PolicyPatch,
+    PolicyPatchResponse, ResolvedPolicy, SandboxProfile,
+};
 
 /// Blocking round trip to a session's control socket, off the async runtime
 /// — same reasoning as the sandbox panel's commands: the client is blocking
@@ -69,18 +66,76 @@ pub struct PolicyConfig {
     pub profile: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PolicyExplanation {
-    pub effective: PolicyConfig,
-    /// Human-readable provenance per field, e.g. "profile:strict", "cli:--allow /tmp".
-    pub sources: Vec<String>,
+/// What to resolve a policy from: a named profile, an optional policy file,
+/// and the overrides layered on top — the same three inputs `shadictl policy
+/// explain` takes.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct PolicyInputs {
+    pub profile: Option<String>,
+    pub policy_file: Option<String>,
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+    pub net_allow: Vec<String>,
+    pub allow_command: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyExplanation {
+    pub effective: PolicyDescription,
+    pub sources: PolicySources,
+    /// The attached session's live policy, when one was given. A session that
+    /// has been patched since it started will not match `effective`, which is
+    /// what these inputs resolve to rather than what is currently running.
+    pub live: Option<LivePolicySnapshot>,
+}
+
+/// Where each part of the effective policy came from.
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicySources {
+    pub profile: String,
+    pub profile_defaults: ProfileDefaultsView,
+    pub policy_file: Option<PolicyFileSource>,
+    pub overrides: PolicyInputsView,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProfileDefaultsView {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyFileSource {
+    pub path: String,
+    pub values: PolicyFileValues,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyInputsView {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+    pub net_allow: Vec<String>,
+    pub allow_command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct PolicyDiff {
-    pub added: Vec<String>,
-    pub removed: Vec<String>,
-    pub changed: Vec<String>,
+    pub equivalent: bool,
+    pub changed: Vec<PolicyFieldDiff>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyFieldDiff {
+    pub field: String,
+    pub current: Vec<String>,
+    pub baseline: Vec<String>,
 }
 
 /// Show the effective policy of the attached session (`/policy query`).
@@ -103,18 +158,148 @@ pub async fn policy_patch(
     blocking(move || control::send_patch(&PathBuf::from(socket_path), &patch)).await
 }
 
-/// Resolved policy plus source inputs (`/policy explain`).
-#[tauri::command]
-pub async fn policy_explain(socket_path: String) -> Result<PolicyExplanation, String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+fn parse_profile(name: Option<&str>) -> Result<SandboxProfile, String> {
+    match name {
+        Some(name) => SandboxProfile::from_name(name).ok_or_else(|| {
+            format!("unknown profile '{name}'; expected strict, balanced or connected")
+        }),
+        None => Ok(SandboxProfile::Balanced),
+    }
 }
 
-/// Diff effective policy against a baseline profile (`/policy diff`).
+/// Read the sandbox-relevant values out of a policy file. Fields the file
+/// carries for other purposes (shadictl's keychain and trusted-secret rules)
+/// are ignored rather than rejected.
+fn read_policy_file(path: &str) -> Result<PolicyFileValues, String> {
+    let data = std::fs::read_to_string(path)
+        .map_err(|err| format!("could not read policy file {path}: {err}"))?;
+    serde_json::from_str(&data).map_err(|err| format!("{path} is not a valid policy file: {err}"))
+}
+
+fn resolve(inputs: &PolicyInputs) -> Result<(ResolvedPolicy, SandboxProfile, PolicyFileValues), String> {
+    let profile = parse_profile(inputs.profile.as_deref())?;
+    let file_values = match inputs.policy_file.as_deref() {
+        Some(path) => read_policy_file(path)?,
+        None => PolicyFileValues::default(),
+    };
+
+    let overrides = PolicyOverrides {
+        profile: Some(profile),
+        allow: inputs.allow.iter().map(PathBuf::from).collect(),
+        read: inputs.read.iter().map(PathBuf::from).collect(),
+        write: inputs.write.iter().map(PathBuf::from).collect(),
+        net_block: inputs.net_block,
+        net_allow: inputs.net_allow.clone(),
+        allow_command: inputs.allow_command.clone(),
+    };
+
+    let resolved = shadi_sandbox::resolve_policy(&overrides, &file_values)?;
+    Ok((resolved, profile, file_values))
+}
+
+fn describe(inputs: &PolicyInputs) -> Result<PolicyDescription, String> {
+    let (resolved, _, _) = resolve(inputs)?;
+    Ok(shadi_sandbox::describe_policy(
+        &resolved.policy,
+        &resolved.blocked,
+        &resolved.allow,
+    ))
+}
+
+/// Resolved policy plus source inputs (`/policy explain`).
 #[tauri::command]
-pub async fn policy_diff(socket_path: String, baseline_profile: String) -> Result<PolicyDiff, String> {
-    let _ = (socket_path, baseline_profile);
-    not_implemented(PANEL_ISSUE)
+pub async fn policy_explain(
+    inputs: PolicyInputs,
+    socket_path: Option<String>,
+) -> Result<PolicyExplanation, String> {
+    blocking(move || {
+        let (resolved, profile, file_values) = resolve(&inputs)?;
+        let defaults = profile.defaults();
+
+        let live = match socket_path.as_deref() {
+            Some(path) => control::query_policy(&PathBuf::from(path))
+                .ok()
+                .and_then(|value| serde_json::from_value(value).ok()),
+            None => None,
+        };
+
+        Ok(PolicyExplanation {
+            effective: shadi_sandbox::describe_policy(
+                &resolved.policy,
+                &resolved.blocked,
+                &resolved.allow,
+            ),
+            sources: PolicySources {
+                profile: profile.as_str().to_string(),
+                profile_defaults: ProfileDefaultsView {
+                    allow: defaults.allow,
+                    read: defaults.read,
+                    write: defaults.write,
+                    net_block: defaults.net_block,
+                },
+                policy_file: inputs.policy_file.clone().map(|path| PolicyFileSource {
+                    path,
+                    values: file_values,
+                }),
+                overrides: PolicyInputsView {
+                    allow: inputs.allow.clone(),
+                    read: inputs.read.clone(),
+                    write: inputs.write.clone(),
+                    net_block: inputs.net_block,
+                    net_allow: inputs.net_allow.clone(),
+                    allow_command: inputs.allow_command.clone(),
+                },
+            },
+            live,
+        })
+    })
+    .await
+}
+
+/// Diff a resolved policy against a baseline profile's own (`/policy diff`).
+#[tauri::command]
+pub async fn policy_diff(
+    inputs: PolicyInputs,
+    baseline_profile: String,
+) -> Result<PolicyDiff, String> {
+    blocking(move || {
+        let current = describe(&inputs)?;
+        let baseline = describe(&PolicyInputs {
+            profile: Some(baseline_profile),
+            ..Default::default()
+        })?;
+
+        let mut changed = Vec::new();
+        let mut compare = |field: &str, current: &[String], baseline: &[String]| {
+            if current != baseline {
+                changed.push(PolicyFieldDiff {
+                    field: field.to_string(),
+                    current: current.to_vec(),
+                    baseline: baseline.to_vec(),
+                });
+            }
+        };
+
+        compare("allow", &current.allow, &baseline.allow);
+        compare("read", &current.read, &baseline.read);
+        compare("write", &current.write, &baseline.write);
+        compare("net_allow", &current.net_allow, &baseline.net_allow);
+        compare("allow_command", &current.allow_command, &baseline.allow_command);
+        compare("block_command", &current.block_command, &baseline.block_command);
+        if current.net_block != baseline.net_block {
+            changed.push(PolicyFieldDiff {
+                field: "net_block".to_string(),
+                current: vec![current.net_block.to_string()],
+                baseline: vec![baseline.net_block.to_string()],
+            });
+        }
+
+        Ok(PolicyDiff {
+            equivalent: changed.is_empty(),
+            changed,
+        })
+    })
+    .await
 }
 
 /// The named profile presets `shadictl --profile` accepts.

--- a/apps/shadi_desktop/src-tauri/src/commands/policy.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/policy.rs
@@ -3,16 +3,61 @@
 
 //! Policy inspector and editor (agntcy/shadi#116) — replaces `shadictl
 //! shell`'s `/policy query|patch|explain|diff` and the `--profile` presets.
+//!
+//! `query` and `patch` reach a live session over its control socket, the
+//! same client `shadi_sandbox::control` gives the sandbox panel. `explain`
+//! and `diff` stay stubs: their shadictl equivalents resolve a policy file,
+//! a named profile and CLI flags against shadictl's own `Cli` type
+//! (`policy_helpers::resolve_policy`), which is private to that binary and
+//! not yet factored into a form this app can call. That factoring is its
+//! own piece of work, not something to rush alongside the live-session half.
+
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use shadi_sandbox::{control, PolicyPatch, PolicyPatchResponse};
 
 use super::not_implemented;
 
 const PANEL_ISSUE: u32 = 116;
 
-/// Serde-friendly mirror of `shadi_sandbox::SandboxPolicy` — the desktop app
-/// doesn't link `shadi_sandbox` yet (that lands with #116's implementation),
-/// so this is an independent shape with the same fields, not a re-export.
+/// Blocking round trip to a session's control socket, off the async runtime
+/// — same reasoning as the sandbox panel's commands: the client is blocking
+/// socket I/O, so this must not tie up a Tauri async worker.
+async fn blocking<T, F>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(f)
+        .await
+        .map_err(|err| format!("policy task failed: {err}"))?
+}
+
+/// Mirrors the JSON `handle_query` sends over the control socket
+/// (`crates/shadictl/src/policy_watch.rs`) — the live effective policy of an
+/// attached session, not shadictl's own private `SandboxPolicy` type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LivePolicySnapshot {
+    pub allow_read: Vec<String>,
+    pub allow_write: Vec<String>,
+    pub net_allow: Vec<String>,
+    pub net_blocked: bool,
+    pub allow_command: Vec<String>,
+    pub block_command: Vec<String>,
+    /// Filesystem and command changes staged by a prior patch, pending the
+    /// restart that applies them.
+    pub staged_read: Vec<String>,
+    pub staged_write: Vec<String>,
+    pub staged_allow: Vec<String>,
+    /// The live network allowlist, when the session's proxy applied a
+    /// network patch immediately rather than staging it.
+    pub net_allow_live: Option<Vec<String>>,
+}
+
+/// The policy a sandbox is launched with (`sandbox_launch`'s
+/// `LaunchSandboxRequest`) — a config to build a fresh `SandboxPolicy` from,
+/// not the live, already-resolved shape `LivePolicySnapshot` reads back.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PolicyConfig {
     pub allow: Vec<String>,
@@ -40,16 +85,22 @@ pub struct PolicyDiff {
 
 /// Show the effective policy of the attached session (`/policy query`).
 #[tauri::command]
-pub async fn policy_query(socket_path: String) -> Result<PolicyConfig, String> {
-    let _ = socket_path;
-    not_implemented(PANEL_ISSUE)
+pub async fn policy_query(socket_path: String) -> Result<LivePolicySnapshot, String> {
+    blocking(move || {
+        let value = control::query_policy(&PathBuf::from(socket_path))?;
+        serde_json::from_value(value)
+            .map_err(|err| format!("session returned an unexpected policy shape: {err}"))
+    })
+    .await
 }
 
 /// Patch the policy of the attached session live (`/policy patch`).
 #[tauri::command]
-pub async fn policy_patch(socket_path: String, patch: PolicyConfig) -> Result<PolicyConfig, String> {
-    let _ = (socket_path, patch);
-    not_implemented(PANEL_ISSUE)
+pub async fn policy_patch(
+    socket_path: String,
+    patch: PolicyPatch,
+) -> Result<PolicyPatchResponse, String> {
+    blocking(move || control::send_patch(&PathBuf::from(socket_path), &patch)).await
 }
 
 /// Resolved policy plus source inputs (`/policy explain`).

--- a/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/sandbox.rs
@@ -92,9 +92,9 @@ where
         .map_err(|err| format!("sandbox task failed: {err}"))?
 }
 
-/// Build a [`SandboxPolicy`] the way `shadictl` does: network first, then the
-/// profile's paths, then the caller's own on top, so an explicit path can only
-/// widen what the profile granted.
+/// Build a [`SandboxPolicy`] through the same layering shadictl uses, so a
+/// sandbox launched here and one launched from the command line resolve the
+/// same way.
 fn policy_from_config(config: &PolicyConfig) -> Result<SandboxPolicy, String> {
     let profile = match config.profile.as_deref() {
         Some(name) => Some(SandboxProfile::from_name(name).ok_or_else(|| {
@@ -102,59 +102,19 @@ fn policy_from_config(config: &PolicyConfig) -> Result<SandboxPolicy, String> {
         })?),
         None => None,
     };
-    let defaults = profile.map(|p| p.defaults());
 
-    let net_block = config.net_block || defaults.as_ref().map(|d| d.net_block).unwrap_or(false);
-    let mut policy = SandboxPolicy::new().block_network(net_block);
-
-    for destination in &config.net_allow {
-        policy = policy.allow_network_destination(destination.clone());
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    {
-        policy = policy.use_minimal_platform_profile();
-    }
-
-    if let Some(defaults) = defaults.as_ref() {
-        policy = apply_paths(policy, &defaults.read, PathMode::Read)?;
-        policy = apply_paths(policy, &defaults.write, PathMode::Write)?;
-        policy = apply_paths(policy, &defaults.allow, PathMode::Allow)?;
-    }
-
-    policy = apply_paths(policy, &config.read, PathMode::Read)?;
-    policy = apply_paths(policy, &config.write, PathMode::Write)?;
-    policy = apply_paths(policy, &config.allow, PathMode::Allow)?;
-
-    Ok(policy)
-}
-
-enum PathMode {
-    Read,
-    Write,
-    Allow,
-}
-
-fn apply_paths(
-    mut policy: SandboxPolicy,
-    paths: &[String],
-    mode: PathMode,
-) -> Result<SandboxPolicy, String> {
-    let label = match mode {
-        PathMode::Read => "read",
-        PathMode::Write => "write",
-        PathMode::Allow => "allow",
+    let overrides = shadi_sandbox::PolicyOverrides {
+        profile,
+        allow: config.allow.iter().map(PathBuf::from).collect(),
+        read: config.read.iter().map(PathBuf::from).collect(),
+        write: config.write.iter().map(PathBuf::from).collect(),
+        net_block: config.net_block,
+        net_allow: config.net_allow.clone(),
+        allow_command: Vec::new(),
     };
-    for path in paths {
-        let resolved = std::fs::canonicalize(path)
-            .map_err(|err| format!("invalid {label} path {path}: {err}"))?;
-        policy = match mode {
-            PathMode::Read => policy.allow_read_path(&resolved),
-            PathMode::Write => policy.allow_write_path(&resolved),
-            PathMode::Allow => policy.allow_read_path(&resolved).allow_write_path(&resolved),
-        };
-    }
-    Ok(policy)
+
+    shadi_sandbox::resolve_policy(&overrides, &shadi_sandbox::PolicyFileValues::default())
+        .map(|resolved| resolved.policy)
 }
 
 /// Launch a sandboxed process (mirrors `shadictl <flags> -- <command>`).

--- a/apps/shadi_desktop/src/App.tsx
+++ b/apps/shadi_desktop/src/App.tsx
@@ -4,12 +4,14 @@ import { AgentBridgePanel } from "./panels/AgentBridgePanel";
 import { SlimRoomsPanel } from "./panels/SlimRoomsPanel";
 import { OnboardingPanel } from "./panels/OnboardingPanel";
 import { SandboxPanel } from "./panels/SandboxPanel";
+import { PolicyPanel } from "./panels/PolicyPanel";
 import { RoomsProvider } from "./shared/rooms";
 
 // Identity first: nothing else works until onboarding has run.
 const TABS = [
   { id: "identity", label: "Identity", render: () => <OnboardingPanel /> },
   { id: "sandbox", label: "Sandbox", render: () => <SandboxPanel /> },
+  { id: "policy", label: "Policy", render: () => <PolicyPanel /> },
   { id: "rooms", label: "Rooms", render: () => <SlimRoomsPanel /> },
   { id: "agentbridge", label: "agentbridge", render: () => <AgentBridgePanel /> },
 ] as const;

--- a/apps/shadi_desktop/src/panels/PolicyPanel.css
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.css
@@ -140,3 +140,18 @@
 .pl-axes dd {
   margin: 0;
 }
+
+.pl-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.pl-row select,
+.pl-field select {
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}

--- a/apps/shadi_desktop/src/panels/PolicyPanel.css
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.css
@@ -1,0 +1,142 @@
+.pl-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pl-card {
+  background: var(--panel-bg, #ffffff);
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pl-card h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.pl-card h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--error-fg, #b3261e);
+}
+
+.pl-row {
+  display: flex;
+  gap: 8px;
+}
+
+.pl-row input {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.pl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pl-field span {
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-field input {
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border, #d9dee2);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.pl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.pl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.pl-list-label {
+  font-size: 12px;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pl-list li {
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.pl-empty {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-staged {
+  border-top: 1px solid var(--panel-border, #d9dee2);
+  padding-top: 12px;
+}
+
+.pl-accepted {
+  margin: 0;
+  color: var(--ok-fg, #2e7d5b);
+  font-weight: 600;
+}
+
+.pl-rejected {
+  margin: 0;
+  color: var(--error-fg, #b3261e);
+  font-weight: 600;
+}
+
+.pl-axes {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.pl-axes dt {
+  color: var(--muted-fg, #5b6770);
+}
+
+.pl-axes dd {
+  margin: 0;
+}

--- a/apps/shadi_desktop/src/panels/PolicyPanel.tsx
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.tsx
@@ -42,6 +42,59 @@ interface PolicyPatchResponse {
   pending_restart: string[];
 }
 
+interface PolicyDescription {
+  allow: string[];
+  read: string[];
+  write: string[];
+  net_block: boolean;
+  net_allow: string[];
+  platform_profile: string;
+  allow_command: string[];
+  block_command: string[];
+}
+
+interface PolicyInputs {
+  profile: string | null;
+  policy_file: string | null;
+  allow: string[];
+  read: string[];
+  write: string[];
+  net_block: boolean;
+  net_allow: string[];
+  allow_command: string[];
+}
+
+interface PolicyExplanation {
+  effective: PolicyDescription;
+  sources: {
+    profile: string;
+    profile_defaults: { allow: string[]; read: string[]; write: string[]; net_block: boolean };
+    policy_file: { path: string; values: Record<string, unknown> } | null;
+    overrides: {
+      allow: string[];
+      read: string[];
+      write: string[];
+      net_block: boolean;
+      net_allow: string[];
+      allow_command: string[];
+    };
+  };
+  live: LivePolicySnapshot | null;
+}
+
+interface PolicyFieldDiff {
+  field: string;
+  current: string[];
+  baseline: string[];
+}
+
+interface PolicyDiffResult {
+  equivalent: boolean;
+  changed: PolicyFieldDiff[];
+}
+
+const PROFILES = ["strict", "balanced", "connected"] as const;
+
 const EMPTY_PATCH: PolicyPatch = {
   add_allow: [],
   add_read: [],
@@ -229,6 +282,217 @@ function PatchResultView({ result }: { result: PolicyPatchResponse }) {
   );
 }
 
+function ResolveSection({ attached }: { attached: string | null }) {
+  const [profile, setProfile] = useState<string>("balanced");
+  const [policyFile, setPolicyFile] = useState("");
+  const [allow, setAllow] = useState("");
+  const [read, setRead] = useState("");
+  const [write, setWrite] = useState("");
+  const [netBlock, setNetBlock] = useState(false);
+  const [netAllow, setNetAllow] = useState("");
+  const [baseline, setBaseline] = useState<string>("strict");
+  const [explanation, setExplanation] = useState<PolicyExplanation | null>(null);
+  const [diff, setDiff] = useState<PolicyDiffResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function currentInputs(): PolicyInputs {
+    return {
+      profile,
+      policy_file: policyFile.trim() || null,
+      allow: splitList(allow),
+      read: splitList(read),
+      write: splitList(write),
+      net_block: netBlock,
+      net_allow: splitList(netAllow),
+      allow_command: [],
+    };
+  }
+
+  async function run(what: "explain" | "diff") {
+    setBusy(true);
+    setError(null);
+    try {
+      if (what === "explain") {
+        setDiff(null);
+        setExplanation(
+          await invoke<PolicyExplanation>("policy_explain", {
+            inputs: currentInputs(),
+            socketPath: attached,
+          }),
+        );
+      } else {
+        setExplanation(null);
+        setDiff(
+          await invoke<PolicyDiffResult>("policy_diff", {
+            inputs: currentInputs(),
+            baselineProfile: baseline,
+          }),
+        );
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <section className="pl-card">
+        <h2>Resolve from inputs</h2>
+        <p className="pl-hint">
+          What a profile, a policy file and these paths resolve to — answered without a running
+          session, so you can check a policy before launching anything.
+          {attached !== null && " The attached session's live policy is shown alongside it."}
+        </p>
+        <div className="pl-grid">
+          <label className="pl-field">
+            <span>Profile</span>
+            <select value={profile} onChange={(e) => setProfile(e.target.value)}>
+              {PROFILES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="pl-field">
+            <span>Policy file (optional)</span>
+            <input
+              value={policyFile}
+              onChange={(e) => setPolicyFile(e.target.value)}
+              placeholder="/path/to/policy.json"
+            />
+          </label>
+          <label className="pl-field">
+            <span>Read+write paths</span>
+            <input value={allow} onChange={(e) => setAllow(e.target.value)} placeholder="/tmp/work" />
+          </label>
+          <label className="pl-field">
+            <span>Read-only paths</span>
+            <input value={read} onChange={(e) => setRead(e.target.value)} />
+          </label>
+          <label className="pl-field">
+            <span>Write-only paths</span>
+            <input value={write} onChange={(e) => setWrite(e.target.value)} />
+          </label>
+          <label className="pl-field">
+            <span>Network allow (hosts)</span>
+            <input value={netAllow} onChange={(e) => setNetAllow(e.target.value)} />
+          </label>
+        </div>
+        <label className="pl-check">
+          <input type="checkbox" checked={netBlock} onChange={(e) => setNetBlock(e.target.checked)} />
+          <span>Block network regardless of the profile</span>
+        </label>
+        <div className="pl-row">
+          <button onClick={() => run("explain")} disabled={busy}>
+            Explain
+          </button>
+          <button onClick={() => run("diff")} disabled={busy}>
+            Diff against
+          </button>
+          <select value={baseline} onChange={(e) => setBaseline(e.target.value)}>
+            {PROFILES.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+        <ErrorText message={error} />
+      </section>
+
+      {explanation !== null && <ExplanationView explanation={explanation} />}
+      {diff !== null && <DiffView diff={diff} baseline={baseline} />}
+    </>
+  );
+}
+
+function ExplanationView({ explanation }: { explanation: PolicyExplanation }) {
+  const { effective, sources, live } = explanation;
+  return (
+    <section className="pl-card">
+      <h2>Effective policy</h2>
+      <div className="pl-grid">
+        <PolicyList label="Read+write" items={effective.allow} />
+        <PolicyList label="Read-only" items={effective.read} />
+        <PolicyList label="Write-only" items={effective.write} />
+        <PolicyList
+          label={`Network allow (${effective.net_block ? "blocked by default" : "open by default"})`}
+          items={effective.net_allow}
+        />
+        <PolicyList label="Allowed commands" items={effective.allow_command} />
+        <PolicyList label="Blocked commands" items={effective.block_command} />
+      </div>
+      <p className="pl-hint">Platform sandbox profile: {effective.platform_profile}</p>
+
+      <div className="pl-staged">
+        <h3>Where it came from</h3>
+        <div className="pl-grid">
+          <PolicyList
+            label={`Profile "${sources.profile}" grants`}
+            items={[
+              ...sources.profile_defaults.allow,
+              ...sources.profile_defaults.read,
+              ...sources.profile_defaults.write,
+            ]}
+          />
+          <PolicyList
+            label={sources.policy_file ? `File ${sources.policy_file.path}` : "Policy file"}
+            items={sources.policy_file ? [JSON.stringify(sources.policy_file.values)] : []}
+          />
+          <PolicyList
+            label="Your overrides"
+            items={[
+              ...sources.overrides.allow,
+              ...sources.overrides.read,
+              ...sources.overrides.write,
+              ...sources.overrides.net_allow,
+            ]}
+          />
+        </div>
+      </div>
+
+      {live !== null && (
+        <div className="pl-staged">
+          <h3>The attached session right now</h3>
+          <p className="pl-hint">
+            A session patched since it started will differ from the resolved policy above.
+          </p>
+          <div className="pl-grid">
+            <PolicyList label="Read" items={live.allow_read} />
+            <PolicyList label="Write" items={live.allow_write} />
+            <PolicyList label="Network allow" items={live.net_allow} />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DiffView({ diff, baseline }: { diff: PolicyDiffResult; baseline: string }) {
+  return (
+    <section className="pl-card">
+      <h2>Diff against {baseline}</h2>
+      {diff.equivalent ? (
+        <p className="pl-accepted">Identical to the {baseline} profile.</p>
+      ) : (
+        <div className="pl-grid">
+          {diff.changed.map((field) => (
+            <div key={field.field} className="pl-list">
+              <span className="pl-list-label">{field.field}</span>
+              <PolicyList label="this policy" items={field.current} />
+              <PolicyList label={baseline} items={field.baseline} />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function PolicyPanel() {
   const [sessionId, setSessionId] = useState("");
   const [attached, setAttached] = useState<string | null>(null);
@@ -305,6 +569,7 @@ export function PolicyPanel() {
       {snapshot !== null && <SnapshotView snapshot={snapshot} />}
       {attached !== null && <PatchForm onSubmit={onPatch} busy={busy} />}
       {patchResult !== null && <PatchResultView result={patchResult} />}
+      <ResolveSection attached={attached} />
     </div>
   );
 }

--- a/apps/shadi_desktop/src/panels/PolicyPanel.tsx
+++ b/apps/shadi_desktop/src/panels/PolicyPanel.tsx
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "./PolicyPanel.css";
+
+interface LivePolicySnapshot {
+  allow_read: string[];
+  allow_write: string[];
+  net_allow: string[];
+  net_blocked: boolean;
+  allow_command: string[];
+  block_command: string[];
+  staged_read: string[];
+  staged_write: string[];
+  staged_allow: string[];
+  net_allow_live: string[] | null;
+}
+
+interface PolicyPatch {
+  add_allow: string[];
+  add_read: string[];
+  add_write: string[];
+  add_allow_command: string[];
+  remove_allow_command: string[];
+  add_block_command: string[];
+  remove_block_command: string[];
+  add_net_allow: string[];
+  remove_net_allow: string[];
+}
+
+interface PatchAxisStatus {
+  // "applied" | "unchanged" | "pending_restart" | "rejected", but the panel
+  // only needs to display it, never branch on a specific value.
+  [key: string]: unknown;
+}
+
+interface PolicyPatchResponse {
+  accepted: boolean;
+  filesystem: PatchAxisStatus;
+  commands: PatchAxisStatus;
+  network: PatchAxisStatus;
+  message: string;
+  pending_restart: string[];
+}
+
+const EMPTY_PATCH: PolicyPatch = {
+  add_allow: [],
+  add_read: [],
+  add_write: [],
+  add_allow_command: [],
+  remove_allow_command: [],
+  add_block_command: [],
+  remove_block_command: [],
+  add_net_allow: [],
+  remove_net_allow: [],
+};
+
+function splitList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function axisLabel(status: PatchAxisStatus | undefined): string {
+  if (!status) return "—";
+  const value = Object.values(status)[0] ?? status;
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function ErrorText({ message }: { message: string | null }) {
+  if (!message) return null;
+  return <p className="pl-error">{message}</p>;
+}
+
+function PolicyList({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div className="pl-list">
+      <span className="pl-list-label">{label}</span>
+      {items.length === 0 ? (
+        <span className="pl-empty">none</span>
+      ) : (
+        <ul>
+          {items.map((item) => (
+            <li key={item}>
+              <code>{item}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SnapshotView({ snapshot }: { snapshot: LivePolicySnapshot }) {
+  return (
+    <section className="pl-card">
+      <h2>Effective policy</h2>
+      <div className="pl-grid">
+        <PolicyList label="Read" items={snapshot.allow_read} />
+        <PolicyList label="Write" items={snapshot.allow_write} />
+        <PolicyList label="Allowed commands" items={snapshot.allow_command} />
+        <PolicyList label="Blocked commands" items={snapshot.block_command} />
+        <PolicyList
+          label={`Network allow (${snapshot.net_blocked ? "blocked by default" : "open by default"})`}
+          items={snapshot.net_allow}
+        />
+        {snapshot.net_allow_live !== null && (
+          <PolicyList label="Network allow (live proxy)" items={snapshot.net_allow_live} />
+        )}
+      </div>
+      {(snapshot.staged_read.length > 0 ||
+        snapshot.staged_write.length > 0 ||
+        snapshot.staged_allow.length > 0) && (
+        <div className="pl-staged">
+          <h3>Staged, pending restart</h3>
+          <div className="pl-grid">
+            <PolicyList label="Read" items={snapshot.staged_read} />
+            <PolicyList label="Write" items={snapshot.staged_write} />
+            <PolicyList label="Allow" items={snapshot.staged_allow} />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PatchForm({
+  onSubmit,
+  busy,
+}: {
+  onSubmit: (patch: PolicyPatch) => void;
+  busy: boolean;
+}) {
+  const [addAllow, setAddAllow] = useState("");
+  const [addRead, setAddRead] = useState("");
+  const [addWrite, setAddWrite] = useState("");
+  const [addNetAllow, setAddNetAllow] = useState("");
+  const [addAllowCommand, setAddAllowCommand] = useState("");
+  const [addBlockCommand, setAddBlockCommand] = useState("");
+
+  function submit() {
+    onSubmit({
+      ...EMPTY_PATCH,
+      add_allow: splitList(addAllow),
+      add_read: splitList(addRead),
+      add_write: splitList(addWrite),
+      add_net_allow: splitList(addNetAllow),
+      add_allow_command: splitList(addAllowCommand),
+      add_block_command: splitList(addBlockCommand),
+    });
+    setAddAllow("");
+    setAddRead("");
+    setAddWrite("");
+    setAddNetAllow("");
+    setAddAllowCommand("");
+    setAddBlockCommand("");
+  }
+
+  const hasInput =
+    [addAllow, addRead, addWrite, addNetAllow, addAllowCommand, addBlockCommand].some(
+      (s) => s.trim().length > 0,
+    );
+
+  return (
+    <section className="pl-card">
+      <h2>Patch</h2>
+      <p className="pl-hint">
+        Adds to the running session's policy. Filesystem changes here are usually staged until
+        the sandboxed process restarts; network and command changes can take effect immediately —
+        the response below says which.
+      </p>
+      <div className="pl-grid">
+        <label className="pl-field">
+          <span>Add read+write paths</span>
+          <input value={addAllow} onChange={(e) => setAddAllow(e.target.value)} placeholder="/tmp/work" />
+        </label>
+        <label className="pl-field">
+          <span>Add read-only paths</span>
+          <input value={addRead} onChange={(e) => setAddRead(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add write-only paths</span>
+          <input value={addWrite} onChange={(e) => setAddWrite(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add network allow (hosts)</span>
+          <input
+            value={addNetAllow}
+            onChange={(e) => setAddNetAllow(e.target.value)}
+            placeholder="api.example.com"
+          />
+        </label>
+        <label className="pl-field">
+          <span>Add allowed commands</span>
+          <input value={addAllowCommand} onChange={(e) => setAddAllowCommand(e.target.value)} />
+        </label>
+        <label className="pl-field">
+          <span>Add blocked commands</span>
+          <input value={addBlockCommand} onChange={(e) => setAddBlockCommand(e.target.value)} />
+        </label>
+      </div>
+      <button onClick={submit} disabled={busy || !hasInput}>
+        {busy ? "Applying…" : "Apply patch"}
+      </button>
+    </section>
+  );
+}
+
+function PatchResultView({ result }: { result: PolicyPatchResponse }) {
+  return (
+    <section className="pl-card">
+      <h2>Patch result</h2>
+      <p className={result.accepted ? "pl-accepted" : "pl-rejected"}>
+        {result.accepted ? "Accepted" : "Rejected"}
+        {result.message ? ` — ${result.message}` : ""}
+      </p>
+      <dl className="pl-axes">
+        <dt>Filesystem</dt>
+        <dd>{axisLabel(result.filesystem)}</dd>
+        <dt>Commands</dt>
+        <dd>{axisLabel(result.commands)}</dd>
+        <dt>Network</dt>
+        <dd>{axisLabel(result.network)}</dd>
+      </dl>
+      {result.pending_restart.length > 0 && (
+        <p className="pl-hint">Needs a restart to take effect: {result.pending_restart.join(", ")}</p>
+      )}
+    </section>
+  );
+}
+
+export function PolicyPanel() {
+  const [sessionId, setSessionId] = useState("");
+  const [attached, setAttached] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<LivePolicySnapshot | null>(null);
+  const [patchResult, setPatchResult] = useState<PolicyPatchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async (socketPath: string) => {
+    try {
+      setSnapshot(await invoke<LivePolicySnapshot>("policy_query", { socketPath }));
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (attached === null) return;
+    refresh(attached);
+    const timer = setInterval(() => refresh(attached), 4000);
+    return () => clearInterval(timer);
+  }, [attached, refresh]);
+
+  async function onAttach() {
+    const trimmed = sessionId.trim();
+    if (!trimmed) {
+      setError("Enter a session name or socket path.");
+      return;
+    }
+    setError(null);
+    setPatchResult(null);
+    setAttached(trimmed);
+  }
+
+  async function onPatch(patch: PolicyPatch) {
+    if (attached === null) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await invoke<PolicyPatchResponse>("policy_patch", {
+        socketPath: attached,
+        patch,
+      });
+      setPatchResult(result);
+      await refresh(attached);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="pl-panel">
+      <section className="pl-card">
+        <h2>Attach</h2>
+        <p className="pl-hint">
+          Same session name or socket path as the Sandbox tab — a session started with{" "}
+          <code>shadictl --watch-policy</code> exposes one; a session launched from the Sandbox
+          tab does not, since serving a control socket is shadictl's job.
+        </p>
+        <div className="pl-row">
+          <input
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+            placeholder="myagent, or /tmp/shadi-ctl-myagent.sock"
+          />
+          <button onClick={onAttach}>Attach</button>
+        </div>
+        <ErrorText message={error} />
+      </section>
+
+      {snapshot !== null && <SnapshotView snapshot={snapshot} />}
+      {attached !== null && <PatchForm onSubmit={onPatch} busy={busy} />}
+      {patchResult !== null && <PatchResultView result={patchResult} />}
+    </div>
+  );
+}

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -5,10 +5,15 @@ pub mod control;
 pub mod net_proxy;
 pub mod policy;
 pub mod policy_patch;
+pub mod resolve;
 mod platform;
 
 pub use net_proxy::{NetAllowlist, NetProxy};
 pub use policy::{PlatformSandboxProfile, ProfileDefaults, SandboxPolicy, SandboxProfile};
+pub use resolve::{
+    canonicalize_path, default_blocked_commands, describe_policy, is_command_blocked,
+    resolve_policy, PolicyDescription, PolicyFileValues, PolicyOverrides, ResolvedPolicy,
+};
 pub use policy_patch::{
     ControlMessage, ControlResponse, PatchAxisStatus, PolicyPatch, PolicyPatchResponse,
     ProcessResources,

--- a/crates/shadi_sandbox/src/policy.rs
+++ b/crates/shadi_sandbox/src/policy.rs
@@ -9,6 +9,15 @@ pub enum PlatformSandboxProfile {
     Minimal,
 }
 
+impl PlatformSandboxProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Compatibility => "compatibility",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SandboxPolicy {
     allow_read: Vec<PathBuf>,
@@ -56,6 +65,15 @@ impl SandboxProfile {
             "balanced" => Some(Self::Balanced),
             "connected" => Some(Self::Connected),
             _ => None,
+        }
+    }
+
+    /// The name this profile is spelled with on the command line.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::Balanced => "balanced",
+            Self::Connected => "connected",
         }
     }
 

--- a/crates/shadi_sandbox/src/resolve.rs
+++ b/crates/shadi_sandbox/src/resolve.rs
@@ -1,0 +1,376 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolving a [`SandboxPolicy`] from layered inputs.
+//!
+//! Three layers, lowest precedence first: a named [`SandboxProfile`]'s
+//! defaults, a policy file's values, then per-invocation overrides. Callers
+//! keep their own on-disk and command-line types and map them onto
+//! [`PolicyFileValues`] and [`PolicyOverrides`] here, so the layering rules
+//! live in one place instead of being restated by every front end that has
+//! to build a policy.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::{field, info_span};
+
+use crate::policy::{SandboxPolicy, SandboxProfile};
+
+/// A policy file's sandbox-relevant values.
+///
+/// Paths here are lenient: one that does not exist on the current OS is
+/// skipped rather than rejected, so a file can list a preset's macOS, Linux
+/// and Windows paths together and still resolve everywhere.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct PolicyFileValues {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    /// `None` leaves the profile's own network default in place.
+    pub net_block: Option<bool>,
+    pub net_allow: Vec<String>,
+    pub allow_command: Vec<String>,
+    pub block_command: Vec<String>,
+}
+
+/// Per-invocation overrides layered over the profile and the policy file.
+///
+/// Unlike [`PolicyFileValues`], paths here must exist: they name what this
+/// specific run asked for, so a bad one is an error rather than something to
+/// skip silently.
+#[derive(Debug, Clone, Default)]
+pub struct PolicyOverrides {
+    /// `None` resolves to [`SandboxProfile::Balanced`].
+    pub profile: Option<SandboxProfile>,
+    pub allow: Vec<PathBuf>,
+    pub read: Vec<PathBuf>,
+    pub write: Vec<PathBuf>,
+    pub net_block: bool,
+    pub net_allow: Vec<String>,
+    pub allow_command: Vec<String>,
+}
+
+/// A resolved policy and the command sets that go with it.
+#[derive(Debug)]
+pub struct ResolvedPolicy {
+    pub policy: SandboxPolicy,
+    pub blocked: HashSet<String>,
+    pub allow: HashSet<String>,
+}
+
+/// A resolved policy flattened for display or serialization.
+///
+/// `allow` holds the paths that are both readable and writable; `read` and
+/// `write` hold the ones that are only one or the other.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PolicyDescription {
+    pub allow: Vec<String>,
+    pub read: Vec<String>,
+    pub write: Vec<String>,
+    pub net_block: bool,
+    pub net_allow: Vec<String>,
+    pub platform_profile: String,
+    pub allow_command: Vec<String>,
+    pub block_command: Vec<String>,
+}
+
+/// Commands blocked unless a policy explicitly allows them: destructive
+/// filesystem operations, privilege escalation, package managers and
+/// anything that moves data off the machine.
+pub fn default_blocked_commands() -> HashSet<&'static str> {
+    [
+        "rm", "rmdir", "shred", "srm", "dd", "mkfs", "fdisk", "parted", "wipefs", "chmod", "chown",
+        "chgrp", "chattr", "shutdown", "reboot", "halt", "systemctl", "apt", "brew", "pip", "yum",
+        "pacman", "mv", "cp", "truncate", "sudo", "su", "doas", "pkexec", "scp", "rsync", "sftp",
+        "ftp",
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Whether `cmd` is blocked: in the block set and not rescued by the allow set.
+pub fn is_command_blocked(cmd: &str, blocked: &HashSet<String>, allow: &HashSet<String>) -> bool {
+    blocked.contains(cmd) && !allow.contains(cmd)
+}
+
+pub fn canonicalize_path(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    std::fs::canonicalize(path)
+}
+
+/// Layer profile defaults, then file values, then overrides, into one policy.
+pub fn resolve_policy(
+    overrides: &PolicyOverrides,
+    file_policy: &PolicyFileValues,
+) -> Result<ResolvedPolicy, String> {
+    let mut blocked = default_blocked_commands()
+        .into_iter()
+        .map(|cmd| cmd.to_string())
+        .collect::<HashSet<_>>();
+    for cmd in file_policy.block_command.iter() {
+        blocked.insert(cmd.to_string());
+    }
+
+    let mut allow = file_policy
+        .allow_command
+        .iter()
+        .map(|cmd| cmd.to_string())
+        .collect::<HashSet<_>>();
+    for cmd in overrides.allow_command.iter() {
+        allow.insert(cmd.to_string());
+    }
+
+    let profile = overrides.profile.unwrap_or(SandboxProfile::Balanced);
+    let span = info_span!(
+        "shadi.policy.resolve",
+        policy.allowed_paths = field::Empty,
+        network.mode = field::Empty,
+        policy.profile = %profile.as_str(),
+    );
+    let _guard = span.enter();
+
+    let defaults = profile.defaults();
+    let mut policy = SandboxPolicy::new()
+        .block_network(overrides.net_block || file_policy.net_block.unwrap_or(defaults.net_block));
+
+    for destination in &file_policy.net_allow {
+        policy = policy.allow_network_destination(destination.clone());
+    }
+    for destination in &overrides.net_allow {
+        policy = policy.allow_network_destination(destination.clone());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        policy = policy.use_minimal_platform_profile();
+    }
+
+    policy = apply_string_paths(policy, &defaults.read, PathMode::Read)?;
+    policy = apply_string_paths(policy, &defaults.write, PathMode::Write)?;
+    policy = apply_string_paths(policy, &defaults.allow, PathMode::Allow)?;
+
+    policy = apply_preset_paths(policy, &file_policy.read, PathMode::Read);
+    policy = apply_preset_paths(policy, &file_policy.write, PathMode::Write);
+    policy = apply_preset_paths(policy, &file_policy.allow, PathMode::Allow);
+
+    policy = apply_paths(policy, &overrides.read, PathMode::Read)?;
+    policy = apply_paths(policy, &overrides.write, PathMode::Write)?;
+    policy = apply_paths(policy, &overrides.allow, PathMode::Allow)?;
+
+    let allowed_paths = policy
+        .allow_read()
+        .iter()
+        .chain(policy.allow_write().iter())
+        .collect::<std::collections::BTreeSet<_>>();
+    span.record("policy.allowed_paths", allowed_paths.len() as i64);
+    let network_mode = if policy.net_blocked() { "blocked" } else { "allowed" };
+    span.record("network.mode", field::display(network_mode));
+
+    Ok(ResolvedPolicy {
+        policy,
+        blocked,
+        allow,
+    })
+}
+
+/// Flatten a resolved policy for display or serialization.
+pub fn describe_policy(
+    policy: &SandboxPolicy,
+    blocked: &HashSet<String>,
+    allow: &HashSet<String>,
+) -> PolicyDescription {
+    let is_writable = |path: &PathBuf| policy.allow_write().iter().any(|write| write == path);
+    let is_readable = |path: &PathBuf| policy.allow_read().iter().any(|read| read == path);
+    let display = |paths: Vec<&PathBuf>| {
+        paths
+            .into_iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    let mut blocked_list = blocked.iter().cloned().collect::<Vec<_>>();
+    blocked_list.sort();
+    let mut allow_list = allow.iter().cloned().collect::<Vec<_>>();
+    allow_list.sort();
+
+    PolicyDescription {
+        allow: display(policy.allow_read().iter().filter(|p| is_writable(p)).collect()),
+        read: display(policy.allow_read().iter().filter(|p| !is_writable(p)).collect()),
+        write: display(policy.allow_write().iter().filter(|p| !is_readable(p)).collect()),
+        net_block: policy.net_blocked(),
+        net_allow: policy.net_allow().to_vec(),
+        platform_profile: policy.platform_profile().as_str().to_string(),
+        allow_command: allow_list,
+        block_command: blocked_list,
+    }
+}
+
+enum PathMode {
+    Read,
+    Write,
+    Allow,
+}
+
+impl PathMode {
+    fn label(&self) -> &'static str {
+        match self {
+            PathMode::Read => "read",
+            PathMode::Write => "write",
+            PathMode::Allow => "allow",
+        }
+    }
+}
+
+fn apply_string_paths(
+    mut policy: SandboxPolicy,
+    paths: &[String],
+    mode: PathMode,
+) -> Result<SandboxPolicy, String> {
+    for path in paths.iter() {
+        let path = canonicalize_path(path)
+            .map_err(|err| format!("invalid {} path {}: {}", mode.label(), path, err))?;
+        policy = apply_path(policy, &path, &mode);
+    }
+    Ok(policy)
+}
+
+/// Like [`apply_string_paths`], but skips paths that do not exist, so a
+/// cross-platform preset resolves on every OS.
+fn apply_preset_paths(mut policy: SandboxPolicy, paths: &[String], mode: PathMode) -> SandboxPolicy {
+    for path in paths.iter() {
+        if let Ok(canonical) = canonicalize_path(path) {
+            policy = apply_path(policy, &canonical, &mode);
+        }
+    }
+    policy
+}
+
+fn apply_paths(
+    mut policy: SandboxPolicy,
+    paths: &[PathBuf],
+    mode: PathMode,
+) -> Result<SandboxPolicy, String> {
+    for path in paths.iter() {
+        let path = canonicalize_path(path)
+            .map_err(|err| format!("invalid {} path {}: {}", mode.label(), path.display(), err))?;
+        policy = apply_path(policy, &path, &mode);
+    }
+    Ok(policy)
+}
+
+fn apply_path(policy: SandboxPolicy, path: &PathBuf, mode: &PathMode) -> SandboxPolicy {
+    match mode {
+        PathMode::Read => policy.allow_read_path(path),
+        PathMode::Write => policy.allow_write_path(path),
+        PathMode::Allow => policy.allow_read_path(path).allow_write_path(path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overrides_layer_over_the_profile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let overrides = PolicyOverrides {
+            profile: Some(SandboxProfile::Strict),
+            allow: vec![dir.path().to_path_buf()],
+            ..Default::default()
+        };
+        let resolved =
+            resolve_policy(&overrides, &PolicyFileValues::default()).expect("resolve");
+
+        let canonical = canonicalize_path(dir.path()).expect("canonical");
+        assert!(resolved.policy.allow_read().contains(&canonical));
+        assert!(resolved.policy.allow_write().contains(&canonical));
+    }
+
+    #[test]
+    fn a_missing_file_path_is_skipped_but_a_missing_override_is_an_error() {
+        let file_policy = PolicyFileValues {
+            read: vec!["/definitely/not/here".to_string()],
+            ..Default::default()
+        };
+        resolve_policy(&PolicyOverrides::default(), &file_policy)
+            .expect("a missing policy-file path is skipped");
+
+        let overrides = PolicyOverrides {
+            read: vec![PathBuf::from("/definitely/not/here")],
+            ..Default::default()
+        };
+        let err = resolve_policy(&overrides, &PolicyFileValues::default())
+            .expect_err("a missing override path is rejected");
+        assert!(err.contains("invalid read path"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn net_block_comes_from_the_profile_unless_something_overrides_it() {
+        let connected = PolicyOverrides {
+            profile: Some(SandboxProfile::Connected),
+            ..Default::default()
+        };
+        let resolved =
+            resolve_policy(&connected, &PolicyFileValues::default()).expect("resolve");
+        assert!(!resolved.policy.net_blocked(), "connected leaves network on");
+
+        let file_policy = PolicyFileValues {
+            net_block: Some(true),
+            ..Default::default()
+        };
+        let resolved = resolve_policy(&connected, &file_policy).expect("resolve");
+        assert!(resolved.policy.net_blocked(), "the file turns it back off");
+    }
+
+    #[test]
+    fn file_and_override_commands_both_reach_the_allow_set() {
+        let overrides = PolicyOverrides {
+            allow_command: vec!["rm".to_string()],
+            ..Default::default()
+        };
+        let file_policy = PolicyFileValues {
+            allow_command: vec!["mv".to_string()],
+            block_command: vec!["git".to_string()],
+            ..Default::default()
+        };
+        let resolved = resolve_policy(&overrides, &file_policy).expect("resolve");
+
+        assert!(!is_command_blocked("rm", &resolved.blocked, &resolved.allow));
+        assert!(!is_command_blocked("mv", &resolved.blocked, &resolved.allow));
+        assert!(is_command_blocked("git", &resolved.blocked, &resolved.allow));
+        assert!(is_command_blocked("sudo", &resolved.blocked, &resolved.allow));
+    }
+
+    #[test]
+    fn describe_policy_splits_read_write_and_both() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let read_only = dir.path().join("read");
+        let write_only = dir.path().join("write");
+        let both = dir.path().join("both");
+        for path in [&read_only, &write_only, &both] {
+            std::fs::create_dir(path).expect("mkdir");
+        }
+
+        let overrides = PolicyOverrides {
+            read: vec![read_only.clone()],
+            write: vec![write_only.clone()],
+            allow: vec![both.clone()],
+            ..Default::default()
+        };
+        let resolved =
+            resolve_policy(&overrides, &PolicyFileValues::default()).expect("resolve");
+        let described = describe_policy(&resolved.policy, &resolved.blocked, &resolved.allow);
+
+        let canonical = |path: &PathBuf| {
+            canonicalize_path(path)
+                .expect("canonical")
+                .display()
+                .to_string()
+        };
+        assert!(described.allow.contains(&canonical(&both)));
+        assert!(described.read.contains(&canonical(&read_only)));
+        assert!(described.write.contains(&canonical(&write_only)));
+        assert!(!described.read.contains(&canonical(&both)));
+    }
+}

--- a/crates/shadictl/src/cli_types.rs
+++ b/crates/shadictl/src/cli_types.rs
@@ -1101,9 +1101,4 @@ pub(crate) struct ProcessTrustedSecretRule {
     pub(crate) exec_sha256: Option<String>,
 }
 
-#[derive(Debug)]
-pub(crate) struct ResolvedPolicy {
-    pub(crate) policy: SandboxPolicy,
-    pub(crate) blocked: HashSet<String>,
-    pub(crate) allow: HashSet<String>,
-}
+pub(crate) use shadi_sandbox::ResolvedPolicy;

--- a/crates/shadictl/src/main_tests.rs
+++ b/crates/shadictl/src/main_tests.rs
@@ -406,7 +406,7 @@
 
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
-            let default_read = canonicalize_string_path("/").expect("canonical root path");
+            let default_read = shadi_sandbox::canonicalize_path("/").expect("canonical root path");
             assert_eq!(
                 resolved.policy.platform_profile(),
                 PlatformSandboxProfile::Minimal
@@ -420,7 +420,7 @@
 
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
-            let default_read = canonicalize_string_path("/").expect("canonical root path");
+            let default_read = shadi_sandbox::canonicalize_path("/").expect("canonical root path");
             assert!(resolved
                 .policy
                 .allow_read()
@@ -531,7 +531,7 @@
         let mut cli = build_cli();
         cli.profile = Some(LauncherProfile::Strict);
         let resolved = resolve_policy(&cli, &PolicyFile::default()).expect("resolve");
-        let default_read = canonicalize_string_path("/").expect("canonical root path");
+        let default_read = shadi_sandbox::canonicalize_path("/").expect("canonical root path");
         assert!(resolved.policy.net_blocked());
         assert!(!resolved
             .policy
@@ -557,7 +557,7 @@
 
     #[test]
     fn is_command_blocked_allows_unknown_when_not_blocked() {
-        let blocked = default_blocked_commands()
+        let blocked = shadi_sandbox::default_blocked_commands()
             .into_iter()
             .map(|cmd| cmd.to_string())
             .collect::<HashSet<_>>();
@@ -567,7 +567,7 @@
 
     #[test]
     fn command_blocking_respects_allowlist() {
-        let blocked = default_blocked_commands()
+        let blocked = shadi_sandbox::default_blocked_commands()
             .into_iter()
             .map(|cmd| cmd.to_string())
             .collect::<HashSet<_>>();
@@ -1306,8 +1306,8 @@
     #[test]
     fn canonicalize_helpers_resolve_paths() {
         let dir = temp_dir();
-        let path = canonicalize_path(&dir.path().to_path_buf()).expect("path");
-        let text = canonicalize_string_path(dir.path().to_str().expect("str")).expect("str path");
+        let path = shadi_sandbox::canonicalize_path(dir.path()).expect("path");
+        let text = shadi_sandbox::canonicalize_path(dir.path().to_str().expect("str")).expect("str path");
         assert_eq!(path, text);
     }
 
@@ -3614,13 +3614,13 @@ members = [{ did = "did:key:zA", role = "human" }]
 
     #[test]
     fn blocklist_blocks_default_command() {
-        let blocked = default_blocked_commands();
+        let blocked = shadi_sandbox::default_blocked_commands();
         assert!(blocked.contains("rm"));
     }
 
     #[test]
     fn allowlist_overrides_blocklist() {
-        let blocked = default_blocked_commands();
+        let blocked = shadi_sandbox::default_blocked_commands();
         let allow = ["rm"].into_iter().collect::<HashSet<_>>();
         assert!(blocked.contains("rm"));
         assert!(allow.contains("rm"));

--- a/crates/shadictl/src/policy_helpers.rs
+++ b/crates/shadictl/src/policy_helpers.rs
@@ -1,135 +1,43 @@
 use super::*;
-use shadi_sandbox::{PlatformSandboxProfile, SandboxProfile};
+use shadi_sandbox::{PolicyFileValues, PolicyOverrides, SandboxProfile};
 
 pub(crate) fn format_policy(
     policy: &SandboxPolicy,
     blocked: &HashSet<String>,
     allow: &HashSet<String>,
 ) -> Result<String, String> {
-    #[derive(serde::Serialize)]
-    struct PolicyDump {
-        allow: Vec<String>,
-        read: Vec<String>,
-        write: Vec<String>,
-        net_block: bool,
-        net_allow: Vec<String>,
-        platform_profile: String,
-        allow_command: Vec<String>,
-        block_command: Vec<String>,
-    }
-
-    let allow_paths = policy
-        .allow_read()
-        .iter()
-        .filter(|path| policy.allow_write().iter().any(|write| write == *path))
-        .map(|path| path.display().to_string())
-        .collect::<Vec<_>>();
-    let read_paths = policy
-        .allow_read()
-        .iter()
-        .filter(|path| !policy.allow_write().iter().any(|write| write == *path))
-        .map(|path| path.display().to_string())
-        .collect::<Vec<_>>();
-    let write_paths = policy
-        .allow_write()
-        .iter()
-        .filter(|path| !policy.allow_read().iter().any(|read| read == *path))
-        .map(|path| path.display().to_string())
-        .collect::<Vec<_>>();
-    let mut blocked_list = blocked.iter().cloned().collect::<Vec<_>>();
-    blocked_list.sort();
-    let mut allow_list = allow.iter().cloned().collect::<Vec<_>>();
-    allow_list.sort();
-
-    let dump = PolicyDump {
-        allow: allow_paths,
-        read: read_paths,
-        write: write_paths,
-        net_block: policy.net_blocked(),
-        net_allow: policy.net_allow().to_vec(),
-        platform_profile: match policy.platform_profile() {
-            PlatformSandboxProfile::Compatibility => "compatibility".to_string(),
-            PlatformSandboxProfile::Minimal => "minimal".to_string(),
-        },
-        allow_command: allow_list,
-        block_command: blocked_list,
-    };
-
-    serde_json::to_string_pretty(&dump).map_err(|err| err.to_string())
+    let described = shadi_sandbox::describe_policy(policy, blocked, allow);
+    serde_json::to_string_pretty(&described).map_err(|err| err.to_string())
 }
 
+/// Map this binary's `Cli` and `PolicyFile` onto the layering rules in
+/// `shadi_sandbox::resolve`, which the desktop app resolves policy with too.
 pub(crate) fn resolve_policy(cli: &Cli, file_policy: &PolicyFile) -> Result<ResolvedPolicy, String> {
-    let mut blocked = default_blocked_commands()
-        .into_iter()
-        .map(|cmd| cmd.to_string())
-        .collect::<HashSet<_>>();
-    for cmd in file_policy.block_command.iter() {
-        blocked.insert(cmd.to_string());
-    }
-
-    let mut allow = file_policy
-        .allow_command
-        .iter()
-        .map(|cmd| cmd.to_string())
-        .collect::<HashSet<_>>();
-    for cmd in cli.allow_command.iter() {
-        allow.insert(cmd.to_string());
-    }
-
-    let profile_name = match cli.profile.unwrap_or(LauncherProfile::Balanced) {
-        LauncherProfile::Strict => "strict",
-        LauncherProfile::Balanced => "balanced",
-        LauncherProfile::Connected => "connected",
+    let overrides = PolicyOverrides {
+        profile: cli.profile.map(|profile| match profile {
+            LauncherProfile::Strict => SandboxProfile::Strict,
+            LauncherProfile::Balanced => SandboxProfile::Balanced,
+            LauncherProfile::Connected => SandboxProfile::Connected,
+        }),
+        allow: cli.allow.clone(),
+        read: cli.read.clone(),
+        write: cli.write.clone(),
+        net_block: cli.net_block,
+        net_allow: cli.net_allow.clone(),
+        allow_command: cli.allow_command.clone(),
     };
-    let span = info_span!(
-        "shadi.policy.resolve",
-        policy.allowed_paths = field::Empty,
-        network.mode = field::Empty,
-        policy.profile = %profile_name,
-    );
-    let _guard = span.enter();
 
-    let profile = profile_defaults(cli.profile);
-    let profile_net_block = profile.net_block.unwrap_or(false);
-    let mut policy = SandboxPolicy::new()
-        .block_network(cli.net_block || file_policy.net_block.unwrap_or(profile_net_block));
+    let file_values = PolicyFileValues {
+        allow: file_policy.allow.clone(),
+        read: file_policy.read.clone(),
+        write: file_policy.write.clone(),
+        net_block: file_policy.net_block,
+        net_allow: file_policy.net_allow.clone(),
+        allow_command: file_policy.allow_command.clone(),
+        block_command: file_policy.block_command.clone(),
+    };
 
-    for destination in &file_policy.net_allow {
-        policy = policy.allow_network_destination(destination.clone());
-    }
-    for destination in &cli.net_allow {
-        policy = policy.allow_network_destination(destination.clone());
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    {
-        policy = policy.use_minimal_platform_profile();
-    }
-
-    policy = apply_string_paths(policy, &profile.read, PathMode::Read)?;
-    policy = apply_string_paths(policy, &profile.write, PathMode::Write)?;
-    policy = apply_string_paths(policy, &profile.allow, PathMode::Allow)?;
-
-    policy = apply_preset_paths(policy, &file_policy.read, PathMode::Read)?;
-    policy = apply_preset_paths(policy, &file_policy.write, PathMode::Write)?;
-    policy = apply_preset_paths(policy, &file_policy.allow, PathMode::Allow)?;
-
-    policy = apply_paths(policy, &cli.read, PathMode::Read)?;
-    policy = apply_paths(policy, &cli.write, PathMode::Write)?;
-    policy = apply_paths(policy, &cli.allow, PathMode::Allow)?;
-
-    let mut allowed_paths = BTreeSet::new();
-    allowed_paths.extend(policy.allow_read().iter().cloned());
-    allowed_paths.extend(policy.allow_write().iter().cloned());
-    span.record("policy.allowed_paths", &(allowed_paths.len() as i64));
-    let network_mode = if policy.net_blocked() { "blocked" } else { "allowed" };
-    span.record("network.mode", &field::display(network_mode));
-
-    Ok(ResolvedPolicy {
-        policy,
-        blocked,
-        allow,
-    })
+    shadi_sandbox::resolve_policy(&overrides, &file_values)
 }
 
 pub(crate) fn profile_defaults(profile: Option<LauncherProfile>) -> PolicyFile {
@@ -158,88 +66,7 @@ pub(crate) fn profile_defaults(profile: Option<LauncherProfile>) -> PolicyFile {
     }
 }
 
-pub(crate) fn is_command_blocked(
-    cmd: &str,
-    blocked: &HashSet<String>,
-    allow: &HashSet<String>,
-) -> bool {
-    blocked.contains(cmd) && !allow.contains(cmd)
-}
-
-enum PathMode {
-    Read,
-    Write,
-    Allow,
-}
-
-fn apply_string_paths(
-    mut policy: SandboxPolicy,
-    paths: &[String],
-    mode: PathMode,
-) -> Result<SandboxPolicy, String> {
-    for path in paths.iter() {
-        let path = canonicalize_string_path(path)
-            .map_err(|err| format!("invalid {} path {}: {}", mode.label(), path, err))?;
-        policy = apply_path(policy, &path, &mode);
-    }
-    Ok(policy)
-}
-
-/// Like `apply_string_paths` but silently skips paths that do not exist on
-/// the current operating system.  Used for policy-file `read`/`allow`/`write`
-/// lists so that cross-platform presets (which list paths for all three
-/// platforms) work correctly on every OS without failure.
-fn apply_preset_paths(
-    mut policy: SandboxPolicy,
-    paths: &[String],
-    mode: PathMode,
-) -> Result<SandboxPolicy, String> {
-    for path in paths.iter() {
-        match canonicalize_string_path(path) {
-            Ok(canonical) => {
-                policy = apply_path(policy, &canonical, &mode);
-            }
-            Err(_) => {
-                // Path does not exist on this OS — silently skip.
-                // This is expected for cross-platform presets that list paths
-                // for macOS, Linux, and Windows simultaneously.
-            }
-        }
-    }
-    Ok(policy)
-}
-
-fn apply_paths(
-    mut policy: SandboxPolicy,
-    paths: &[PathBuf],
-    mode: PathMode,
-) -> Result<SandboxPolicy, String> {
-    for path in paths.iter() {
-        let path = canonicalize_path(path)
-            .map_err(|err| format!("invalid {} path {}: {}", mode.label(), path.display(), err))?;
-        policy = apply_path(policy, &path, &mode);
-    }
-    Ok(policy)
-}
-
-fn apply_path(mut policy: SandboxPolicy, path: &PathBuf, mode: &PathMode) -> SandboxPolicy {
-    match mode {
-        PathMode::Read => policy = policy.allow_read_path(path),
-        PathMode::Write => policy = policy.allow_write_path(path),
-        PathMode::Allow => policy = policy.allow_read_path(path).allow_write_path(path),
-    }
-    policy
-}
-
-impl PathMode {
-    fn label(&self) -> &'static str {
-        match self {
-            PathMode::Read => "read",
-            PathMode::Write => "write",
-            PathMode::Allow => "allow",
-        }
-    }
-}
+pub(crate) use shadi_sandbox::is_command_blocked;
 
 pub(crate) fn list_keychain(prefix: Option<&str>) -> Result<(), String> {
     let store = default_secret_store();
@@ -260,14 +87,6 @@ pub(crate) fn list_keychain_with_store(
     }
     keys.sort();
     Ok(keys)
-}
-
-pub(crate) fn canonicalize_path(path: &PathBuf) -> std::io::Result<PathBuf> {
-    std::fs::canonicalize(path)
-}
-
-pub(crate) fn canonicalize_string_path(path: &str) -> std::io::Result<PathBuf> {
-    std::fs::canonicalize(Path::new(path))
 }
 
 pub(crate) fn load_policy_file(path: &Path) -> std::io::Result<PolicyFile> {
@@ -321,42 +140,3 @@ pub(crate) fn parse_key_env(value: &str) -> Result<(&str, &str), String> {
     Ok((key, env))
 }
 
-pub(crate) fn default_blocked_commands() -> HashSet<&'static str> {
-    [
-        "rm",
-        "rmdir",
-        "shred",
-        "srm",
-        "dd",
-        "mkfs",
-        "fdisk",
-        "parted",
-        "wipefs",
-        "chmod",
-        "chown",
-        "chgrp",
-        "chattr",
-        "shutdown",
-        "reboot",
-        "halt",
-        "systemctl",
-        "apt",
-        "brew",
-        "pip",
-        "yum",
-        "pacman",
-        "mv",
-        "cp",
-        "truncate",
-        "sudo",
-        "su",
-        "doas",
-        "pkexec",
-        "scp",
-        "rsync",
-        "sftp",
-        "ftp",
-    ]
-    .into_iter()
-    .collect()
-}


### PR DESCRIPTION
Stacked on #209 — **review that one first**; this PR's diff is only its own commit.

Closes the rest of #116.

Policy resolution — profile defaults, then policy file, then overrides — lived in shadictl and took its whole `Cli` struct, so nothing outside that binary could resolve a policy. `explain`/`diff` need exactly that, and the desktop's `sandbox_launch` had already grown a second hand-rolled copy of the same layering.

`shadi_sandbox::resolve` now owns it, taking `PolicyOverrides`/`PolicyFileValues` instead of a `Cli`. shadictl's `resolve_policy`/`format_policy` keep their signatures and map onto it — **no call site or test assertion changed**, which is the main evidence the refactor is behaviour-preserving. `sandbox_launch` drops its duplicate.

The panel gains a resolve-from-inputs section: what a profile + file + paths produce, where each part came from, and a diff against a baseline profile. With a session attached, its live policy shows next to the resolved one — a session patched since launch will differ, and that gap is worth seeing.

## Verification

- **1157 workspace tests** pass (1152 + 5 new for the resolver), zero assertion changes
- 35 desktop tests, clippy and `pnpm build` clean; both lockfiles in sync

One flake seen and **not** caused by this change: `commands::identity::tests::an_rsa_only_account_reports_what_it_published` failed once under parallel execution, then passed 35/35 single-threaded and across 5 parallel runs. Its `test_support::set` fake is a shared global — same category as #204. Filing separately.