### PR TITLE
fix(release): release whenever main is ahead of the registry

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-release_always = false
+release_always = true
 publish = true
 publish_no_verify = true
 publish_timeout = "30m"


### PR DESCRIPTION
`release_always = true` retries on the next push. Idempotent: it publishes only while a version is ahead of the registry.

