### PR TITLE
docs: spell out host-local SHADI vs multi-host AgentBridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,37 @@
 [![Crates](https://github.com/agntcy/shadi/actions/workflows/release-rust.yml/badge.svg?branch=main)](https://github.com/agntcy/shadi/actions/workflows/release-rust.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agntcy/shadi/badge)](https://scorecard.dev/viewer/?uri=github.com/agntcy/shadi)
 
-**SHADI** (Secure Host for Agentic AI Dynamic Instantiation) is a hardened
-runtime for AI agents. **AgentBridge** is the A2A interconnect that lets those
-agents work together on that host.
+**SHADI** (Secure Host for Agentic AI Dynamic Instantiation) hardens *this*
+machine. **AgentBridge** connects agents that may live on this host or on
+other hosts.
 
-SHADI is the security boundary: identity verification, gated secret access,
-OS-level sandboxing, encrypted local memory, and authenticated SLIM messaging.
-AgentBridge is how agents join that boundary as peers. It wraps Claude Code,
-Copilot, Codex, Cursor Agent, or any `CliAdapter` as a DID-signed A2A listener
-so `list --local`, `delegate`, `handoff`, and `coordinate` run over SLIM
-instead of ad-hoc pipes.
+SHADI is the local security boundary: identity verification, gated secret
+access, OS-level sandboxing, encrypted local memory, and the SLIM node this
+host admits. It does not control a remote agent's process, files, or
+sandbox — only what runs here.
+
+AgentBridge is the A2A interconnect across that gap. It wraps Claude Code,
+Copilot, Codex, Cursor Agent, or any `CliAdapter` as a DID-signed listener
+and talks to peers over SLIM, wherever they are registered. `list --local`
+shows listeners on this host; `delegate`, `handoff`, and `coordinate` reach
+a `slim://` peer on this machine or another.
 
 ## Why this repo
 
-For teams that want agents to use real tools and real credentials without
-treating the host machine as fully trusted, and to pass work between those
-agents without leaving the same identity and sandbox rules.
+For teams that want a locked-down host for the agents they run locally, and
+a way to pass work to agents that are not on that host.
 
-- Verify who an agent is before releasing secrets.
-- Constrain what a process can read, write, execute, and reach on the network.
-- Keep local memory encrypted at rest.
-- Connect agents over authenticated SLIM messaging.
-- Discover local listeners and token-pass tasks over A2A (`agentbridge`).
-- Audit changes with snapshots and runtime inspection tools.
+- Verify who a local agent is before releasing secrets on this machine.
+- Constrain what a local process can read, write, execute, and reach.
+- Keep this host's memory encrypted at rest.
+- Admit only authenticated SLIM peers onto this host's node.
+- Reach agents on other hosts over A2A (`agentbridge`), not ad-hoc pipes.
+- Audit local changes with snapshots and runtime inspection tools.
 
 ## What You Get
 
 - [`shadictl`](https://agntcy.github.io/shadi/cli/#shadictl-shadi): the main CLI for policy, sandbox execution, identity, secrets, memory, and shell control.
-- [`agentbridge`](https://agntcy.github.io/shadi/agentbridge/): the A2A interconnect — coding CLIs (Claude Code, Copilot, Codex, Cursor Agent) are the flagship peers.
+- [`agentbridge`](https://agntcy.github.io/shadi/agentbridge/): the A2A interconnect across hosts — coding CLIs (Claude Code, Copilot, Codex, Cursor Agent) are the flagship peers.
 - [`shadi_sandbox`](https://agntcy.github.io/shadi/architecture/#2-sandbox-layer): OS-enforced sandbox policy.
 - [`agent_secrets`](https://agntcy.github.io/shadi/architecture/#1-secrets-layer): keychain-backed secret storage and verification gates.
 - [`shadi_memory`](https://agntcy.github.io/shadi/architecture/#3-memory-layer): SQLCipher-backed local memory.


### PR DESCRIPTION
## Summary
- Clarify that SHADI hardens only this machine, while AgentBridge reaches A2A peers on this host or others.

## Test plan
- [ ] Read the README opening: SHADI = this host; AgentBridge = agents that may be elsewhere
- [ ] Confirm the “Why this repo” bullets no longer imply AgentBridge is local-only


Made with [Cursor](https://cursor.com)