### PR TITLE
docs(demos): add curated round-robin Rust sample run

### DIFF
--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -478,7 +478,7 @@ corrupting the state machine.
     | Native `handoff` specs | ✅ | Same `--from`/`--to` as `coordinate`, including `cursor-agent` and `slim:<id>` |
     | `register --tool cursor-agent` | ✅ | Same sandbox + DID listener as the other tools |
     | `list --local` | ✅ | Live listeners from on-host register leases |
-    | Two-line token-passing coding | ✅ | [Round-robin Rust Demo](demos/collab-rust.md) — `avatar` `delegate` + capped apply + agent-as-A2A-client `handoff --from slim:` until `cargo test` |
+    | Two-line token-passing coding | ✅ | [Round-robin Rust Demo](demos/collab-rust.md) — `avatar` `delegate` + capped apply + agent-as-A2A-client `NEXT` until `cargo test` ([sample run](demos/collab-rust-sample.md)) |
 
     ### What remains
 

--- a/docs/content/demos/collab-rust-sample.md
+++ b/docs/content/demos/collab-rust-sample.md
@@ -1,0 +1,202 @@
+# Sample run: round-robin Rust
+
+Recorded 8 September 2026 on `main` (`80cd393`), after
+[PR #226](https://github.com/agntcy/shadi/pull/226). One invocation of
+[`run-collab-demo.sh`](run-collab-demo.sh) (`PROBLEM=both`, `MAX_CYCLES=10`)
+registered four harness listeners, token-passed two crates, and exited **0**
+in about four minutes.
+
+This is a curated transcript, not a guarantee that the next live run
+follows the same hop order or writes the same two lines. How to start the
+script is in the [round-robin Rust demo](collab-rust.md).
+
+| | |
+|---|---|
+| Problems | `sort` and `fifo`, both **SOLVED** |
+| Hops | 7 coding delegates (1 + 6) |
+| Tests | `sort` 5/5 · `fifo` 2/2 |
+| Failed delegates | none |
+| Endpoint | `slim://127.0.0.1:47591` |
+
+## Listeners
+
+`list --local` after register (DIDs truncated; they match
+[`demo-env.sh`](demo-env.sh)):
+
+```text
+Local agentbridge adapters:
+claude-code   did:key:z6MkhRuJ…PZa1  slim://127.0.0.1:47591
+copilot       did:key:z6MkmJUc…MnwT  slim://127.0.0.1:47591
+codex         did:key:z6MkmaFF…uGr6  slim://127.0.0.1:47591
+cursor-agent  did:key:z6MktdzQ…qS5Q  slim://127.0.0.1:47591
+```
+
+`avatar` only `delegate`s the coding prompt. After `NEXT <peer>`, that
+same `register` process shares the turn (`…/<tool>-a2a-client` →
+`…/<peer>-a2a`). `DONE` does not send a listener handoff.
+
+## sort — 1 hop
+
+Claude replaced the identity stub with a two-line insertion sort and
+wrote `DONE`. `no_prebuilt_sort` reads `src/lib.rs` from disk and
+confirmed there is no `.sort(`.
+
+| Hop | Agent | Apply | Route | Tests |
+|---|---|---|---|---|
+| 1 | claude-code | `REPLACE` 2 lines at 5 | `DONE` | 5 / 5 |
+
+Reply:
+
+```text
+REPLACE 5
+let mut items = items;
+for i in 1..items.len() { let mut j = i; while j > 0 && items[j-1] > items[j] { items.swap(j-1, j); j -= 1; } } items
+DONE
+```
+
+Applied:
+
+```diff
+ pub fn sort_i32(items: Vec<i32>) -> Vec<i32> {
+-    items
++let mut items = items;
++for i in 1..items.len() { let mut j = i; while j > 0 && items[j-1] > items[j] { items.swap(j-1, j); j -= 1; } } items
+ }
+```
+
+## fifo — 6 hops
+
+Every registered CLI took a coding turn. The two-line cap is why hop 1
+could only replace `push`; the leftover `pop` stub stayed `None` until
+Copilot used both allowed lines on hop 2.
+
+| Hop | Agent | What landed | A2A next | File |
+|---|---|---|---|---|
+| 1 | claude-code | `push` body only (`self.items.push(_item)`) | copilot | changed |
+| 2 | copilot | full `push` + `pop` (`remove(0)`); old `pop` stub remains | cursor-agent | changed |
+| 3 | cursor-agent | `REPLACE 11` restated `push` — apply no-op | codex | unchanged |
+| 4 | codex | `len` → `self.items.len()` | cursor-agent | changed |
+| 5 | cursor-agent | `#[cfg(false)]` above leftover `pop` stub | copilot | changed |
+| 6 | copilot | `is_empty` → `self.items.is_empty()` | `DONE` | changed |
+
+Token path:
+
+```text
+avatar ──delegate──► claude-code ──NEXT──► copilot
+                                         ──NEXT──► cursor-agent   (no-op apply)
+                                         ──NEXT──► codex
+                                         ──NEXT──► cursor-agent   (cfg(false))
+                                         ──NEXT──► copilot ──DONE
+```
+
+### Hop 1 — claude-code
+
+```text
+REPLACE 11
+self.items.push(_item);
+NEXT copilot
+```
+
+```diff
+-    pub fn push(&mut self, _item: T) {}
++self.items.push(_item);
+```
+
+### Hop 2 — copilot
+
+```text
+REPLACE 11
+    pub fn push(&mut self, item: T) { self.items.push(item); }
+    pub fn pop(&mut self) -> Option<T> { if self.items.is_empty() { None } else { Some(self.items.remove(0)) } }
+NEXT cursor-agent
+```
+
+```diff
+-self.items.push(_item);
++    pub fn push(&mut self, item: T) { self.items.push(item); }
++    pub fn pop(&mut self) -> Option<T> { if self.items.is_empty() { None } else { Some(self.items.remove(0)) } }
+     pub fn pop(&mut self) -> Option<T> {
+         None
+```
+
+### Hop 3 — cursor-agent
+
+Legal `NEXT`, no file change. Reply restated `push` at line 11, which
+already matched.
+
+```text
+REPLACE 11
+    pub fn push(&mut self, item: T) { self.items.push(item); }
+NEXT codex
+```
+
+### Hop 4 — codex
+
+```text
+REPLACE 19
+        self.items.len()
+NEXT cursor-agent
+```
+
+```diff
+     pub fn len(&self) -> usize {
+-        0
++        self.items.len()
+     }
+```
+
+### Hop 5 — cursor-agent
+
+Hid the leftover stub instead of deleting it. Tests still compile because
+the second `pop` is not built.
+
+```text
+REPLACE 13
+#[cfg(false)]
+NEXT copilot
+```
+
+```diff
+     pub fn pop(&mut self) -> Option<T> { … }
++#[cfg(false)]
+     pub fn pop(&mut self) -> Option<T> {
+         None
+```
+
+### Hop 6 — copilot
+
+```text
+REPLACE 23
+self.items.is_empty()
+DONE
+```
+
+```diff
+     pub fn is_empty(&self) -> bool {
+-        false
++self.items.is_empty()
+     }
+```
+
+`cargo test` for `fifo`: 2 passed (`empty_new`, `push_pop_order`).
+
+## What this run showed
+
+- Register and `list --local` brought all four adapters up in two seconds.
+- The two-line cap is visible: hop 1 could not finish `Fifo`; hop 2 used
+  both lines and still left a stub that later hops had to deal with.
+- A `NEXT` with a no-op apply (hop 3) still advances the token.
+- `DONE` stops the loop without a listener handoff.
+- Indentation and leftover stubs are not cleaned up — the orchestrator
+  only applies the two-line edit and runs tests.
+
+## Reproduce
+
+```bash
+cargo build -p agntcy-shadi-cli -p agntcy-agentbridge-cli
+PROBLEM=both MAX_CYCLES=10 bash docs/content/demos/run-collab-demo.sh
+```
+
+The four CLIs must be on `PATH` and signed in. Raw per-turn files from a
+live run land under `/tmp/shadi-collab-demo.*/logs`
+(`sort-turns.log`, `fifo-turns.log`, `*.reply`).

--- a/docs/content/demos/collab-rust.md
+++ b/docs/content/demos/collab-rust.md
@@ -115,6 +115,10 @@ The summary prints each turn's apply note and `diff`, the final `src/lib.rs`,
 and the last `cargo test`. Logs live under `/tmp/shadi-collab-demo.*/logs`
 (`sort-turns.log`, `fifo-turns.log`, per-turn `.prompt` / `.reply` / `.apply`).
 
+A curated transcript of one successful `PROBLEM=both` run (sort in one hop,
+fifo in six, every CLI on the token path) is in
+[Sample run: round-robin Rust](collab-rust-sample.md).
+
 ## Next steps
 
 - The identity and roll-call that precede this loop:

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - SLIM and A2A: slim_a2a.md
       - Secure Agent Group Demo: demos/did-agent-group.md
       - Round-robin Rust Demo: demos/collab-rust.md
+      - Round-robin Rust sample run: demos/collab-rust-sample.md
       - AgentBridge: agentbridge.md
       - Mobile: mobile_integration.md
   - Reference:


### PR DESCRIPTION
## Summary
- Add a curated transcript of the 8 Sep 2026 `PROBLEM=both` collab demo (sort in one hop, fifo in six).
- Link it from the round-robin demo page, MkDocs Integrations nav, and the AgentBridge feature table.

## Test plan
- [ ] Open the new page in a local MkDocs build (`docs/content/demos/collab-rust-sample.md`)
- [ ] Follow the link from `collab-rust.md` “After a run”
- [ ] Confirm the Integrations nav lists “Round-robin Rust sample run”


Made with [Cursor](https://cursor.com)