### PR TITLE
fix(shadictl): keep terminate ahead of restart when both arrive at once

### DIFF
--- a/crates/shadictl/src/sandbox_snapshot.rs
+++ b/crates/shadictl/src/sandbox_snapshot.rs
@@ -56,16 +56,24 @@ fn wait_for_child_or_interrupt(
             return Ok(ChildWaitOutcome::Exited(status));
         }
 
-        if interrupted.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
-            || terminate_requested.is_some_and(|flag| {
-                flag.load(std::sync::atomic::Ordering::SeqCst)
-            })
-        {
+        // Read restart before terminate. Both are read once per iteration so
+        // the choice between them is made from one snapshot; taking restart
+        // first means a terminate stored before it is always visible here, so
+        // terminate keeps its priority even when both land mid-iteration.
+        // Reading terminate first let a restart stored in between win.
+        let restart =
+            restart_requested.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst));
+        let terminate = interrupted
+            .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
+            || terminate_requested
+                .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst));
+
+        if terminate {
             let _ = child.kill();
             return child.wait().map(ChildWaitOutcome::Terminated);
         }
 
-        if restart_requested.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::SeqCst)) {
+        if restart {
             let _ = child.kill();
             let _ = child.wait()?;
             return Ok(ChildWaitOutcome::RestartRequested);


### PR DESCRIPTION
`wait_for_child_or_interrupt` read the terminate flags, then the restart flag, and acted on whichever it saw. A restart stored **between** those two reads won even though terminate was stored first — inverting the priority the function exists to enforce.

Both flags are now read once per iteration, restart first. With `SeqCst` stores, seeing restart means a terminate stored before it is visible in the same snapshot, so terminate keeps priority however the two land.

## How it surfaced

`coverage` failed on #210 with `wait_for_child_terminate_takes_priority_over_restart`. Worth noting why it went unseen: that PR was stacked on a feature branch, and `coverage.yml` is `pull_request: branches: [main]`, so coverage had never run on it. It only appeared once the PR was retargeted to main.

The test's helper thread and the poll loop both sleep 100ms, so they align, and llvm-cov instrumentation widens the window between the two reads. Reproduced **1-in-6 under `cargo llvm-cov` locally, 0-in-20 without it**. Not caused by #210's changes — that branch doesn't touch this file — though moving code across a crate boundary there plausibly shifted timing enough to surface it.

## No test added

Deliberate. Setting both flags before entry passes with *or* without this fix, since the old order was only wrong for stores landing mid-iteration. I wrote that test, confirmed it passed unfixed, and dropped it rather than leave something that looks like a regression guard but guards nothing. The existing timing test now passes 12/12 under llvm-cov (previously 1-in-6 failures).

## Verification

- 1152 workspace tests pass; clippy clean in the changed range