### PR TITLE
feat(agentbridge): prove agent DID and ship native handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
+          components: clippy
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -77,6 +78,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: just windows-test
+      - name: Clippy
+        if: runner.os != 'Windows'
+        run: cargo clippy --workspace --exclude shadi_desktop --exclude agntcy-shadi-py --exclude agntcy-shadi-cli --all-targets --all-features -- -D warnings -A clippy::field_reassign_with_default -A clippy::too_many_arguments
+      - name: Clippy (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cargo clippy --workspace --exclude shadi_desktop --exclude agntcy-shadi-py --exclude agntcy-shadi-cli --all-targets --all-features -- -D warnings -A clippy::field_reassign_with_default -A clippy::too_many_arguments
 
   lockfiles:
     name: Lockfiles in sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.98.0
-          components: clippy
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -78,13 +77,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: just windows-test
-      - name: Clippy
-        if: runner.os != 'Windows'
-        run: cargo clippy --workspace --exclude shadi_desktop --exclude agntcy-shadi-py --exclude agntcy-shadi-cli --all-targets --all-features -- -D warnings -A clippy::field_reassign_with_default -A clippy::too_many_arguments
-      - name: Clippy (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: cargo clippy --workspace --exclude shadi_desktop --exclude agntcy-shadi-py --exclude agntcy-shadi-cli --all-targets --all-features -- -D warnings -A clippy::field_reassign_with_default -A clippy::too_many_arguments
 
   lockfiles:
     name: Lockfiles in sync

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -70,6 +70,6 @@ jobs:
       - name: Build frontend (tsc + vite)
         run: pnpm build
 
-      - name: Check src-tauri
+      - name: Test src-tauri
         working-directory: apps/shadi_desktop/src-tauri
-        run: cargo check --locked
+        run: cargo test --locked

--- a/apps/shadi_desktop/README.md
+++ b/apps/shadi_desktop/README.md
@@ -4,10 +4,24 @@ A native control-plane app for `shadictl`, `agentbridge`, and the SHADI shell �
 [agntcy/shadi#112](https://github.com/agntcy/shadi/issues/112) for the epic and panel
 breakdown.
 
-This is scaffolding only ([agntcy/shadi#113](https://github.com/agntcy/shadi/issues/113)):
-an empty window, no feature panels yet. Tauri (Rust backend in `src-tauri/`, linking the
-core SHADI crates directly) + React/Vite/TypeScript frontend, following
+Tauri (Rust backend in `src-tauri/`, linking the core SHADI crates directly) plus
+a React/Vite/TypeScript frontend, following
 [block/buzz](https://github.com/block/buzz)'s desktop app layout.
+
+## What is implemented
+
+Five tabs are wired today:
+
+- **Identity** — SSH / 1Password onboarding, GitHub handle cross-check, derived agent DIDs ([#123](https://github.com/agntcy/shadi/issues/123)). The remaining identity/secrets IPC from [#117](https://github.com/agntcy/shadi/issues/117) is still stubbed.
+- **Sandbox** — list, launch, attach, and kill sessions via `shadi_sandbox` ([#115](https://github.com/agntcy/shadi/issues/115)).
+- **Policy** — live query/patch plus explain/diff against `shadi_sandbox` ([#116](https://github.com/agntcy/shadi/issues/116)).
+- **Rooms** — SLIM node, groups, roster, and persistence ([#118](https://github.com/agntcy/shadi/issues/118), [#138](https://github.com/agntcy/shadi/issues/138)).
+- **agentbridge** — list, handoff, delegate, and coordinate with live round events ([#120](https://github.com/agntcy/shadi/issues/120)).
+
+Agent Directory and trace/memory backends still return `not_implemented`
+([#119](https://github.com/agntcy/shadi/issues/119),
+[#121](https://github.com/agntcy/shadi/issues/121)). There is no signed
+desktop release yet ([#124](https://github.com/agntcy/shadi/issues/124)).
 
 ## Develop
 

--- a/apps/shadi_desktop/src-tauri/src/commands/mod.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/mod.rs
@@ -3,9 +3,10 @@
 
 //! The Tauri IPC command contract — see ../../docs/ipc-contract.md.
 //!
-//! `agentbridge`, `slim` and `identity` are implemented; the rest are still
-//! stubs returning [`not_implemented`], one panel issue each
-//! (agntcy/shadi#115, #116, #119, #121).
+//! `agentbridge`, `slim`, `sandbox`, policy query/patch/explain/diff, and
+//! identity onboarding are implemented. DIR, remaining identity/secrets
+//! commands, and trace/memory still return [`not_implemented`]
+//! (agntcy/shadi#117, #119, #121).
 
 pub mod agentbridge;
 pub mod bootstrap;

--- a/apps/shadi_desktop/src-tauri/src/commands/policy.rs
+++ b/apps/shadi_desktop/src-tauri/src/commands/policy.rs
@@ -55,6 +55,9 @@ pub struct LivePolicySnapshot {
 /// The policy a sandbox is launched with (`sandbox_launch`'s
 /// `LaunchSandboxRequest`) — a config to build a fresh `SandboxPolicy` from,
 /// not the live, already-resolved shape `LivePolicySnapshot` reads back.
+/// This is a full-replacement launch config, not the additive control-socket
+/// [`shadi_sandbox::PolicyPatch`]. Keep the types separate so a live patch
+/// cannot be mistaken for a launch config.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PolicyConfig {
     pub allow: Vec<String>,

--- a/crates/agent_secrets/src/auth.rs
+++ b/crates/agent_secrets/src/auth.rs
@@ -16,6 +16,20 @@ impl AgentVerifier for NoopVerifier {
     }
 }
 
+/// Accepts a session only when [`SessionContext::did`] was proven from a
+/// signature on the message. A caller-set `verified` flag is not enough.
+pub struct DidProofVerifier;
+
+impl AgentVerifier for DidProofVerifier {
+    fn verify(&self, session: &SessionContext) -> SecretResult<()> {
+        if session.did_proven && session.did.as_ref().is_some_and(|did| !did.is_empty()) {
+            Ok(())
+        } else {
+            Err(SecretError::NotAuthorized)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,5 +40,20 @@ mod tests {
         let session = SessionContext::new("agent", "session");
         let err = verifier.verify(&session).unwrap_err();
         assert!(matches!(err, SecretError::NotAuthorized));
+    }
+
+    #[test]
+    fn did_proof_verifier_rejects_asserted_only_session() {
+        let verifier = DidProofVerifier;
+        let mut asserted = SessionContext::new("agent", "session");
+        asserted.verified = true;
+        asserted.did = Some("did:key:zexample".to_string());
+        assert!(matches!(
+            verifier.verify(&asserted),
+            Err(SecretError::NotAuthorized)
+        ));
+
+        let proven = SessionContext::new("agent", "session").with_proven_did("did:key:zexample");
+        verifier.verify(&proven).expect("proven DID must pass");
     }
 }

--- a/crates/agent_secrets/src/lib.rs
+++ b/crates/agent_secrets/src/lib.rs
@@ -11,7 +11,7 @@ pub mod session;
 use std::fmt;
 
 pub use agent::AgentSecretAccess;
-pub use auth::AgentVerifier;
+pub use auth::{AgentVerifier, DidProofVerifier, NoopVerifier};
 pub use memory::SecretBytes;
 pub use policy::SecretPolicy;
 pub use session::SessionContext;

--- a/crates/agent_secrets/src/platform/macos.rs
+++ b/crates/agent_secrets/src/platform/macos.rs
@@ -53,8 +53,11 @@ impl fmt::Display for KeychainError {
 }
 
 #[cfg(any(test, feature = "coverage"))]
-fn keychain_fixture() -> &'static Mutex<HashMap<(String, String), Vec<u8>>> {
-    static FIXTURE: OnceLock<Mutex<HashMap<(String, String), Vec<u8>>>> = OnceLock::new();
+type KeychainFixture = Mutex<HashMap<(String, String), Vec<u8>>>;
+
+#[cfg(any(test, feature = "coverage"))]
+fn keychain_fixture() -> &'static KeychainFixture {
+    static FIXTURE: OnceLock<KeychainFixture> = OnceLock::new();
     FIXTURE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -339,7 +342,7 @@ mod tests {
     /// and need to tell that apart from a keychain that is actually broken.
     fn get_missing_key_reports_not_found() {
         let store = MacosKeychainStore::new(unique_service());
-        let err = store.get("missing-key").err().expect("error");
+        let err = store.get("missing-key").expect_err("error");
         assert!(
             matches!(err, SecretError::InvalidInput),
             "expected not-found, got {err:?}"

--- a/crates/agent_secrets/src/session.rs
+++ b/crates/agent_secrets/src/session.rs
@@ -8,9 +8,12 @@ pub struct SessionContext {
     pub verified: bool,
     pub claims: Vec<String>,
     /// The peer's DID, once established for this session. `None` until an
-    /// identity layer sets it (asserted by the caller in the app-layer phase;
-    /// cryptographically proven from a DID-signed token in later phases).
+    /// identity layer sets it. On the agentbridge SLIM path this is proven
+    /// from a DID-signed payload (`did_proven`); a locally set `verified`
+    /// bool is not application auth.
     pub did: Option<String>,
+    /// True only after a signature on the message bound this [`did`].
+    pub did_proven: bool,
 }
 
 impl SessionContext {
@@ -21,12 +24,43 @@ impl SessionContext {
             verified: false,
             claims: Vec::new(),
             did: None,
+            did_proven: false,
         }
     }
 
-    /// Attach the peer's DID to this session context.
+    /// Attach a DID that has not been proven. Not sufficient for the
+    /// agentbridge SLIM send/recv gate.
     pub fn with_did(mut self, did: impl Into<String>) -> Self {
         self.did = Some(did.into());
+        self.did_proven = false;
         self
+    }
+
+    /// Attach a DID that was verified from a signature on the message.
+    pub fn with_proven_did(mut self, did: impl Into<String>) -> Self {
+        self.did = Some(did.into());
+        self.did_proven = true;
+        self.verified = true;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_did_does_not_mark_proven() {
+        let session = SessionContext::new("agent", "s").with_did("did:key:zexample");
+        assert_eq!(session.did.as_deref(), Some("did:key:zexample"));
+        assert!(!session.did_proven);
+        assert!(!session.verified);
+    }
+
+    #[test]
+    fn with_proven_did_sets_proof_and_verified() {
+        let session = SessionContext::new("agent", "s").with_proven_did("did:key:zexample");
+        assert!(session.did_proven);
+        assert!(session.verified);
     }
 }

--- a/crates/agent_transport_slim/src/lib.rs
+++ b/crates/agent_transport_slim/src/lib.rs
@@ -327,4 +327,20 @@ mod tests {
         let err = channel.recv(&ctx).unwrap_err();
         assert!(matches!(err, SecretError::NotAuthorized));
     }
+
+    #[test]
+    fn recv_accepts_envelope_when_session_did_is_unset() {
+        let identity = shadi_identity::AgentIdentity::generate().unwrap();
+        let envelope = shadi_identity::wrap_signed_message(&identity, b"task").unwrap();
+        let session = TestSession {
+            sent: Mutex::new(Vec::new()),
+            recv_data: envelope,
+        };
+        let store = MemoryStore;
+        let allow = AllowVerifier;
+        let channel = SecureAgentChannel::new(&session, &allow, &store).with_signer(&identity);
+        let ctx = SessionContext::new("agent", "session");
+        let payload = channel.recv(&ctx).unwrap();
+        assert_eq!(payload, b"task");
+    }
 }

--- a/crates/agent_transport_slim/src/lib.rs
+++ b/crates/agent_transport_slim/src/lib.rs
@@ -4,7 +4,10 @@
 mod native;
 mod stdio_bridge;
 
-use agent_secrets::{AgentVerifier, SecretResult, SecretStore, SessionContext};
+use agent_secrets::{AgentVerifier, SecretError, SecretResult, SecretStore, SessionContext};
+use shadi_identity::{
+    looks_like_did_proof, unwrap_signed_message, wrap_signed_message, AgentIdentity,
+};
 
 pub use native::{NativeSlimBootstrap, NativeSlimSession};
 pub use stdio_bridge::{
@@ -21,6 +24,9 @@ pub struct SecureAgentChannel<'a> {
     session: &'a dyn SlimSession,
     verifier: &'a dyn AgentVerifier,
     store: &'a dyn SecretStore,
+    /// When set, send wraps the payload in a DID-proof envelope and recv
+    /// requires a valid envelope. This is the agentbridge SLIM path.
+    signer: Option<&'a AgentIdentity>,
 }
 
 impl<'a> SecureAgentChannel<'a> {
@@ -33,19 +39,63 @@ impl<'a> SecureAgentChannel<'a> {
             session,
             verifier,
             store,
+            signer: None,
         }
     }
 
+    /// Prove the agent DID on every send/recv. The verifier sees a
+    /// [`SessionContext`] with `did_proven` only after the signature checks.
+    pub fn with_signer(mut self, identity: &'a AgentIdentity) -> Self {
+        self.signer = Some(identity);
+        self
+    }
+
     pub fn send(&self, ctx: &SessionContext, message: &[u8]) -> SecretResult<()> {
-        self.verifier.verify(ctx)?;
+        let outgoing = if let Some(identity) = self.signer {
+            wrap_signed_message(identity, message).map_err(|_| SecretError::NotAuthorized)?
+        } else {
+            message.to_vec()
+        };
+        self.authorize_bytes(ctx, &outgoing)?;
         let _ = self.store;
-        self.session.send(message)
+        self.session.send(&outgoing)
     }
 
     pub fn recv(&self, ctx: &SessionContext) -> SecretResult<Vec<u8>> {
+        let raw = self.session.recv()?;
+        if self.signer.is_some() || looks_like_did_proof(&raw) {
+            let proven = self.authorize_bytes(ctx, &raw)?;
+            return Ok(proven.unwrap_or(raw));
+        }
         self.verifier.verify(ctx)?;
         let _ = self.store;
-        self.session.recv()
+        Ok(raw)
+    }
+
+    /// Verify a DID-proof envelope (or reject unsigned bytes on a proven
+    /// channel). Returns the inner payload when an envelope was present.
+    fn authorize_bytes(
+        &self,
+        ctx: &SessionContext,
+        bytes: &[u8],
+    ) -> SecretResult<Option<Vec<u8>>> {
+        if looks_like_did_proof(bytes) {
+            let verified = unwrap_signed_message(bytes).map_err(|_| SecretError::NotAuthorized)?;
+            if let Some(expected) = ctx.did.as_deref() {
+                if expected != verified.did {
+                    // Mesh member presenting another agent's DID.
+                    return Err(SecretError::NotAuthorized);
+                }
+            }
+            let proven = ctx.clone().with_proven_did(&verified.did);
+            self.verifier.verify(&proven)?;
+            return Ok(Some(verified.payload));
+        }
+        if self.signer.is_some() {
+            return Err(SecretError::NotAuthorized);
+        }
+        self.verifier.verify(ctx)?;
+        Ok(None)
     }
 }
 
@@ -210,5 +260,71 @@ mod tests {
         store.put("key", b"value", SecretPolicy::default()).unwrap();
         assert!(store.list_keys().unwrap().is_empty());
         store.delete("key").unwrap();
+    }
+
+    #[test]
+    fn send_wraps_payload_in_did_proof() {
+        let session = TestSession::new();
+        let store = MemoryStore;
+        let allow = AllowVerifier;
+        let identity = shadi_identity::AgentIdentity::generate().unwrap();
+        let channel = SecureAgentChannel::new(&session, &allow, &store).with_signer(&identity);
+        let ctx = SessionContext::new("agent", "session").with_did(identity.did());
+
+        channel.send(&ctx, b"hello").unwrap();
+        let sent = session.sent.lock().unwrap().clone();
+        assert!(shadi_identity::looks_like_did_proof(&sent));
+        let verified = shadi_identity::unwrap_signed_message(&sent).unwrap();
+        assert_eq!(verified.did, identity.did());
+        assert_eq!(verified.payload, b"hello");
+    }
+
+    #[test]
+    fn recv_rejects_forged_peer_did() {
+        let honest = shadi_identity::AgentIdentity::generate().unwrap();
+        let impostor = shadi_identity::AgentIdentity::generate().unwrap();
+        let envelope = shadi_identity::wrap_signed_message(&honest, b"task").unwrap();
+
+        let session = TestSession {
+            sent: Mutex::new(Vec::new()),
+            recv_data: envelope,
+        };
+        let store = MemoryStore;
+        let proof = agent_secrets::DidProofVerifier;
+        let channel = SecureAgentChannel::new(&session, &proof, &store).with_signer(&impostor);
+        // Context claims the impostor's DID; the message is signed by someone else.
+        let ctx = SessionContext::new("agent", "session").with_did(impostor.did());
+
+        let err = channel.recv(&ctx).unwrap_err();
+        assert!(matches!(err, SecretError::NotAuthorized));
+    }
+
+    #[test]
+    fn recv_accepts_matching_proven_did() {
+        let honest = shadi_identity::AgentIdentity::generate().unwrap();
+        let envelope = shadi_identity::wrap_signed_message(&honest, b"task").unwrap();
+        let session = TestSession {
+            sent: Mutex::new(Vec::new()),
+            recv_data: envelope,
+        };
+        let store = MemoryStore;
+        let proof = agent_secrets::DidProofVerifier;
+        let channel = SecureAgentChannel::new(&session, &proof, &store).with_signer(&honest);
+        let ctx = SessionContext::new("agent", "session").with_did(honest.did());
+
+        let payload = channel.recv(&ctx).unwrap();
+        assert_eq!(payload, b"task");
+    }
+
+    #[test]
+    fn proven_channel_rejects_unsigned_recv() {
+        let identity = shadi_identity::AgentIdentity::generate().unwrap();
+        let session = TestSession::new();
+        let store = MemoryStore;
+        let proof = agent_secrets::DidProofVerifier;
+        let channel = SecureAgentChannel::new(&session, &proof, &store).with_signer(&identity);
+        let ctx = SessionContext::new("agent", "session").with_did(identity.did());
+        let err = channel.recv(&ctx).unwrap_err();
+        assert!(matches!(err, SecretError::NotAuthorized));
     }
 }

--- a/crates/agent_transport_slim/src/native.rs
+++ b/crates/agent_transport_slim/src/native.rs
@@ -243,22 +243,23 @@ fn build_client_config() -> Result<ClientConfig, String> {
 }
 
 fn build_client_config_for_endpoint(endpoint: &str, tls: &TlsMaterial) -> ClientConfig {
-    let mut config = ClientConfig::default();
-    config.endpoint = resolve_client_endpoint_value(endpoint);
-    config.tls = TlsClientConfig {
-        insecure: false,
-        insecure_skip_verify: false,
-        source: TlsSource::File {
-            cert: tls.cert.display().to_string(),
-            key: tls.key.display().to_string(),
+    ClientConfig {
+        endpoint: resolve_client_endpoint_value(endpoint),
+        tls: TlsClientConfig {
+            insecure: false,
+            insecure_skip_verify: false,
+            source: TlsSource::File {
+                cert: tls.cert.display().to_string(),
+                key: tls.key.display().to_string(),
+            },
+            ca_source: CaSource::File {
+                path: tls.ca.display().to_string(),
+            },
+            include_system_ca_certs_pool: false,
+            tls_version: "tls1.3".to_string(),
         },
-        ca_source: CaSource::File {
-            path: tls.ca.display().to_string(),
-        },
-        include_system_ca_certs_pool: false,
-        tls_version: "tls1.3".to_string(),
-    };
-    config
+        ..ClientConfig::default()
+    }
 }
 
 fn resolve_client_tls_material() -> Result<TlsMaterial, String> {
@@ -552,22 +553,23 @@ mod tests {
 
     #[cfg(not(windows))]
     fn build_test_server_config(endpoint: &str, tls: &TlsMaterial) -> slim_bindings::ServerConfig {
-        let mut config = slim_bindings::ServerConfig::default();
-        config.endpoint = endpoint.to_string();
-        config.tls = slim_bindings::TlsServerConfig {
-            insecure: false,
-            source: TlsSource::File {
-                cert: tls.cert.display().to_string(),
-                key: tls.key.display().to_string(),
+        slim_bindings::ServerConfig {
+            endpoint: endpoint.to_string(),
+            tls: slim_bindings::TlsServerConfig {
+                insecure: false,
+                source: TlsSource::File {
+                    cert: tls.cert.display().to_string(),
+                    key: tls.key.display().to_string(),
+                },
+                client_ca: CaSource::File {
+                    path: tls.ca.display().to_string(),
+                },
+                include_system_ca_certs_pool: Some(false),
+                tls_version: Some("tls1.3".to_string()),
+                reload_client_ca_file: Some(false),
             },
-            client_ca: CaSource::File {
-                path: tls.ca.display().to_string(),
-            },
-            include_system_ca_certs_pool: Some(false),
-            tls_version: Some("tls1.3".to_string()),
-            reload_client_ca_file: Some(false),
-        };
-        config
+            ..slim_bindings::ServerConfig::default()
+        }
     }
 
     #[cfg(not(windows))]

--- a/crates/agentbridge/src/adapters/cursor_agent.rs
+++ b/crates/agentbridge/src/adapters/cursor_agent.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::{
     adapter::{CliAdapter, CliAdapterError},
     context::{ArtifactPayload, ConversationMessage, ContextPacket},
+    subprocess::TrackedSubprocess,
 };
 
 /// Adapter for the Cursor Agent CLI (`cursor-agent`).
@@ -18,6 +19,7 @@ pub struct CursorAgentAdapter {
     id: AgentId,
     work_dir: PathBuf,
     session_id: std::sync::Mutex<Option<String>>,
+    subprocess: TrackedSubprocess,
 }
 
 impl CursorAgentAdapter {
@@ -26,6 +28,7 @@ impl CursorAgentAdapter {
             id: AgentId(id.into()),
             work_dir: work_dir.into(),
             session_id: std::sync::Mutex::new(None),
+            subprocess: TrackedSubprocess::new(),
         }
     }
 
@@ -57,8 +60,9 @@ impl CursorAgentAdapter {
 
         cmd.arg(prompt);
 
-        let output = cmd
-            .output()
+        let output = self
+            .subprocess
+            .output(&mut cmd)
             .map_err(|e| CliAdapterError::Subprocess(format!("failed to run cursor-agent: {e}")))?;
 
         if !output.status.success() && output.stdout.is_empty() {
@@ -117,6 +121,10 @@ impl CliAdapter for CursorAgentAdapter {
 
     fn execute_prompt(&self, prompt: &str) -> Result<String, CliAdapterError> {
         self.run_print(prompt, None)
+    }
+
+    fn kill_in_flight(&self) {
+        self.subprocess.kill();
     }
 }
 

--- a/crates/agentbridge_cli/src/commands/coordinate.rs
+++ b/crates/agentbridge_cli/src/commands/coordinate.rs
@@ -30,13 +30,10 @@ struct AgentEntry {
 ///
 /// With N agents and quorum = N:
 ///
-///   1. Agent 1 proposes  → engine: Applied (1/N)
-///   2. Agent 2 proposes  → engine: Applied (2/N)
-///      → vote round: agents 1,2 each endorse a proposal
-///   3. Agent 3 proposes  → engine: Applied (3/N)
-///      → vote round: agents 1,2,3 each endorse a proposal
-///   ...
-///   N. Agent N proposes  → engine: FINALIZED (votes already counted!)
+/// 1. Agent 1 proposes → engine: Applied (1/N)
+/// 2. Agent 2 proposes → engine: Applied (2/N), then a vote round
+/// 3. Agent 3 proposes → engine: Applied (3/N), then a vote round
+/// 4. Agent N proposes → engine: FINALIZED (votes already counted)
 ///
 /// This guarantees the endorsement phase actually runs before finalization,
 /// so the winner is the agent whose implementation earned the most peer votes.

--- a/crates/agentbridge_cli/src/commands/delegate.rs
+++ b/crates/agentbridge_cli/src/commands/delegate.rs
@@ -5,6 +5,10 @@ use shadi_mas::{
 
 /// Delegate a single task to a remote agentbridge adapter over A2A/SLIM.
 ///
+/// Remote `TASK_STATE_AUTH_REQUIRED` is handled by `LiveA2ATaskAdapter`:
+/// re-prove the agent DID, optionally escalate (`SHADI_AUTH_REQUIRED_POLICY=ask`),
+/// then deny with a reason on timeout or repeat bound.
+///
 /// The adapter must be registered and listening on the SLIM node. Use
 /// `agentbridge register --tool <name>` in a separate terminal first.
 /// Coding-agent adapters authenticate via DID/keys only (`SHADI_SLIM_AUTH=did`,

--- a/crates/agentbridge_cli/src/commands/handoff.rs
+++ b/crates/agentbridge_cli/src/commands/handoff.rs
@@ -1,57 +1,65 @@
 use agentbridge::{
-    adapters::generic_stdio::GenericStdioAdapter,
+    adapters::{
+        claude_code::ClaudeCodeAdapter,
+        codex::CodexAdapter,
+        copilot::CopilotAdapter,
+        cursor_agent::CursorAgentAdapter,
+        generic_stdio::GenericStdioAdapter,
+    },
     CliAdapter, ContextPacket,
 };
+use shadi_mas::{
+    Epoch, PatternKind, TaskAdapter, TaskEnvelope,
+    experiments::{LiveA2ATaskAdapter, LiveA2ATaskAdapterConfig},
+};
 use std::path::Path;
+use std::sync::Arc;
 
 /// Transfer context from one CLI tool to another.
 ///
-/// Phase 1 workflow (both tools must be `generic-stdio` subprocess adapters):
-///   1. Snapshot the source adapter → `ContextPacket`
-///   2. Optionally persist the packet to `--save <path>` for recovery
-///   3. Inject the packet into the destination adapter
+/// `--from` / `--to` accept the same specs as `coordinate`:
+/// `claude-code`, `copilot`, `codex`, `cursor-agent`, `generic-stdio:<cmd>`,
+/// `slim:<id>`, plus a bare subprocess command (Phase 1 GenericStdio).
 ///
-/// Phase 2 will replace the subprocess-based source/dest with native adapters
-/// (claude-code, copilot, codex) and route the packet over A2A/SLIM.
+/// The snapshot is an LLM summary of the source session this cycle, not a
+/// true session export. `--save` / `--from-file` still persist the packet.
 pub fn run(
-    from_cmd: &str,
-    to_cmd: &str,
+    from_spec: &str,
+    to_spec: &str,
     save: Option<&str>,
+    slim_endpoint: &str,
 ) -> anyhow::Result<()> {
-    // Spawn source adapter.
-    let src = GenericStdioAdapter::spawn("source", from_cmd, &[])?;
-    println!("Source adapter '{}' connected.", from_cmd);
+    let src = open_peer(from_spec, slim_endpoint)?;
+    println!("Source '{}' connected.", src.label());
 
-    // Snapshot context.
-    let ctx: ContextPacket = src.snapshot_context().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let ctx = src.snapshot().map_err(|e| anyhow::anyhow!("{e}"))?;
     println!(
-        "Captured context: {} messages, {} files, {} artifacts.",
+        "Captured context (LLM session summary, not a full export): {} messages, {} files, {} artifacts.",
         ctx.conversation.len(),
         ctx.code_context.files.len(),
         ctx.artifacts.len(),
     );
 
-    // Persist if requested.
     if let Some(path) = save {
         let bytes = ctx.to_bytes()?;
         std::fs::write(path, &bytes)?;
         println!("Context saved to {path}.");
     }
 
-    // Spawn destination adapter.
-    let dst = GenericStdioAdapter::spawn("destination", to_cmd, &[])?;
-    println!("Destination adapter '{}' connected.", to_cmd);
-
-    // Inject context.
-    dst.inject_context(&ctx).map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("Context successfully handed off to '{}'.", to_cmd);
-
+    let dst = open_peer(to_spec, slim_endpoint)?;
+    println!("Destination '{}' connected.", dst.label());
+    dst.inject(&ctx).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("Context successfully handed off to '{}'.", dst.label());
     Ok(())
 }
 
 /// Load a previously saved `ContextPacket` from disk and inject it into a
 /// destination adapter. Useful for resuming after a crash.
-pub fn run_from_file(context_path: &Path, to_cmd: &str) -> anyhow::Result<()> {
+pub fn run_from_file(
+    context_path: &Path,
+    to_spec: &str,
+    slim_endpoint: &str,
+) -> anyhow::Result<()> {
     let bytes = std::fs::read(context_path)?;
     let ctx = ContextPacket::from_bytes(&bytes)?;
     println!(
@@ -60,9 +68,209 @@ pub fn run_from_file(context_path: &Path, to_cmd: &str) -> anyhow::Result<()> {
         ctx.conversation.len(),
     );
 
-    let dst = GenericStdioAdapter::spawn("destination", to_cmd, &[])?;
-    dst.inject_context(&ctx).map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("Context injected into '{to_cmd}'.");
-
+    let dst = open_peer(to_spec, slim_endpoint)?;
+    dst.inject(&ctx).map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("Context injected into '{}'.", dst.label());
     Ok(())
+}
+
+enum HandoffPeer {
+    Local {
+        label: String,
+        adapter: Arc<dyn CliAdapter>,
+    },
+    Slim {
+        agent_id: String,
+        adapter: LiveA2ATaskAdapter,
+    },
+}
+
+impl HandoffPeer {
+    fn label(&self) -> &str {
+        match self {
+            HandoffPeer::Local { label, .. } => label,
+            HandoffPeer::Slim { agent_id, .. } => agent_id,
+        }
+    }
+
+    fn snapshot(&self) -> Result<ContextPacket, String> {
+        match self {
+            HandoffPeer::Local { adapter, .. } => adapter
+                .snapshot_context()
+                .map_err(|e| e.to_string()),
+            HandoffPeer::Slim { agent_id, adapter } => {
+                let summary = dispatch_prompt(
+                    adapter,
+                    "Summarize this session for handoff: current goal, key decisions, files changed, what remains.",
+                )?;
+                let mut pkt = ContextPacket::new(agent_id.clone());
+                pkt.conversation.push(agentbridge::ConversationMessage {
+                    role: "assistant".to_string(),
+                    content: summary.clone(),
+                });
+                pkt.artifacts.push(agentbridge::ArtifactPayload {
+                    name: "session_summary.md".to_string(),
+                    content: summary,
+                    media_type: "text/markdown".to_string(),
+                });
+                Ok(pkt)
+            }
+        }
+    }
+
+    fn inject(&self, ctx: &ContextPacket) -> Result<(), String> {
+        match self {
+            HandoffPeer::Local { adapter, .. } => adapter.inject_context(ctx).map_err(|e| e.to_string()),
+            HandoffPeer::Slim { adapter, .. } => {
+                let prompt = render_inject_prompt(ctx);
+                let _ = dispatch_prompt(adapter, &prompt)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+fn dispatch_prompt(adapter: &LiveA2ATaskAdapter, prompt: &str) -> Result<String, String> {
+    let task_id = format!("handoff-{}", uuid::Uuid::new_v4());
+    adapter.dispatch(TaskEnvelope {
+        task_id: task_id.clone(),
+        pattern: PatternKind::Development,
+        epoch: Epoch(0),
+        correlation_id: Some(task_id),
+        body: prompt.as_bytes().to_vec(),
+    })?;
+    let dispatches = adapter.dispatches()?;
+    dispatches
+        .last()
+        .map(|record| record.response.clone())
+        .ok_or_else(|| "handoff dispatch produced no response".to_string())
+}
+
+fn render_inject_prompt(ctx: &ContextPacket) -> String {
+    let mut system = format!(
+        "You are continuing a coding session from {}.\n\n",
+        ctx.source_agent
+    );
+    for msg in &ctx.conversation {
+        system.push_str(&format!("[{}]: {}\n", msg.role, msg.content));
+    }
+    for art in &ctx.artifacts {
+        system.push_str(&format!("\n## {}\n{}\n", art.name, art.content));
+    }
+    system.push_str("\nAcknowledge you have received the handoff context.");
+    system
+}
+
+fn open_peer(spec: &str, slim_endpoint: &str) -> anyhow::Result<HandoffPeer> {
+    if spec.starts_with("claude-code") {
+        let work_dir = spec
+            .strip_prefix("claude-code:")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+        return Ok(HandoffPeer::Local {
+            label: "claude-code".to_string(),
+            adapter: Arc::new(ClaudeCodeAdapter::new("claude-code", work_dir)),
+        });
+    }
+    if spec.starts_with("cursor-agent") {
+        let work_dir = spec
+            .strip_prefix("cursor-agent:")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+        return Ok(HandoffPeer::Local {
+            label: "cursor-agent".to_string(),
+            adapter: Arc::new(CursorAgentAdapter::new("cursor-agent", work_dir)),
+        });
+    }
+    if spec.starts_with("copilot") {
+        let work_dir = spec
+            .strip_prefix("copilot:")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+        return Ok(HandoffPeer::Local {
+            label: "copilot".to_string(),
+            adapter: Arc::new(CopilotAdapter::new("copilot", work_dir)),
+        });
+    }
+    if spec.starts_with("codex") {
+        let work_dir = spec
+            .strip_prefix("codex:")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+        return Ok(HandoffPeer::Local {
+            label: "codex".to_string(),
+            adapter: Arc::new(CodexAdapter::new("codex", work_dir)),
+        });
+    }
+    if let Some(cmd) = spec.strip_prefix("generic-stdio:") {
+        return spawn_stdio("generic-stdio", cmd);
+    }
+    if let Some(rest) = spec.strip_prefix("slim:") {
+        let (agent_id, endpoint) = rest
+            .split_once('@')
+            .map(|(id, ep)| (id.to_string(), ep.to_string()))
+            .unwrap_or_else(|| (rest.to_string(), slim_endpoint.to_string()));
+        let config = LiveA2ATaskAdapterConfig {
+            endpoint,
+            agent_id: "handoff".to_string(),
+            local_name: Some("agntcy/shadi/handoff-a2a".to_string()),
+            peer_agent_id: agent_id.clone(),
+            destination: Some(format!("agntcy/shadi/{agent_id}-a2a")),
+        };
+        return Ok(HandoffPeer::Slim {
+            agent_id,
+            adapter: LiveA2ATaskAdapter::new(config),
+        });
+    }
+    spawn_stdio(spec, spec)
+}
+
+fn spawn_stdio(label: &str, cmd: &str) -> anyhow::Result<HandoffPeer> {
+    let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
+    let prog = parts[0];
+    let args: Vec<&str> = if parts.len() > 1 {
+        parts[1].split_whitespace().collect()
+    } else {
+        vec![]
+    };
+    let adapter = GenericStdioAdapter::spawn(label, prog, &args)
+        .map_err(|e| anyhow::anyhow!("failed to spawn {label}: {e}"))?;
+    Ok(HandoffPeer::Local {
+        label: label.to_string(),
+        adapter: Arc::new(adapter),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_peer_accepts_native_and_slim_specs() {
+        let claude = open_peer("claude-code", "127.0.0.1:47357").expect("claude");
+        assert_eq!(claude.label(), "claude-code");
+        let copilot = open_peer("copilot", "127.0.0.1:47357").expect("copilot");
+        assert_eq!(copilot.label(), "copilot");
+        let codex = open_peer("codex", "127.0.0.1:47357").expect("codex");
+        assert_eq!(codex.label(), "codex");
+        let cursor = open_peer("cursor-agent", "127.0.0.1:47357").expect("cursor");
+        assert_eq!(cursor.label(), "cursor-agent");
+        match open_peer("slim:peer@10.0.0.1:9", "127.0.0.1:47357").expect("slim") {
+            HandoffPeer::Slim { agent_id, .. } => assert_eq!(agent_id, "peer"),
+            _ => panic!("expected slim peer"),
+        }
+    }
+
+    #[test]
+    fn render_inject_prompt_includes_source_and_summary() {
+        let mut ctx = ContextPacket::new("claude-code");
+        ctx.conversation.push(agentbridge::ConversationMessage {
+            role: "assistant".to_string(),
+            content: "working on parser".to_string(),
+        });
+        let prompt = render_inject_prompt(&ctx);
+        assert!(prompt.contains("claude-code"));
+        assert!(prompt.contains("working on parser"));
+        assert!(prompt.contains("Acknowledge"));
+    }
 }

--- a/crates/agentbridge_cli/src/commands/register.rs
+++ b/crates/agentbridge_cli/src/commands/register.rs
@@ -8,11 +8,12 @@ use a2a_server::{
     AgentExecutor, DefaultRequestHandler, InMemoryTaskStore, RequestHandler,
     ServiceParams as A2AServiceParams,
 };
-use agentbridge::{
+use         agentbridge::{
     adapters::{
         claude_code::ClaudeCodeAdapter,
         codex::CodexAdapter,
         copilot::CopilotAdapter,
+        cursor_agent::CursorAgentAdapter,
         generic_stdio::GenericStdioAdapter,
     },
     dir_registry::DirError,
@@ -124,9 +125,36 @@ pub fn run(
                 println!("Adapter ready. Use 'agentbridge handoff' or 'agentbridge coordinate'.");
             }
         }
+        "cursor-agent" => {
+            let work_dir = command
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| ".".into()));
+            let adapter = Arc::new(CursorAgentAdapter::new("cursor-agent", work_dir));
+            println!(
+                "Registered Cursor Agent adapter (agent id: {})",
+                adapter.agent_id().0
+            );
+            if let Some(endpoint) = slim_endpoint {
+                println!(
+                    "Starting SLIM A2A listener on {endpoint} as agntcy/shadi/cursor-agent-a2a ..."
+                );
+                run_slim_listener("cursor-agent", adapter, endpoint, dir_publish.as_ref())
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            } else {
+                if let Some(opts) = dir_publish.as_ref() {
+                    publish_card_to_dir(
+                        "cursor-agent",
+                        None,
+                        best_effort_did("cursor-agent").as_deref(),
+                        opts,
+                    )?;
+                }
+                println!("Adapter ready. Use 'agentbridge handoff' or 'agentbridge coordinate'.");
+            }
+        }
         other => {
             anyhow::bail!(
-                "Unknown tool type '{}'. Supported: generic-stdio, claude-code, copilot, codex.",
+                "Unknown tool type '{}'. Supported: generic-stdio, claude-code, copilot, codex, cursor-agent.",
                 other
             );
         }
@@ -303,7 +331,18 @@ impl RequestHandler for AgentBridgeRequestHandler {
         req: SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
         self.ready.notify_waiters();
-        self.inner.send_message(params, req).await
+        match admit_incoming_message(req) {
+            IncomingAdmission::Proven { request, did } => {
+                tracing::info!(%did, "admitted A2A message with proven agent DID");
+                self.inner.send_message(params, request).await
+            }
+            IncomingAdmission::AuthRequired { request, reason } => {
+                Ok(parked_auth_required(&request, &reason))
+            }
+            IncomingAdmission::Forged { request, reason } => {
+                Ok(rejected_forged_did(&request, &reason))
+            }
+        }
     }
 
     async fn send_streaming_message(
@@ -312,7 +351,34 @@ impl RequestHandler for AgentBridgeRequestHandler {
         req: SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         self.ready.notify_waiters();
-        self.inner.send_streaming_message(params, req).await
+        match admit_incoming_message(req) {
+            IncomingAdmission::Proven { request, did } => {
+                tracing::info!(%did, "admitted A2A stream with proven agent DID");
+                self.inner.send_streaming_message(params, request).await
+            }
+            IncomingAdmission::AuthRequired { request, reason } => {
+                let task = parked_auth_required(&request, &reason);
+                Ok(Box::pin(futures::stream::once(async move {
+                    match task {
+                        SendMessageResponse::Task(task) => Ok(StreamResponse::Task(task)),
+                        SendMessageResponse::Message(message) => {
+                            Ok(StreamResponse::Message(message))
+                        }
+                    }
+                })))
+            }
+            IncomingAdmission::Forged { request, reason } => {
+                let task = rejected_forged_did(&request, &reason);
+                Ok(Box::pin(futures::stream::once(async move {
+                    match task {
+                        SendMessageResponse::Task(task) => Ok(StreamResponse::Task(task)),
+                        SendMessageResponse::Message(message) => {
+                            Ok(StreamResponse::Message(message))
+                        }
+                    }
+                })))
+            }
+        }
     }
 
     async fn get_task(
@@ -671,6 +737,107 @@ fn parse_name(name: &str) -> Result<Name, String> {
     })
 }
 
+#[derive(Debug)]
+enum IncomingAdmission {
+    Proven {
+        did: String,
+        request: SendMessageRequest,
+    },
+    AuthRequired {
+        request: SendMessageRequest,
+        reason: String,
+    },
+    Forged {
+        request: SendMessageRequest,
+        reason: String,
+    },
+}
+
+/// Application-layer gate: the payload must be signed by the claimed agent DID.
+/// Missing/unsigned proof parks the task (`AUTH_REQUIRED`). A mesh member that
+/// presents another agent's DID is rejected.
+fn admit_incoming_message(mut req: SendMessageRequest) -> IncomingAdmission {
+    let text = extract_text(&req.message);
+    if text == "(no text parts)" || !shadi_identity::looks_like_did_proof(text.as_bytes()) {
+        return IncomingAdmission::AuthRequired {
+            request: req,
+            reason: "DID proof required on the message".to_string(),
+        };
+    }
+    match shadi_identity::unwrap_signed_message(text.as_bytes()) {
+        Ok(verified) => {
+            let payload = String::from_utf8_lossy(&verified.payload).into_owned();
+            req.message.parts = vec![Part::text(payload)];
+            IncomingAdmission::Proven {
+                did: verified.did,
+                request: req,
+            }
+        }
+        Err(shadi_identity::IdentityError::Proof(msg)) if msg.contains("forged DID") => {
+            IncomingAdmission::Forged {
+                request: req,
+                reason: msg,
+            }
+        }
+        Err(_) => IncomingAdmission::AuthRequired {
+            request: req,
+            reason: "DID proof required on the message".to_string(),
+        },
+    }
+}
+
+fn task_ids_from(req: &SendMessageRequest) -> (String, String) {
+    let task_id = req
+        .message
+        .task_id
+        .clone()
+        .unwrap_or_else(new_task_id);
+    let context_id = req
+        .message
+        .context_id
+        .clone()
+        .unwrap_or_else(new_context_id);
+    (task_id, context_id)
+}
+
+fn parked_auth_required(req: &SendMessageRequest, reason: &str) -> SendMessageResponse {
+    let (task_id, context_id) = task_ids_from(req);
+    SendMessageResponse::Task(Task {
+        id: task_id,
+        context_id,
+        status: TaskStatus {
+            state: TaskState::AuthRequired,
+            message: Some(Message::new(
+                Role::Agent,
+                vec![Part::text(reason.to_string())],
+            )),
+            timestamp: None,
+        },
+        artifacts: None,
+        history: None,
+        metadata: None,
+    })
+}
+
+fn rejected_forged_did(req: &SendMessageRequest, reason: &str) -> SendMessageResponse {
+    let (task_id, context_id) = task_ids_from(req);
+    SendMessageResponse::Task(Task {
+        id: task_id,
+        context_id,
+        status: TaskStatus {
+            state: TaskState::Rejected,
+            message: Some(Message::new(
+                Role::Agent,
+                vec![Part::text(reason.to_string())],
+            )),
+            timestamp: None,
+        },
+        artifacts: None,
+        history: None,
+        metadata: None,
+    })
+}
+
 fn extract_text(message: &Message) -> String {
     let text = message
         .parts
@@ -746,6 +913,67 @@ mod tests {
     fn preview_truncates_to_first_nonblank_line() {
         assert_eq!(preview("\n\nhello world", 5), "hello…");
         assert_eq!(preview("short", 20), "short");
+    }
+
+    fn sample_request(text: impl Into<String>) -> SendMessageRequest {
+        SendMessageRequest {
+            message: Message::new(Role::User, vec![Part::text(text.into())]),
+            configuration: None,
+            metadata: None,
+            tenant: None,
+        }
+    }
+
+    #[test]
+    fn admit_unsigned_message_parks_auth_required() {
+        match admit_incoming_message(sample_request("plain task")) {
+            IncomingAdmission::AuthRequired { reason, .. } => {
+                assert!(reason.contains("DID proof required"));
+            }
+            other => panic!("expected AUTH_REQUIRED, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn admit_forged_did_is_rejected() {
+        let honest = shadi_identity::AgentIdentity::generate().unwrap();
+        let impostor = shadi_identity::AgentIdentity::generate().unwrap();
+        let envelope = shadi_identity::wrap_signed_message(&honest, b"task").unwrap();
+        // Claim the impostor's DID while keeping the honest signature.
+        let sig_line = {
+            let text = String::from_utf8(envelope.clone()).unwrap();
+            text.lines().nth(2).unwrap().to_string()
+        };
+        let forged = format!(
+            "SHADI-DID-PROOF/1\n{}\n{}\ntask",
+            impostor.did(),
+            sig_line
+        );
+        match admit_incoming_message(sample_request(forged)) {
+            IncomingAdmission::Forged { reason, .. } => {
+                assert!(reason.contains("forged DID"), "{reason}");
+            }
+            IncomingAdmission::AuthRequired { reason, .. } => {
+                panic!("forged DID must be rejected, not parked: {reason}");
+            }
+            IncomingAdmission::Proven { did, .. } => {
+                panic!("forged DID must not prove as {did}");
+            }
+        }
+    }
+
+    #[test]
+    fn admit_honest_proof_unwraps_payload() {
+        let id = shadi_identity::AgentIdentity::generate().unwrap();
+        let envelope = shadi_identity::wrap_signed_message(&id, b"real prompt").unwrap();
+        let text = String::from_utf8(envelope).unwrap();
+        match admit_incoming_message(sample_request(text)) {
+            IncomingAdmission::Proven { did, request } => {
+                assert_eq!(did, id.did());
+                assert_eq!(extract_text(&request.message), "real prompt");
+            }
+            _ => panic!("honest proof must be admitted"),
+        }
     }
 
     #[test]

--- a/crates/agentbridge_cli/src/main.rs
+++ b/crates/agentbridge_cli/src/main.rs
@@ -64,12 +64,18 @@ enum Cmd {
     },
 
     /// Hand off context from one CLI tool to another.
+    ///
+    /// `--from` / `--to` accept the same specs as `coordinate`
+    /// (`claude-code`, `copilot`, `codex`, `cursor-agent`,
+    /// `generic-stdio:<cmd>`, `slim:<id>`). A bare command still opens
+    /// GenericStdio. The snapshot is an LLM session summary this cycle,
+    /// not a true session export.
     Handoff {
-        /// Subprocess command for the source adapter.
+        /// Source spec (native tool, generic-stdio:<cmd>, slim:<id>, or a command).
         #[arg(long)]
         from: String,
 
-        /// Subprocess command for the destination adapter.
+        /// Destination spec (same forms as --from).
         #[arg(long)]
         to: String,
 
@@ -80,6 +86,10 @@ enum Cmd {
         /// Load a saved ContextPacket instead of snapshotting a live source.
         #[arg(long, value_name = "FILE")]
         from_file: Option<String>,
+
+        /// SLIM node endpoint used for slim:<id> specs.
+        #[arg(long, env = "SLIM_ENDPOINT", default_value = "127.0.0.1:47357")]
+        slim_endpoint: String,
     },
 
     /// Delegate a single task to a remote agentbridge adapter over A2A/SLIM.
@@ -147,7 +157,7 @@ fn main() {
 
     let result = match cli.command {
         Cmd::Register { tool, command, args, dir_publish, dir_server, gh_token, slim_endpoint } => {
-            let publish_opts = dir_publish.then(|| commands::register::DirPublishOptions {
+            let publish_opts = dir_publish.then_some(commands::register::DirPublishOptions {
                 server: dir_server.as_str(),
                 gh_token: gh_token.as_deref(),
             });
@@ -162,11 +172,15 @@ fn main() {
         Cmd::List { local, dir_server, gh_token } => {
             commands::list::run(local, &dir_server, gh_token.as_deref())
         }
-        Cmd::Handoff { from, to, save, from_file } => {
+        Cmd::Handoff { from, to, save, from_file, slim_endpoint } => {
             if let Some(file) = from_file {
-                commands::handoff::run_from_file(std::path::Path::new(&file), &to)
+                commands::handoff::run_from_file(
+                    std::path::Path::new(&file),
+                    &to,
+                    &slim_endpoint,
+                )
             } else {
-                commands::handoff::run(&from, &to, save.as_deref())
+                commands::handoff::run(&from, &to, save.as_deref(), &slim_endpoint)
             }
         }
         Cmd::Delegate { prompt, to, agent_id, endpoint } => {
@@ -235,5 +249,25 @@ mod tests {
     #[test]
     fn rejects_unknown_subcommand() {
         assert!(Cli::try_parse_from(["agentbridge", "nope"]).is_err());
+    }
+
+    #[test]
+    fn parses_native_handoff_specs() {
+        let cli = Cli::try_parse_from([
+            "agentbridge",
+            "handoff",
+            "--from",
+            "claude-code",
+            "--to",
+            "copilot",
+        ])
+        .expect("parse");
+        match cli.command {
+            Cmd::Handoff { from, to, .. } => {
+                assert_eq!(from, "claude-code");
+                assert_eq!(to, "copilot");
+            }
+            _ => panic!("expected handoff subcommand"),
+        }
     }
 }

--- a/crates/shadi_identity/src/auth.rs
+++ b/crates/shadi_identity/src/auth.rs
@@ -78,6 +78,12 @@ pub fn create_app(
     service.create_app(name, provider, verifier)
 }
 
+#[cfg(test)]
+pub(crate) fn lock_slim_auth_env() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Build DID-JWT auth for `agent_id`: derive the agent key from `human_seed` (via
 /// SHADI's HKDF agent derivation) and trust the comma-separated `member_dids` as the
 /// allow-list. Pure (no environment access) so it is easy to unit-test.
@@ -197,9 +203,8 @@ mod tests {
 
     #[test]
     fn did_auth_from_env_selects_mode() {
-        // These env vars are touched by no other test in this crate, so a single
-        // sequential test needs no cross-test lock.
         use std::env;
+        let _guard = crate::auth::lock_slim_auth_env();
         let member = AgentIdentity::derive(b"human", "avatar").unwrap().did();
 
         env::remove_var("SHADI_SLIM_AUTH");

--- a/crates/shadi_identity/src/did_proof.rs
+++ b/crates/shadi_identity/src/did_proof.rs
@@ -1,0 +1,201 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Application-layer DID proof for agentbridge SLIM messages.
+//!
+//! Node auth (mesh join) is not enough: a member can present another agent's
+//! DID unless the payload is bound to the sender's `did:key` by an Ed25519
+//! signature. This module is that binding. It does not invent a new identity
+//! system — it signs with the existing [`AgentIdentity`] Ed25519 key.
+
+use crate::{parse_did_key, AgentIdentity, IdentityError, SlimAuth};
+use base64::Engine as _;
+use ed25519_dalek::Signature;
+
+const MAGIC: &[u8] = b"SHADI-DID-PROOF/1";
+const DOMAIN: &[u8] = b"SHADI-DID-PROOF/1";
+
+/// Payload plus the `did:key` that signed it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedPayload {
+    pub did: String,
+    pub payload: Vec<u8>,
+}
+
+/// True when `bytes` start with the DID-proof envelope header.
+pub fn looks_like_did_proof(bytes: &[u8]) -> bool {
+    bytes.starts_with(MAGIC) && bytes.get(MAGIC.len()) == Some(&b'\n')
+}
+
+/// Wrap `payload` in a DID-proof envelope signed by `identity`.
+pub fn wrap_signed_message(
+    identity: &AgentIdentity,
+    payload: &[u8],
+) -> Result<Vec<u8>, IdentityError> {
+    let did = identity.did();
+    let sig = identity.sign_bytes(&canonical(&did, payload));
+    let sig_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sig);
+    let mut out = Vec::with_capacity(MAGIC.len() + did.len() + sig_b64.len() + payload.len() + 4);
+    out.extend_from_slice(MAGIC);
+    out.push(b'\n');
+    out.extend_from_slice(did.as_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(sig_b64.as_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+/// Verify a DID-proof envelope and return the bound DID plus the inner payload.
+///
+/// A mesh member that copies another agent's DID into the header but signs
+/// with its own key fails here — the public key is taken from the claimed
+/// `did:key`, not from the caller.
+pub fn unwrap_signed_message(envelope: &[u8]) -> Result<VerifiedPayload, IdentityError> {
+    if !looks_like_did_proof(envelope) {
+        return Err(IdentityError::Proof(
+            "message is not a DID-proof envelope".to_string(),
+        ));
+    }
+    let (did, sig_b64, payload) = split_envelope(envelope)?;
+    if !did.starts_with("did:key:") {
+        return Err(IdentityError::Proof(format!(
+            "claimed DID is not did:key: {did}"
+        )));
+    }
+    let vk = parse_did_key(&did)?;
+    let sig_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(sig_b64.as_bytes())
+        .map_err(|_| IdentityError::Proof("invalid signature encoding".to_string()))?;
+    let sig_arr: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| IdentityError::Proof("signature must be 64 bytes".to_string()))?;
+    let sig = Signature::from_bytes(&sig_arr);
+    vk.verify_strict(&canonical(&did, payload), &sig)
+        .map_err(|_| {
+            IdentityError::Proof(
+                "forged DID: signature does not match the claimed did:key".to_string(),
+            )
+        })?;
+    Ok(VerifiedPayload {
+        did,
+        payload: payload.to_vec(),
+    })
+}
+
+/// Sign `payload` with the agent DID derived from the process environment.
+///
+/// Uses the same `SHADI_SLIM_AUTH=did` / `SLIM_HUMAN_SEED` contract as mesh
+/// join. Shared-secret node auth cannot produce an application-layer proof.
+pub fn sign_message_from_env(agent_id: &str, payload: &[u8]) -> Result<Vec<u8>, IdentityError> {
+    match crate::require_did_auth_from_env(agent_id)? {
+        SlimAuth::Did { signing_pem, did, .. } => {
+            let identity = AgentIdentity::from_pkcs8_pem(&signing_pem)?;
+            if identity.did() != did {
+                return Err(IdentityError::Proof(
+                    "env-derived identity DID does not match SlimAuth DID".to_string(),
+                ));
+            }
+            wrap_signed_message(&identity, payload)
+        }
+        SlimAuth::SharedSecret(_) => Err(IdentityError::Config(
+            "DID proof requires SHADI_SLIM_AUTH=did; shared-secret node auth is not application auth"
+                .to_string(),
+        )),
+    }
+}
+
+fn canonical(did: &str, payload: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(DOMAIN.len() + did.len() + payload.len() + 2);
+    msg.extend_from_slice(DOMAIN);
+    msg.push(0);
+    msg.extend_from_slice(did.as_bytes());
+    msg.push(0);
+    msg.extend_from_slice(payload);
+    msg
+}
+
+fn split_envelope(bytes: &[u8]) -> Result<(String, String, &[u8]), IdentityError> {
+    let mut start = 0;
+    let mut headers = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let rel = bytes[start..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .ok_or_else(|| IdentityError::Proof("truncated DID-proof envelope".to_string()))?;
+        headers.push(&bytes[start..start + rel]);
+        start += rel + 1;
+    }
+    let magic = headers[0];
+    if magic != MAGIC {
+        return Err(IdentityError::Proof("bad DID-proof magic".to_string()));
+    }
+    let did = std::str::from_utf8(headers[1])
+        .map_err(|_| IdentityError::Proof("DID is not UTF-8".to_string()))?
+        .to_string();
+    let sig = std::str::from_utf8(headers[2])
+        .map_err(|_| IdentityError::Proof("signature is not UTF-8".to_string()))?
+        .to_string();
+    if did.is_empty() || sig.is_empty() {
+        return Err(IdentityError::Proof(
+            "DID-proof envelope missing DID or signature".to_string(),
+        ));
+    }
+    Ok((did, sig, &bytes[start..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_and_unwrap_round_trips() {
+        let id = AgentIdentity::generate().unwrap();
+        let envelope = wrap_signed_message(&id, b"handoff body").unwrap();
+        assert!(looks_like_did_proof(&envelope));
+        let verified = unwrap_signed_message(&envelope).unwrap();
+        assert_eq!(verified.did, id.did());
+        assert_eq!(verified.payload, b"handoff body");
+    }
+
+    #[test]
+    fn forged_did_is_rejected() {
+        let honest = AgentIdentity::generate().unwrap();
+        let impostor = AgentIdentity::generate().unwrap();
+        let envelope = wrap_signed_message(&honest, b"task").unwrap();
+        // Swap the claimed DID for the impostor's while keeping the honest signature.
+        let parts = split_envelope(&envelope).unwrap();
+        let forged = {
+            let mut out = Vec::new();
+            out.extend_from_slice(MAGIC);
+            out.push(b'\n');
+            out.extend_from_slice(impostor.did().as_bytes());
+            out.push(b'\n');
+            out.extend_from_slice(parts.1.as_bytes());
+            out.push(b'\n');
+            out.extend_from_slice(parts.2);
+            out
+        };
+        let err = unwrap_signed_message(&forged).unwrap_err();
+        match err {
+            IdentityError::Proof(msg) => assert!(msg.contains("forged DID"), "{msg}"),
+            other => panic!("expected Proof, got {other}"),
+        }
+        let _ = parts.0;
+    }
+
+    #[test]
+    fn unsigned_bytes_are_not_a_proof() {
+        assert!(!looks_like_did_proof(b"hello"));
+        let err = unwrap_signed_message(b"hello").unwrap_err();
+        assert!(matches!(err, IdentityError::Proof(_)));
+    }
+
+    #[test]
+    fn tampered_payload_is_rejected() {
+        let id = AgentIdentity::generate().unwrap();
+        let mut envelope = wrap_signed_message(&id, b"original").unwrap();
+        envelope.extend_from_slice(b"-tampered");
+        assert!(unwrap_signed_message(&envelope).is_err());
+    }
+}

--- a/crates/shadi_identity/src/did_proof.rs
+++ b/crates/shadi_identity/src/did_proof.rs
@@ -88,7 +88,11 @@ pub fn unwrap_signed_message(envelope: &[u8]) -> Result<VerifiedPayload, Identit
 /// Uses the same `SHADI_SLIM_AUTH=did` / `SLIM_HUMAN_SEED` contract as mesh
 /// join. Shared-secret node auth cannot produce an application-layer proof.
 pub fn sign_message_from_env(agent_id: &str, payload: &[u8]) -> Result<Vec<u8>, IdentityError> {
-    match crate::require_did_auth_from_env(agent_id)? {
+    sign_message_with_auth(crate::require_did_auth_from_env(agent_id)?, payload)
+}
+
+fn sign_message_with_auth(auth: SlimAuth, payload: &[u8]) -> Result<Vec<u8>, IdentityError> {
+    match auth {
         SlimAuth::Did { signing_pem, did, .. } => {
             let identity = AgentIdentity::from_pkcs8_pem(&signing_pem)?;
             if identity.did() != did {
@@ -197,5 +201,68 @@ mod tests {
         let mut envelope = wrap_signed_message(&id, b"original").unwrap();
         envelope.extend_from_slice(b"-tampered");
         assert!(unwrap_signed_message(&envelope).is_err());
+    }
+
+    fn raw_envelope(did: &[u8], sig: &[u8], payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(MAGIC);
+        out.push(b'\n');
+        out.extend_from_slice(did);
+        out.push(b'\n');
+        out.extend_from_slice(sig);
+        out.push(b'\n');
+        out.extend_from_slice(payload);
+        out
+    }
+
+    #[test]
+    fn unwrap_rejects_malformed_envelopes() {
+        assert!(unwrap_signed_message(b"SHADI-DID-PROOF/1\nonly-one-line").is_err());
+        assert!(split_envelope(b"NOPE\ndid:key:z\nsig\n").is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:web:example.com", b"c2ln", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"@@@", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"YQ", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"", b"c2ln", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:\xff", b"c2ln", b"x")).is_err());
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"sig\xff", b"x")).is_err());
+    }
+
+    #[test]
+    fn sign_from_env_round_trips_did_mode() {
+        let _guard = crate::auth::lock_slim_auth_env();
+        let identity = AgentIdentity::derive(b"human", "avatar").unwrap();
+        std::env::set_var("SHADI_SLIM_AUTH", "did");
+        std::env::set_var("SLIM_HUMAN_SEED", "human");
+        std::env::set_var("SLIM_MEMBER_DIDS", identity.did());
+        let envelope = sign_message_from_env("avatar", b"from-env").unwrap();
+        let verified = unwrap_signed_message(&envelope).unwrap();
+        assert_eq!(verified.did, identity.did());
+        assert_eq!(verified.payload, b"from-env");
+
+        std::env::remove_var("SHADI_SLIM_AUTH");
+        let err = sign_message_from_env("avatar", b"x").unwrap_err();
+        assert!(matches!(err, IdentityError::Config(_)));
+        std::env::remove_var("SLIM_HUMAN_SEED");
+        std::env::remove_var("SLIM_MEMBER_DIDS");
+    }
+
+    #[test]
+    fn sign_with_auth_rejects_shared_secret_and_mismatched_did() {
+        let err = sign_message_with_auth(SlimAuth::SharedSecret(String::new()), b"x").unwrap_err();
+        assert!(matches!(err, IdentityError::Config(_)));
+
+        let signer = AgentIdentity::generate().unwrap();
+        let other = AgentIdentity::generate().unwrap();
+        let mismatched = SlimAuth::Did {
+            signing_pem: signer.to_pkcs8_pem().unwrap(),
+            did: other.did(),
+            member_jwks: String::new(),
+        };
+        let err = sign_message_with_auth(mismatched, b"x").unwrap_err();
+        match err {
+            IdentityError::Proof(msg) => assert!(msg.contains("does not match"), "{msg}"),
+            other => panic!("expected Proof, got {other}"),
+        }
     }
 }

--- a/crates/shadi_identity/src/lib.rs
+++ b/crates/shadi_identity/src/lib.rs
@@ -19,9 +19,14 @@ use pkcs8::LineEnding;
 
 pub mod auth;
 pub mod config;
+pub mod did_proof;
 pub mod ssh;
 
 pub use auth::{build_did_auth, create_app, did_auth_from_env, require_did_auth_from_env, SlimAuth};
+pub use did_proof::{
+    looks_like_did_proof, sign_message_from_env, unwrap_signed_message, wrap_signed_message,
+    VerifiedPayload,
+};
 
 /// Multicodec prefix for an Ed25519 public key (`0xed` varint-encoded).
 const ED25519_MULTICODEC: [u8; 2] = [0xed, 0x01];
@@ -32,6 +37,7 @@ pub enum IdentityError {
     Pkcs8(String),
     InvalidDid(String),
     Config(String),
+    Proof(String),
 }
 
 impl fmt::Display for IdentityError {
@@ -41,6 +47,7 @@ impl fmt::Display for IdentityError {
             IdentityError::Pkcs8(e) => write!(f, "PKCS#8 error: {e}"),
             IdentityError::InvalidDid(e) => write!(f, "invalid did:key: {e}"),
             IdentityError::Config(e) => write!(f, "auth configuration error: {e}"),
+            IdentityError::Proof(e) => write!(f, "DID proof error: {e}"),
         }
     }
 }
@@ -128,6 +135,14 @@ impl AgentIdentity {
 
     pub fn verifying_key(&self) -> VerifyingKey {
         self.signing_key.verifying_key()
+    }
+
+    /// Detached Ed25519 signature over `message` (64 bytes). Used by the
+    /// application-layer DID proof — never log the key or the signature
+    /// together with the seed.
+    pub fn sign_bytes(&self, message: &[u8]) -> [u8; 64] {
+        use ed25519_dalek::Signer;
+        self.signing_key.sign(message).to_bytes()
     }
 
     /// This identity's `did:key`.
@@ -296,9 +311,12 @@ mod tests {
         assert!(IdentityError::Pkcs8("x".into())
             .to_string()
             .contains("PKCS#8"));
-        assert!(IdentityError::InvalidDid("x".into())
+        assert!(            IdentityError::InvalidDid("x".into())
             .to_string()
             .contains("invalid did:key"));
+        assert!(IdentityError::Proof("x".into())
+            .to_string()
+            .contains("DID proof"));
     }
 
     #[test]

--- a/crates/shadi_mas/src/engines/development.rs
+++ b/crates/shadi_mas/src/engines/development.rs
@@ -219,17 +219,19 @@ impl CoordinationEngine for DevelopmentEngine {
                 self.accept_proposal(participant, bytes)
             }
             // Vote: ToolResult.accepted=true means "I endorse tool_name (= AgentId)".
-            SemanticPayload::ToolResult { tool_name, accepted } => {
-                if accepted {
-                    let voter = match &event.metadata.source {
-                        crate::types::EventSource::Peer(id) => id.clone(),
-                        _ => AgentId("local".to_string()),
-                    };
-                    self.accept_vote(voter, AgentId(tool_name))
-                } else {
-                    self.counters.applied += 1;
-                    EventOutcome::Applied
-                }
+            SemanticPayload::ToolResult {
+                tool_name,
+                accepted: true,
+            } => {
+                let voter = match &event.metadata.source {
+                    crate::types::EventSource::Peer(id) => id.clone(),
+                    _ => AgentId("local".to_string()),
+                };
+                self.accept_vote(voter, AgentId(tool_name))
+            }
+            SemanticPayload::ToolResult { accepted: false, .. } => {
+                self.counters.applied += 1;
+                EventOutcome::Applied
             }
             _ => {
                 self.counters.applied += 1;

--- a/crates/shadi_mas/src/experiments/auth_required.rs
+++ b/crates/shadi_mas/src/experiments/auth_required.rs
@@ -1,0 +1,326 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client handling for A2A `TASK_STATE_AUTH_REQUIRED`.
+//!
+//! A remote task can park until the caller re-proves the agent DID or an
+//! operator escalates. This module decides what to do; it does not talk to
+//! SLIM. Timeout and repeat bounds deny the task with a reason so the
+//! coordinate/delegate loop cannot hang.
+
+use std::time::Duration;
+
+use a2a::{SendMessageResponse, TaskState};
+
+/// How many times the client will re-prove or escalate before denying.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 2;
+/// Wall-clock budget for an escalate prompt. Expired escalate is a deny.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthRequiredPolicy {
+    /// Re-sign from the agent DID. Default.
+    ReProve,
+    /// Ask the local harness (`CliAdapter::execute_prompt` / stdin).
+    Ask,
+    /// Fail immediately with a reason.
+    Deny,
+}
+
+impl AuthRequiredPolicy {
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "ask" => Self::Ask,
+            "deny" => Self::Deny,
+            _ => Self::ReProve,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthRequiredConfig {
+    pub policy: AuthRequiredPolicy,
+    pub max_attempts: u32,
+    pub timeout: Duration,
+}
+
+impl Default for AuthRequiredConfig {
+    fn default() -> Self {
+        Self {
+            policy: AuthRequiredPolicy::ReProve,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl AuthRequiredConfig {
+    pub fn from_env() -> Self {
+        let policy = std::env::var("SHADI_AUTH_REQUIRED_POLICY")
+            .map(|raw| AuthRequiredPolicy::parse(&raw))
+            .unwrap_or(AuthRequiredPolicy::ReProve);
+        let max_attempts = std::env::var("SHADI_AUTH_REQUIRED_MAX_ATTEMPTS")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_MAX_ATTEMPTS);
+        let timeout = std::env::var("SHADI_AUTH_REQUIRED_TIMEOUT_MS")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .filter(|n: &u64| *n > 0)
+            .map(Duration::from_millis)
+            .unwrap_or(DEFAULT_TIMEOUT);
+        Self {
+            policy,
+            max_attempts,
+            timeout,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthRequiredAction {
+    /// Sign the same payload again from the agent DID.
+    ReProve,
+    /// Append operator input and retry. `note` is the escalate answer.
+    Escalate { note: String },
+    /// Stop. `reason` is safe to print (no secrets).
+    Deny { reason: String },
+}
+
+/// Decide the next step after a parked `AUTH_REQUIRED` task.
+///
+/// `attempt` is 1-based (the first park is attempt 1).
+pub fn decide_auth_required(attempt: u32, config: &AuthRequiredConfig) -> AuthRequiredAction {
+    if attempt > config.max_attempts {
+        return AuthRequiredAction::Deny {
+            reason: format!(
+                "AUTH_REQUIRED denied: exceeded {} attempts",
+                config.max_attempts
+            ),
+        };
+    }
+    match config.policy {
+        AuthRequiredPolicy::Deny => AuthRequiredAction::Deny {
+            reason: "AUTH_REQUIRED denied by policy".to_string(),
+        },
+        AuthRequiredPolicy::ReProve => AuthRequiredAction::ReProve,
+        AuthRequiredPolicy::Ask => {
+            if attempt == 1 {
+                AuthRequiredAction::ReProve
+            } else {
+                AuthRequiredAction::Escalate {
+                    note: String::new(),
+                }
+            }
+        }
+    }
+}
+
+pub fn is_auth_required(response: &SendMessageResponse) -> bool {
+    matches!(
+        response,
+        SendMessageResponse::Task(task) if task.status.state == TaskState::AuthRequired
+    )
+}
+
+/// Drive send attempts until the task leaves `AUTH_REQUIRED` or is denied.
+///
+/// `send` is called for every attempt (including the first). `escalate` runs
+/// only when policy is `Ask` and the first re-prove was not enough.
+pub fn run_auth_required_loop<S, E>(
+    mut send: S,
+    config: &AuthRequiredConfig,
+    mut escalate: E,
+) -> Result<SendMessageResponse, String>
+where
+    S: FnMut() -> Result<SendMessageResponse, String>,
+    E: FnMut() -> Result<String, String>,
+{
+    let mut attempt = 0u32;
+    loop {
+        let response = send()?;
+        if !is_auth_required(&response) {
+            return Ok(response);
+        }
+        attempt += 1;
+        let action = decide_auth_required(attempt, config);
+        audit_auth_required(attempt, &action);
+        match action {
+            AuthRequiredAction::ReProve => {}
+            AuthRequiredAction::Escalate { .. } => {
+                let started = std::time::Instant::now();
+                let note = escalate().map_err(|err| {
+                    format!("AUTH_REQUIRED denied: escalate failed: {err}")
+                })?;
+                if started.elapsed() > config.timeout {
+                    return Err(format!(
+                        "AUTH_REQUIRED denied: escalate timed out after {}ms",
+                        config.timeout.as_millis()
+                    ));
+                }
+                let _ = note;
+            }
+            AuthRequiredAction::Deny { reason } => return Err(reason),
+        }
+    }
+}
+
+/// Record the decision without secrets or raw tokens.
+pub fn audit_auth_required(attempt: u32, action: &AuthRequiredAction) {
+    match action {
+        AuthRequiredAction::ReProve => {
+            tracing::info!(attempt, decision = "reprove", "AUTH_REQUIRED");
+        }
+        AuthRequiredAction::Escalate { .. } => {
+            tracing::info!(attempt, decision = "escalate", "AUTH_REQUIRED");
+        }
+        AuthRequiredAction::Deny { reason } => {
+            tracing::info!(attempt, decision = "deny", reason, "AUTH_REQUIRED");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a::{Message, Part, Role, Task, TaskStatus};
+
+    #[test]
+    fn policy_parse_defaults_to_reprove() {
+        assert_eq!(AuthRequiredPolicy::parse("ask"), AuthRequiredPolicy::Ask);
+        assert_eq!(AuthRequiredPolicy::parse("DENY"), AuthRequiredPolicy::Deny);
+        assert_eq!(
+            AuthRequiredPolicy::parse("anything"),
+            AuthRequiredPolicy::ReProve
+        );
+    }
+
+    #[test]
+    fn decide_denies_after_max_attempts() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::ReProve,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(decide_auth_required(1, &cfg), AuthRequiredAction::ReProve);
+        assert_eq!(decide_auth_required(2, &cfg), AuthRequiredAction::ReProve);
+        match decide_auth_required(3, &cfg) {
+            AuthRequiredAction::Deny { reason } => {
+                assert!(reason.contains("exceeded"));
+            }
+            other => panic!("expected deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ask_policy_reproves_then_escalates() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::Ask,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(decide_auth_required(1, &cfg), AuthRequiredAction::ReProve);
+        assert!(matches!(
+            decide_auth_required(2, &cfg),
+            AuthRequiredAction::Escalate { .. }
+        ));
+    }
+
+    #[test]
+    fn deny_policy_fails_with_reason() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::Deny,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        match decide_auth_required(1, &cfg) {
+            AuthRequiredAction::Deny { reason } => {
+                assert!(reason.contains("policy"));
+            }
+            other => panic!("expected deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_auth_required_task() {
+        let task = Task {
+            id: "t1".to_string(),
+            context_id: "c1".to_string(),
+            status: TaskStatus {
+                state: TaskState::AuthRequired,
+                message: Some(Message::new(
+                    Role::Agent,
+                    vec![Part::text("prove DID".to_string())],
+                )),
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        };
+        assert!(is_auth_required(&SendMessageResponse::Task(task)));
+        let done = Message::new(Role::Agent, vec![Part::text("ok".to_string())]);
+        assert!(!is_auth_required(&SendMessageResponse::Message(done)));
+    }
+
+    fn parked_task() -> SendMessageResponse {
+        SendMessageResponse::Task(Task {
+            id: "parked".to_string(),
+            context_id: "ctx".to_string(),
+            status: TaskStatus {
+                state: TaskState::AuthRequired,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        })
+    }
+
+    fn completed_message() -> SendMessageResponse {
+        SendMessageResponse::Message(Message::new(
+            Role::Agent,
+            vec![Part::text("done after re-auth".to_string())],
+        ))
+    }
+
+    #[test]
+    fn parked_task_completes_after_reprove() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::ReProve,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        let mut n = 0;
+        let response = run_auth_required_loop(
+            || {
+                n += 1;
+                if n == 1 {
+                    Ok(parked_task())
+                } else {
+                    Ok(completed_message())
+                }
+            },
+            &cfg,
+            || Ok(String::new()),
+        )
+        .expect("re-prove should complete");
+        assert!(!is_auth_required(&response));
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn denied_task_fails_with_reason_and_does_not_hang() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::ReProve,
+            max_attempts: 1,
+            timeout: Duration::from_millis(10),
+        };
+        let err = run_auth_required_loop(|| Ok(parked_task()), &cfg, || Ok(String::new()))
+            .expect_err("must deny after max attempts");
+        assert!(err.contains("AUTH_REQUIRED denied"));
+        assert!(err.contains("exceeded"));
+    }
+}

--- a/crates/shadi_mas/src/experiments/auth_required.rs
+++ b/crates/shadi_mas/src/experiments/auth_required.rs
@@ -323,4 +323,123 @@ mod tests {
         assert!(err.contains("AUTH_REQUIRED denied"));
         assert!(err.contains("exceeded"));
     }
+
+    #[test]
+    fn default_config_matches_published_bounds() {
+        let cfg = AuthRequiredConfig::default();
+        assert_eq!(cfg.policy, AuthRequiredPolicy::ReProve);
+        assert_eq!(cfg.max_attempts, DEFAULT_MAX_ATTEMPTS);
+        assert_eq!(cfg.timeout, DEFAULT_TIMEOUT);
+    }
+
+    #[test]
+    fn from_env_reads_policy_attempts_and_timeout() {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("SHADI_AUTH_REQUIRED_POLICY");
+        std::env::remove_var("SHADI_AUTH_REQUIRED_MAX_ATTEMPTS");
+        std::env::remove_var("SHADI_AUTH_REQUIRED_TIMEOUT_MS");
+        let defaults = AuthRequiredConfig::from_env();
+        assert_eq!(defaults.policy, AuthRequiredPolicy::ReProve);
+        assert_eq!(defaults.max_attempts, DEFAULT_MAX_ATTEMPTS);
+        assert_eq!(defaults.timeout, DEFAULT_TIMEOUT);
+
+        std::env::set_var("SHADI_AUTH_REQUIRED_POLICY", "ask");
+        std::env::set_var("SHADI_AUTH_REQUIRED_MAX_ATTEMPTS", "5");
+        std::env::set_var("SHADI_AUTH_REQUIRED_TIMEOUT_MS", "250");
+        let parsed = AuthRequiredConfig::from_env();
+        assert_eq!(parsed.policy, AuthRequiredPolicy::Ask);
+        assert_eq!(parsed.max_attempts, 5);
+        assert_eq!(parsed.timeout, Duration::from_millis(250));
+
+        std::env::set_var("SHADI_AUTH_REQUIRED_POLICY", "deny");
+        std::env::set_var("SHADI_AUTH_REQUIRED_MAX_ATTEMPTS", "0");
+        std::env::set_var("SHADI_AUTH_REQUIRED_TIMEOUT_MS", "0");
+        let fallback = AuthRequiredConfig::from_env();
+        assert_eq!(fallback.policy, AuthRequiredPolicy::Deny);
+        assert_eq!(fallback.max_attempts, DEFAULT_MAX_ATTEMPTS);
+        assert_eq!(fallback.timeout, DEFAULT_TIMEOUT);
+
+        std::env::remove_var("SHADI_AUTH_REQUIRED_POLICY");
+        std::env::remove_var("SHADI_AUTH_REQUIRED_MAX_ATTEMPTS");
+        std::env::remove_var("SHADI_AUTH_REQUIRED_TIMEOUT_MS");
+    }
+
+    #[test]
+    fn send_error_propagates_without_retry() {
+        let cfg = AuthRequiredConfig::default();
+        let err = run_auth_required_loop(|| Err("transport down".into()), &cfg, || Ok(String::new()))
+            .expect_err("send failure must surface");
+        assert_eq!(err, "transport down");
+    }
+
+    #[test]
+    fn ask_policy_escalates_then_completes() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::Ask,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        let mut n = 0;
+        let mut escalated = 0;
+        let response = run_auth_required_loop(
+            || {
+                n += 1;
+                if n < 3 {
+                    Ok(parked_task())
+                } else {
+                    Ok(completed_message())
+                }
+            },
+            &cfg,
+            || {
+                escalated += 1;
+                Ok("operator-ok".to_string())
+            },
+        )
+        .expect("escalate should complete");
+        assert!(!is_auth_required(&response));
+        assert_eq!(n, 3);
+        assert_eq!(escalated, 1);
+    }
+
+    #[test]
+    fn escalate_failure_denies() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::Ask,
+            max_attempts: 2,
+            timeout: Duration::from_secs(1),
+        };
+        let mut n = 0;
+        let err = run_auth_required_loop(
+            || {
+                n += 1;
+                Ok(parked_task())
+            },
+            &cfg,
+            || Err("no operator".into()),
+        )
+        .expect_err("escalate failure must deny");
+        assert!(err.contains("escalate failed"));
+        assert!(err.contains("no operator"));
+    }
+
+    #[test]
+    fn escalate_timeout_denies() {
+        let cfg = AuthRequiredConfig {
+            policy: AuthRequiredPolicy::Ask,
+            max_attempts: 2,
+            timeout: Duration::from_millis(5),
+        };
+        let err = run_auth_required_loop(
+            || Ok(parked_task()),
+            &cfg,
+            || {
+                std::thread::sleep(Duration::from_millis(20));
+                Ok("late".into())
+            },
+        )
+        .expect_err("slow escalate must time out");
+        assert!(err.contains("timed out"));
+    }
 }

--- a/crates/shadi_mas/src/experiments/mod.rs
+++ b/crates/shadi_mas/src/experiments/mod.rs
@@ -6,7 +6,13 @@ use std::time::{Duration, Instant};
 
 use a2a::*;
 use a2a_client::A2AClient;
-use agent_secrets::{AgentVerifier, SecretError, SecretResult, SessionContext};
+use agent_secrets::{DidProofVerifier, SessionContext};
+
+pub mod auth_required;
+pub use auth_required::{
+    audit_auth_required, decide_auth_required, is_auth_required, run_auth_required_loop,
+    AuthRequiredAction, AuthRequiredConfig, AuthRequiredPolicy,
+};
 use crate::adapters::{MessagingAdapter, TaskAdapter, TaskEnvelope};
 use shadi_a2a::A2AChannelBuilder;
 use slim_bindings::{CaSource, ClientConfig, Name, Service, TlsClientConfig, TlsSource};
@@ -122,6 +128,39 @@ impl LiveA2ATaskAdapter {
     }
 
     fn send_task(&self, task: &TaskEnvelope) -> Result<String, String> {
+        let body = Mutex::new(render_task_message(task));
+        let auth_cfg = AuthRequiredConfig::from_env();
+        let response = run_auth_required_loop(
+            || {
+                let current = body
+                    .lock()
+                    .map_err(|_| "live A2A task body lock poisoned".to_string())?
+                    .clone();
+                let signed = shadi_identity::sign_message_from_env(&self.config.agent_id, current.as_bytes())
+                    .map_err(|err| err.to_string())?;
+                let signed_text = String::from_utf8(signed)
+                    .map_err(|err| format!("DID proof envelope is not UTF-8: {err}"))?;
+                self.send_signed_task(task, &signed_text)
+            },
+            &auth_cfg,
+            || {
+                let note = escalate_auth_required(&auth_cfg)?;
+                let mut guard = body
+                    .lock()
+                    .map_err(|_| "live A2A task body lock poisoned".to_string())?;
+                guard.push_str("\n\nauth_escalate:\n");
+                guard.push_str(&note);
+                Ok(note)
+            },
+        )?;
+        Ok(describe_a2a_response(&response))
+    }
+
+    fn send_signed_task(
+        &self,
+        task: &TaskEnvelope,
+        signed_text: &str,
+    ) -> Result<SendMessageResponse, String> {
         let tls = resolve_client_tls_material_for_agent(Some(&self.config.agent_id))?;
         let local_name = self
             .config
@@ -152,7 +191,7 @@ impl LiveA2ATaskAdapter {
                 task.task_id,
                 attempt
             ));
-            let attempt_result = (|| -> Result<String, String> {
+            let attempt_result = (|| -> Result<SendMessageResponse, String> {
                 let connection_id = service
                     .connect(build_client_config_for_endpoint(&self.config.endpoint, &tls))
                     .map_err(format_slim_error)?;
@@ -161,6 +200,15 @@ impl LiveA2ATaskAdapter {
 
                 let auth = shadi_identity::require_did_auth_from_env(&self.config.agent_id)
                     .map_err(|e| e.to_string())?;
+                let proven_did = match &auth {
+                    shadi_identity::SlimAuth::Did { did, .. } => did.clone(),
+                    shadi_identity::SlimAuth::SharedSecret(_) => {
+                        return Err(
+                            "application auth requires an agent DID; shared-secret node auth is not enough"
+                                .to_string(),
+                        );
+                    }
+                };
                 let app = shadi_identity::create_app(&service, local_name_ref.clone(), &auth)
                     .map_err(format_slim_error)?;
                 app.subscribe(local_name_ref.clone(), Some(connection_id))
@@ -171,11 +219,12 @@ impl LiveA2ATaskAdapter {
                     .build()
                     .map_err(|err| format!("failed to create tokio runtime: {}", err))?;
 
-                let mut session = SessionContext::new(
+                // Outbound payload is DID-signed above; the verifier requires that proof.
+                let session = SessionContext::new(
                     &self.config.agent_id,
-                    &format!("mas-task-session-{}", task.task_id),
-                );
-                session.verified = true;
+                    format!("mas-task-session-{}", task.task_id),
+                )
+                .with_proven_did(proven_did);
 
                 // slim_rpc::Channel captures `tokio::runtime::Handle::current()` at
                 // construction, so build the transport inside the runtime context.
@@ -184,7 +233,7 @@ impl LiveA2ATaskAdapter {
                     A2AChannelBuilder::new(
                         app.clone(),
                         remote_name_ref,
-                        Arc::new(VerifiedSessionVerifier),
+                        Arc::new(DidProofVerifier),
                         session,
                     )
                     .connection_id(connection_id)
@@ -192,26 +241,23 @@ impl LiveA2ATaskAdapter {
                 };
                 let client = A2AClient::new(Box::new(channel));
                 let request = SendMessageRequest {
-                    message: Message::new(
-                        Role::User,
-                        vec![Part::text(render_task_message(task))],
-                    ),
+                    message: Message::new(Role::User, vec![Part::text(signed_text.to_string())]),
                     configuration: None,
                     metadata: None,
                     tenant: None,
                 };
 
-                let response_detail = runtime
+                let response = runtime
                     .block_on(async {
                         let response = client.send_message(&request).await?;
                         client.destroy().await?;
-                        Ok::<String, A2AError>(describe_a2a_response(&response))
+                        Ok::<SendMessageResponse, A2AError>(response)
                     })
                     .map_err(|err| format!("failed to send A2A task {}: {}", task.task_id, err))?;
 
                 let _ = app.unsubscribe(local_name_ref.clone(), Some(connection_id));
                 let _ = service.disconnect(connection_id);
-                Ok(response_detail)
+                Ok(response)
             })();
             let _ = service.shutdown();
 
@@ -233,6 +279,18 @@ impl LiveA2ATaskAdapter {
     }
 }
 
+fn escalate_auth_required(config: &AuthRequiredConfig) -> Result<String, String> {
+    if let Ok(note) = std::env::var("SHADI_AUTH_REQUIRED_ESCALATE") {
+        if !note.trim().is_empty() {
+            return Ok(note);
+        }
+    }
+    Err(format!(
+        "AUTH_REQUIRED denied: no harness escalate answer within {}ms",
+        config.timeout.as_millis()
+    ))
+}
+
 impl TaskAdapter for LiveA2ATaskAdapter {
     fn dispatch(&self, task: TaskEnvelope) -> Result<(), String> {
         let started_at = Instant::now();
@@ -249,18 +307,6 @@ impl TaskAdapter for LiveA2ATaskAdapter {
     }
 }
 
-
-struct VerifiedSessionVerifier;
-
-impl AgentVerifier for VerifiedSessionVerifier {
-    fn verify(&self, session: &SessionContext) -> SecretResult<()> {
-        if session.verified {
-            Ok(())
-        } else {
-            Err(SecretError::NotAuthorized)
-        }
-    }
-}
 
 #[derive(Clone)]
 struct TlsMaterial {
@@ -440,6 +486,7 @@ fn format_slim_error(err: slim_bindings::SlimError) -> String {
 #[cfg(test)]
 mod transport_tests {
     use super::*;
+    use agent_secrets::AgentVerifier;
     use crate::types::{Epoch, PatternKind};
 
     fn sample_task() -> TaskEnvelope {
@@ -655,10 +702,11 @@ mod transport_tests {
     }
 
     #[test]
-    fn verified_session_verifier_enforces_verification() {
+    fn did_proof_verifier_rejects_asserted_verified_flag() {
         let mut session = SessionContext::new("avatar", "unit-test");
-        assert!(VerifiedSessionVerifier.verify(&session).is_err());
         session.verified = true;
-        assert!(VerifiedSessionVerifier.verify(&session).is_ok());
+        assert!(DidProofVerifier.verify(&session).is_err());
+        let proven = SessionContext::new("avatar", "unit-test").with_proven_did("did:key:zexample");
+        assert!(DidProofVerifier.verify(&proven).is_ok());
     }
 }

--- a/crates/shadi_memory/src/lib.rs
+++ b/crates/shadi_memory/src/lib.rs
@@ -37,9 +37,9 @@ impl SqlCipherStore {
                 | OpenFlags::SQLITE_OPEN_CREATE
                 | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
-        conn.pragma_update(None, "key", &key)?;
-        conn.pragma_update(None, "cipher_compatibility", &4)?;
-        conn.pragma_update(None, "foreign_keys", &"ON")?;
+        conn.pragma_update(None, "key", key)?;
+        conn.pragma_update(None, "cipher_compatibility", 4)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS memory_entries (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/shadi_py/src/lib.rs
+++ b/crates/shadi_py/src/lib.rs
@@ -309,6 +309,7 @@ impl PySessionContext {
             verified: self.verified,
             claims: self.claims.clone(),
             did: None,
+            did_proven: false,
         }
     }
 }

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -791,7 +791,7 @@ fn load_or_create_hmac_key() -> Result<Vec<u8>, String> {
     } else {
         use rand::RngCore;
         let mut key = vec![0u8; 32];
-        rand::thread_rng().fill_bytes(&mut key);
+        rand::rng().fill_bytes(&mut key);
         let hex_str = hex::encode(&key);
         std::fs::write(&key_path, hex_str.as_bytes()).map_err(|e| e.to_string())?;
         Ok(key)

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -63,7 +63,7 @@ pub fn spawn_sandboxed(command: &mut Command, policy: &SandboxPolicy) -> Result<
     let cwd = command
         .get_current_dir()
         .map(|path| path.display().to_string())
-        .unwrap_or_else(|| "".to_string());
+        .unwrap_or_default();
     let allowed_paths = policy.allow_read().len() + policy.allow_write().len();
     let network_mode = if policy.net_blocked() { "blocked" } else { "allowed" };
 
@@ -121,7 +121,7 @@ impl SandboxedChild {
         };
 
         if let Ok(ref status) = status {
-            span.record("exit.code", &status.code().unwrap_or(-1));
+            span.record("exit.code", status.code().unwrap_or(-1));
         }
 
         status

--- a/crates/shadi_sandbox/src/net_proxy.rs
+++ b/crates/shadi_sandbox/src/net_proxy.rs
@@ -231,6 +231,10 @@ impl NetProxy {
         // between release and rebind and be handed this port (agntcy/shadi#204).
         // Retry a bounded number of times; production restart is not racing
         // other NetProxy::start calls in-process.
+        Self::bind_with_retry(port, allowlist)
+    }
+
+    fn bind_with_retry(port: u16, allowlist: NetAllowlist) -> std::io::Result<Self> {
         const ATTEMPTS: u32 = 8;
         let mut last_err = None;
         for attempt in 0..ATTEMPTS {
@@ -626,13 +630,18 @@ mod tests {
         assert_eq!(&buf, b"hello");
     }
 
+    static PORT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_proxy_ports() -> std::sync::MutexGuard<'static, ()> {
+        PORT_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn proxy_restart_rebinds_to_same_port() {
         // Serialize against other tests that bind port 0 so the OS cannot
         // hand this proxy's just-released port to a sibling NetProxy::start
         // (agntcy/shadi#204).
-        static PORT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = PORT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = lock_proxy_ports();
 
         // Start proxy, record port, restart it, verify the new proxy answers
         // on the same port — the macOS Seatbelt constraint.
@@ -646,5 +655,18 @@ mod tests {
         // New proxy must actually accept connections on that port.
         let conn = std::net::TcpStream::connect(format!("127.0.0.1:{original_port}"));
         assert!(conn.is_ok(), "restarted proxy not accepting on port {original_port}");
+    }
+
+    #[test]
+    fn bind_with_retry_fails_when_port_held() {
+        let _guard = lock_proxy_ports();
+        let holder = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = holder.local_addr().unwrap().port();
+        let err = match NetProxy::bind_with_retry(port, NetAllowlist::new(vec![])) {
+            Ok(_) => panic!("held port must not rebind"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
+        drop(holder);
     }
 }

--- a/crates/shadi_sandbox/src/net_proxy.rs
+++ b/crates/shadi_sandbox/src/net_proxy.rs
@@ -227,7 +227,24 @@ impl NetProxy {
         // SAFETY: we own `this` exclusively via ManuallyDrop and never
         // access `thread` again after this read.
         let _ = unsafe { std::ptr::read(&this.thread) }.join();
-        Self::bind_and_start(port, allowlist)
+        // Another test in the same process can bind port 0 in the window
+        // between release and rebind and be handed this port (agntcy/shadi#204).
+        // Retry a bounded number of times; production restart is not racing
+        // other NetProxy::start calls in-process.
+        const ATTEMPTS: u32 = 8;
+        let mut last_err = None;
+        for attempt in 0..ATTEMPTS {
+            match Self::bind_and_start(port, allowlist.clone()) {
+                Ok(proxy) => return Ok(proxy),
+                Err(err) => {
+                    last_err = Some(err);
+                    thread::sleep(std::time::Duration::from_millis(5 * u64::from(attempt + 1)));
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            std::io::Error::other("net proxy restart failed to rebind")
+        }))
     }
 
     fn bind_and_start(port: u16, allowlist: NetAllowlist) -> std::io::Result<Self> {
@@ -455,7 +472,7 @@ fn pipe_bidirectional(client: TcpStream, upstream: TcpStream) {
         .name("shadi-proxy-up".into())
         .spawn(move || copy_stream(client, upstream));
 
-    let _ = copy_stream(upstream2, client2);
+    copy_stream(upstream2, client2);
     if let Ok(handle) = t1 {
         let _ = handle.join();
     }
@@ -611,6 +628,12 @@ mod tests {
 
     #[test]
     fn proxy_restart_rebinds_to_same_port() {
+        // Serialize against other tests that bind port 0 so the OS cannot
+        // hand this proxy's just-released port to a sibling NetProxy::start
+        // (agntcy/shadi#204).
+        static PORT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = PORT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         // Start proxy, record port, restart it, verify the new proxy answers
         // on the same port — the macOS Seatbelt constraint.
         let al = NetAllowlist::new(vec![]);

--- a/crates/shadi_sandbox/src/platform/macos.rs
+++ b/crates/shadi_sandbox/src/platform/macos.rs
@@ -502,10 +502,7 @@ mod tests {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
 
-        let mut bytes = Vec::new();
-        bytes.push(0xff);
-        bytes.push(0xfe);
-        let bad = OsString::from_vec(bytes);
+        let bad = OsString::from_vec(vec![0xff, 0xfe]);
         let path = PathBuf::from(bad);
 
         let policy = SandboxPolicy::new().allow_read_path(path);
@@ -518,10 +515,7 @@ mod tests {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
 
-        let mut bytes = Vec::new();
-        bytes.push(0xff);
-        bytes.push(0xfe);
-        let bad = OsString::from_vec(bytes);
+        let bad = OsString::from_vec(vec![0xff, 0xfe]);
         let path = PathBuf::from(bad);
 
         let policy = SandboxPolicy::new().allow_write_path(path);
@@ -531,7 +525,7 @@ mod tests {
 
     #[test]
     fn apply_profile_noop_in_tests() {
-        let profile = CStr::from_bytes_with_nul(b"(version 1)\0").expect("cstr");
+        let profile = c"(version 1)";
         apply_profile(profile).expect("apply");
     }
 

--- a/crates/shadi_sandbox/src/platform/windows.rs
+++ b/crates/shadi_sandbox/src/platform/windows.rs
@@ -616,7 +616,7 @@ fn grant_path_access(
         ptstrName: sid as *mut u16,
     };
 
-    let mut entry = EXPLICIT_ACCESS_W {
+    let entry = EXPLICIT_ACCESS_W {
         grfAccessPermissions: access_mask,
         grfAccessMode: GRANT_ACCESS,
         grfInheritance: NO_INHERITANCE,

--- a/crates/shadi_sandbox/src/platform/windows.rs
+++ b/crates/shadi_sandbox/src/platform/windows.rs
@@ -624,7 +624,7 @@ fn grant_path_access(
     };
 
     let mut acl: *mut ACL = std::ptr::null_mut();
-    let result = unsafe { SetEntriesInAclW(1, &mut entry, rollback.dacl as *mut ACL, &mut acl) };
+    let result = unsafe { SetEntriesInAclW(1, &entry, rollback.dacl as *mut ACL, &mut acl) };
     if result != 0 {
         return Err(win32_error_message("SetEntriesInAclW", result));
     }

--- a/crates/shadi_sandbox/src/policy_patch.rs
+++ b/crates/shadi_sandbox/src/policy_patch.rs
@@ -84,6 +84,7 @@ pub struct PolicyPatchResponse {
 /// A wire-level message sent over the control socket.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum ControlMessage {
     /// Request the current effective policy.
     QueryPolicy,

--- a/crates/shadi_telemetry/src/lib.rs
+++ b/crates/shadi_telemetry/src/lib.rs
@@ -69,7 +69,7 @@ pub fn init(service_name: &str) {
             )
         });
 
-        let fmt_layer = config.console_enabled.then(|| tracing_subscriber::fmt::layer());
+        let fmt_layer = config.console_enabled.then(tracing_subscriber::fmt::layer);
 
         let subscriber = tracing_subscriber::registry()
             .with(otel_layer)

--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -65,7 +65,7 @@ same machine). SLIM is the authenticated transport bus between them.
 flowchart LR
   subgraph reg["agentbridge register  (one per agent)"]
     direction TB
-    tool["CLI tool\ngeneric-stdio | claude-code | copilot | codex"]
+    tool["CLI tool\ngeneric-stdio | claude-code | copilot | codex | cursor-agent"]
     ca["CliAdapter\nexecute_prompt(prompt) → text"]
     srv["A2A server\nAgentBridgeRequestHandler\nInMemoryTaskStore"]
     tool -- "stdin / stdout" --> ca --> srv
@@ -161,13 +161,20 @@ Export a session snapshot from one tool and import it into another. The
 generated artifacts.
 
 ```
-agentbridge handoff --from ./claude-proxy --to ./copilot-proxy
+agentbridge handoff --from claude-code --to copilot
 ```
 
-1. Source adapter → `snapshot_context()` → `ContextPacket`
-2. Packet persisted to `shadi_memory` (SQLCipher-backed, recoverable)
-3. A2A Task sent to destination adapter (skill: `inject-context`)
-4. Destination adapter → `inject_context(packet)`
+`--from` / `--to` accept the same specs as `coordinate` (`claude-code`,
+`copilot`, `codex`, `cursor-agent`, `generic-stdio:<cmd>`, `slim:<id>`).
+A bare subprocess command still opens GenericStdio. `--save` /
+`--from-file` persist the packet.
+
+The snapshot is an LLM summary of the source session this cycle, not a
+true session export.
+
+1. Source adapter → `snapshot_context()` → `ContextPacket` (LLM summary)
+2. Optional `--save` of the packet
+3. Destination adapter → `inject_context(packet)`
 
 ### 2. Task delegation
 

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -88,6 +88,44 @@ flowchart LR
 3. Session verification gates later reads.
 4. The SQLCipher memory key is retrieved through the same secret-control path rather than living in plaintext config.
 
+## Node auth versus application auth
+
+Two different things are called authentication on the SLIM path. Mixing them
+is how a mesh member can present another agent's DID. Tracked in
+agntcy/shadi#182; the handoff proof is agntcy/shadi#183.
+
+**Node auth** answers: may this process join the mesh? SLIM 2.3 provides
+that — `slim login` (OIDC device flow), SPIRE workload identity, or a
+legacy shared secret. A node credential says the process is allowed on the
+wire. It does not say which agent sent a message.
+
+**Application auth** answers: which agent is speaking, and whose is it?
+SLIM does not provide this. SHADI does, with `did:key` agent DIDs derived
+from the human's key. Agentbridge must verify that DID on a handoff,
+delegate, or coordinate task — not the node credential.
+
+| Layer | Question | Credential | Who checks it |
+|---|---|---|---|
+| Node | May this process join the mesh? | `slim login` / SPIRE SVID / shared secret | SLIM |
+| Application | Which agent sent this message? | Agent `did:key` signed over the payload | SHADI / agentbridge |
+| Human binding | Which human does that agent belong to? | Attestation over the agent DID | Not on the wire yet (#141) |
+
+Rules that must stay true when SLIM node auth is adopted:
+
+- Agentbridge verifies SHADI's agent DID chain before accepting a handoff.
+  A node SVID is not a substitute.
+- The node credential and the agent DID travel together; they are not
+  interchangeable.
+- `SessionContext.did` is proven from a signature on the message on the
+  agentbridge SLIM path (`SessionContext.did_proven`). A locally set
+  `session.verified` bool is not application auth.
+- Shared-secret node auth remains valid only for single-mesh setups and
+  is rejected by `agentbridge register --slim-endpoint`, because a
+  listener forwards incoming A2A tasks to a local CLI.
+
+Adopting SLIM's `TokenProvider` / `Verifier` (agntcy/shadi#179) and
+`slim login` / SPIRE (agntcy/shadi#180) must not collapse these layers.
+
 ## 1Password backend
 
 When `SHADI_SECRET_BACKEND=onepassword` is set, secrets are stored in a

--- a/examples/agentbridge_demo/src/main.rs
+++ b/examples/agentbridge_demo/src/main.rs
@@ -387,8 +387,8 @@ fn main() {
         .iter()
         .find(|a| a.starts_with("--scenario=") || *a == "--scenario")
         .and_then(|a| {
-            if a.contains('=') {
-                a.splitn(2, '=').nth(1).map(str::to_string)
+            if let Some((_, value)) = a.split_once('=') {
+                Some(value.to_string())
             } else {
                 args.iter()
                     .skip_while(|b| *b != "--scenario")

--- a/examples/shadi_demo_bot/src/lib.rs
+++ b/examples/shadi_demo_bot/src/lib.rs
@@ -2107,7 +2107,7 @@ mod tests {
     use super::*;
     use clap::Parser;
     use futures::StreamExt;
-    use std::io::{Cursor, Error, ErrorKind};
+    use std::io::{Cursor, Error};
 
     fn demo_send_request(text: &str) -> SendMessageRequest {
         SendMessageRequest {
@@ -2135,7 +2135,7 @@ mod tests {
 
     impl Read for FailingReader {
         fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-            Err(Error::new(ErrorKind::Other, "boom"))
+            Err(Error::other("boom"))
         }
     }
 


### PR DESCRIPTION
## Summary
- Bind SLIM send/recv to a did:key signature so a mesh member cannot present another agent's DID.
- Resolve AUTH_REQUIRED (re-prove / ask / deny) and accept native handoff/register specs, including cursor-agent.

## Test plan
- [ ] `cargo test -p shadi_identity -p agent_transport_slim -p shadi_mas -p agentbridge -p agentbridge_cli`
- [ ] Negative path: forged DID is rejected; unsigned inbound is AUTH_REQUIRED
- [ ] `agentbridge handoff --from <spec> --to <spec>` and `register --tool cursor-agent`


Made with [Cursor](https://cursor.com)