### PR TITLE
fix(release): publish only from a merged release PR again

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-release_always = true
+release_always = false
 publish = true
 publish_no_verify = true
 publish_timeout = "30m"


### PR DESCRIPTION
Reverts #214. That flag was only ever to unstick 0.1.7, whose publish had failed — that's done, crates.io now matches `main`, so nothing is stranded and this is safe to put back.

`release_always = true` publishes on any push where a version is ahead of the registry. Publishing should follow from merging the release PR, not from a version being ahead for some other reason.


bookmark: If a publish fails again: flip this to `true` for one push, then revert.