### PR TITLE
feat(mas): add ASSEMBLY and CONVERGE group protocol

### DIFF
--- a/crates/agentbridge/src/lib.rs
+++ b/crates/agentbridge/src/lib.rs
@@ -22,8 +22,14 @@ pub use subprocess::TrackedSubprocess;
 /// agentbridge so callers have a single dependency.
 pub mod mas {
     pub use shadi_mas::{
+        engines::cascade::{CascadeEngine, CascadeEngineConfig},
         engines::development::{DevelopmentEngine, DevelopmentEngineConfig},
-        AgentId, CoordinationEngine, Epoch, EventId, EventMetadata, EventOutcome, EventSource,
-        MasRuntime, PatternKind, SemanticEvent, SemanticPayload,
+        engines::preference::{PreferenceEngine, PreferenceEngineConfig},
+        engines::resource::{ResourceEngine, ResourceEngineConfig},
+        infer_pattern, parse_announce, parse_converge_vote, AgentId, AssemblySession,
+        ConvergeBallot, ConvergeController, ConvergeDecision, ConvergeHalt, ConvergeSignal,
+        ConvergeSurface, CoordinationEngine, Epoch, EventId, EventMetadata, EventOutcome,
+        EventSource, MasRuntime, PatternKind, ProtocolPhase, ScalarProposal, SemanticEvent,
+        SemanticPayload,
     };
 }

--- a/crates/agentbridge_cli/README.md
+++ b/crates/agentbridge_cli/README.md
@@ -139,8 +139,11 @@ agentbridge delegate "write unit tests for src/parser.rs" \
 
 ### `coordinate` — autonomous multi-round coordination
 
-Run `MasRuntime<DevelopmentEngine>` across a set of agents until a winning code
-artifact is produced. Agents propose, vote, and converge without human mediation.
+Default `--pattern development` is CONVERGE on `DevelopmentEngine` until a
+winning code artifact is produced. `--pattern preference|cascade|resource`
+uses the scalar paper CONVERGE driver. `--assembly` asks the team to model
+the problem first and infer the class. The group protocol is documented in
+[ASSEMBLY and CONVERGE](../../docs/content/assembly-converge.md).
 
 ```bash
 # Local agents (in-process subprocess adapters)

--- a/crates/agentbridge_cli/src/commands/coordinate.rs
+++ b/crates/agentbridge_cli/src/commands/coordinate.rs
@@ -2,9 +2,12 @@ use agentbridge::{
     adapter::CliToolAdapter,
     adapters::generic_stdio::GenericStdioAdapter,
     mas::{
-        AgentId, CoordinationEngine, DevelopmentEngine, DevelopmentEngineConfig, Epoch, EventId,
-        EventMetadata, EventOutcome, EventSource, MasRuntime, PatternKind, SemanticEvent,
-        SemanticPayload,
+        infer_pattern, parse_announce, parse_converge_vote, AgentId, AssemblySession,
+        CascadeEngine, CascadeEngineConfig, ConvergeBallot, ConvergeController, ConvergeHalt,
+        ConvergeSurface, CoordinationEngine, DevelopmentEngine, DevelopmentEngineConfig, Epoch,
+        EventId, EventMetadata, EventOutcome, EventSource, MasRuntime, PatternKind,
+        PreferenceEngine, PreferenceEngineConfig, ResourceEngine, ResourceEngineConfig,
+        SemanticEvent, SemanticPayload,
     },
     open_profile_adapter,
 };
@@ -40,6 +43,8 @@ pub fn run(
     output: Option<&str>,
     require_human: bool,
     slim_endpoint: &str,
+    pattern: PatternKind,
+    assembly: bool,
 ) -> anyhow::Result<()> {
     let agents = build_agents(agent_specs, slim_endpoint)?;
     if agents.is_empty() {
@@ -47,6 +52,17 @@ pub fn run(
             "no agents specified — use --agents claude-code,cursor-agent,copilot,codex \
              or --agents generic-stdio:<cmd>"
         );
+    }
+
+    let mut pattern = pattern;
+    if assembly || pattern == PatternKind::Unmapped {
+        pattern = run_assembly(goal, &agents, pattern)?;
+    }
+    if pattern.is_converge_class() {
+        return run_converge(goal, &agents, max_rounds, pattern);
+    }
+    if pattern == PatternKind::Unmapped {
+        anyhow::bail!("ASSEMBLY inferred an unmapped class; CONVERGE will not start");
     }
 
     let effective_quorum = quorum.min(agents.len());
@@ -154,6 +170,156 @@ pub fn run(
         output,
         require_human,
     )
+}
+
+fn run_assembly(
+    goal: &str,
+    agents: &[AgentEntry],
+    seed: PatternKind,
+) -> anyhow::Result<PatternKind> {
+    let mut session = AssemblySession::default();
+    if seed.is_converge_class() {
+        session.inferred = Some(seed);
+    }
+    println!("─── ASSEMBLY: model the problem ───");
+    println!("Goal: {goal}\n");
+    for agent in agents {
+        let prompt = format!(
+            "phase=ASSEMBLY\nGoal: {goal}\n\
+             Understand this problem with your peers. Propose a system model.\n\
+             You may name a class beyond Preference, Cascade, or Resource.\n\
+             End with one line: CLASS <name>\nNo other protocol."
+        );
+        match invoke_tool(&agent.tool, &prompt, &agent.id.0, "assembly", 0) {
+            Ok(text) => {
+                println!("  [{}] {}", agent.id.0, truncate(&text, 160));
+                session.ingest(text);
+            }
+            Err(e) => println!("  [{}] ASSEMBLY failed: {e}", agent.id.0),
+        }
+    }
+    let inferred = session
+        .inferred
+        .or_else(|| infer_pattern(goal))
+        .unwrap_or(PatternKind::Unmapped);
+    println!("ASSEMBLY inferred {}\n", inferred.as_str());
+    Ok(inferred)
+}
+
+fn run_converge(
+    goal: &str,
+    agents: &[AgentEntry],
+    max_rounds: u64,
+    pattern: PatternKind,
+) -> anyhow::Result<()> {
+    let ids: Vec<AgentId> = agents.iter().map(|a| a.id.clone()).collect();
+    match pattern {
+        PatternKind::Preference => {
+            let cfg = PreferenceEngineConfig::line_with_participants(ids.clone(), 8.0, 0.75)
+                .map_err(anyhow::Error::msg)?;
+            let engine = PreferenceEngine::new(Epoch(0), cfg);
+            drive_converge(goal, agents, engine, max_rounds.max(1))
+        }
+        PatternKind::Cascade => {
+            let cfg = CascadeEngineConfig::scaled(ids.clone()).map_err(anyhow::Error::msg)?;
+            let horizon = max_rounds.min(cfg.paper_horizon()).max(1);
+            let engine = CascadeEngine::new(Epoch(0), cfg);
+            drive_converge(goal, agents, engine, horizon)
+        }
+        PatternKind::Resource => {
+            let cfg = ResourceEngineConfig::scaled(ids.clone()).map_err(anyhow::Error::msg)?;
+            let horizon = max_rounds.min(cfg.paper_horizon).max(1);
+            let engine = ResourceEngine::new(Epoch(0), cfg);
+            drive_converge(goal, agents, engine, horizon)
+        }
+        _ => anyhow::bail!("CONVERGE requires preference, cascade, or resource"),
+    }
+}
+
+fn drive_converge<E: ConvergeSurface>(
+    goal: &str,
+    agents: &[AgentEntry],
+    engine: E,
+    horizon: u64,
+) -> anyhow::Result<()> {
+    let ids: Vec<AgentId> = agents.iter().map(|a| a.id.clone()).collect();
+    let mut runtime = MasRuntime::new(engine);
+    let mut ctl = ConvergeController::new(ids, horizon, runtime.engine().lower_is_better(), 3);
+    println!(
+        "Starting CONVERGE: {} agents, pattern={}, horizon={horizon}",
+        agents.len(),
+        runtime.engine().pattern().as_str()
+    );
+    println!("Goal: {goal}\n");
+
+    for epoch in 0..horizon {
+        if ctl.halt().is_some() {
+            break;
+        }
+        println!("─── CONVERGE epoch {epoch}: announce ───");
+        ctl.begin_epoch();
+        let mut last = EventOutcome::Applied;
+        for agent in agents {
+            let view = runtime.engine().local_view(&agent.id);
+            let fallback = runtime.engine().current_value(&agent.id).unwrap_or(0.0);
+            let prompt = format!(
+                "phase=CONVERGE\nGoal: {goal}\nepoch={epoch}\n{view}\n\
+                 Announce the printed local value. Do not compute the next number.\n\
+                 ANNOUNCE value=<f64> agent={} epoch={epoch}\nThen VOTE CONTINUE or VOTE STOP.\n",
+                agent.id.0
+            );
+            let announced = match invoke_tool(&agent.tool, &prompt, &agent.id.0, "converge", epoch)
+            {
+                Ok(text) => {
+                    println!("  [{}] {}", agent.id.0, truncate(&text, 120));
+                    if let Some(decision) = parse_converge_vote(&text) {
+                        ctl.vote(ConvergeBallot {
+                            participant: agent.id.clone(),
+                            decision,
+                        });
+                    }
+                    parse_announce(&text).unwrap_or(fallback)
+                }
+                Err(e) => {
+                    println!("  [{}] announce failed: {e}", agent.id.0);
+                    fallback
+                }
+            };
+            let ev = runtime.engine().announce_event(
+                &agent.id,
+                epoch,
+                announced,
+                &format!("ann-{}-e{epoch}", agent.id.0),
+            );
+            last = runtime.apply(ev);
+        }
+        if let EventOutcome::Finalized(ref summary) = last {
+            let metric = runtime.engine().metric();
+            let signal = ctl.record_metric(summary.epoch, metric);
+            println!(
+                "  finalized epoch {} metric={:.6} delta={:.6} improved={}",
+                summary.epoch.0, signal.metric, signal.delta, signal.improved
+            );
+        }
+        if ctl.conclude_votes().is_some() {
+            break;
+        }
+    }
+
+    match ctl.halt() {
+        Some(ConvergeHalt::MajorityStop) => println!("CONVERGE halt: majority STOP"),
+        Some(ConvergeHalt::Plateau) => println!("CONVERGE halt: plateau"),
+        Some(ConvergeHalt::PaperHorizon) => println!("CONVERGE halt: paper horizon"),
+        Some(ConvergeHalt::NoSolution) => println!("CONVERGE halt: no solution"),
+        Some(ConvergeHalt::Unmapped) => println!("CONVERGE halt: unmapped class"),
+        None => println!("CONVERGE halt: max rounds"),
+    }
+    let c = runtime.engine().counters();
+    println!(
+        "Counters: applied={} finalized={} rejected={} deferred={}",
+        c.applied, c.finalized, c.rejected, c.deferred
+    );
+    Ok(())
 }
 
 // ─── Prompt builders ─────────────────────────────────────────────────────────
@@ -577,5 +743,76 @@ mod tests {
     fn build_agents_rejects_unknown_specs() {
         let specs = vec!["totally-unknown".to_string()];
         assert!(build_agents(&specs, "127.0.0.1:47357").is_err());
+    }
+
+    struct ReplyTool(&'static str);
+
+    impl ToolAdapter for ReplyTool {
+        fn provider(&self) -> ToolProvider {
+            ToolProvider::AgentSkills
+        }
+
+        fn call(&self, request: ToolCall) -> Result<ToolResult, String> {
+            Ok(ToolResult {
+                provider: ToolProvider::AgentSkills,
+                tool_name: request.tool_name,
+                payload: self.0.as_bytes().to_vec(),
+                target: request.target,
+                correlation_id: request.correlation_id,
+                epoch: request.epoch,
+            })
+        }
+    }
+
+    fn mock_agents(reply: &'static str, n: usize) -> Vec<AgentEntry> {
+        (0..n)
+            .map(|i| AgentEntry {
+                id: AgentId::from(i.to_string().as_str()),
+                tool: Arc::new(ReplyTool(reply)),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn assembly_infers_preference_from_class_line() {
+        let inferred = run_assembly(
+            "share scores",
+            &mock_agents("CLASS preference\nNEXT 1", 2),
+            PatternKind::Unmapped,
+        )
+        .expect("assembly");
+        assert_eq!(inferred, PatternKind::Preference);
+    }
+
+    #[test]
+    fn assembly_unknown_class_is_unmapped() {
+        let inferred = run_assembly(
+            "open markets",
+            &mock_agents("CLASS matching-markets\nDONE", 2),
+            PatternKind::Unmapped,
+        )
+        .expect("assembly");
+        assert_eq!(inferred, PatternKind::Unmapped);
+    }
+
+    #[test]
+    fn unmapped_assembly_does_not_select_a_converge_engine() {
+        let inferred = run_assembly(
+            "matching markets",
+            &mock_agents("CLASS matching-markets", 2),
+            PatternKind::Unmapped,
+        )
+        .unwrap();
+        assert_eq!(inferred, PatternKind::Unmapped);
+        assert!(!inferred.is_converge_class());
+    }
+
+    #[test]
+    fn drive_converge_halts_when_all_vote_stop() {
+        let agents = mock_agents("ANNOUNCE value=0.0\nVOTE STOP", 2);
+        let ids: Vec<AgentId> = agents.iter().map(|a| a.id.clone()).collect();
+        let cfg = PreferenceEngineConfig::line_with_participants(ids, 8.0, 0.75).expect("cfg");
+        let engine = PreferenceEngine::new(Epoch(0), cfg);
+        drive_converge("share scores", &agents, engine, 8).expect("converge");
     }
 }

--- a/crates/agentbridge_cli/src/main.rs
+++ b/crates/agentbridge_cli/src/main.rs
@@ -165,6 +165,16 @@ enum Cmd {
         /// SLIM_MEMBER_DIDS) — shared secrets are not supported.
         #[arg(long, env = "SLIM_ENDPOINT", default_value = "127.0.0.1:47357")]
         slim_endpoint: String,
+
+        /// Coordination pattern. Each value is a CONVERGE class.
+        /// `development` (default) is propose/vote for code.
+        /// `preference`, `cascade`, and `resource` use the scalar paper driver.
+        #[arg(long, default_value = "development", value_parser = shadi_mas::PatternKind::parse_cli)]
+        pattern: shadi_mas::PatternKind,
+
+        /// Run ASSEMBLY first and infer the CONVERGE class from agent replies.
+        #[arg(long)]
+        assembly: bool,
     },
 }
 
@@ -247,6 +257,8 @@ fn main() {
             output,
             require_human,
             slim_endpoint,
+            pattern,
+            assembly,
         } => commands::coordinate::run(
             &goal,
             &agents,
@@ -255,6 +267,8 @@ fn main() {
             output.as_deref(),
             require_human,
             &slim_endpoint,
+            pattern,
+            assembly,
         ),
     };
 
@@ -300,11 +314,40 @@ mod tests {
                 goal,
                 agents,
                 quorum,
+                pattern,
+                assembly,
                 ..
             } => {
                 assert_eq!(goal, "build a parser");
                 assert_eq!(agents, ["claude-code", "copilot"]);
                 assert_eq!(quorum, 2);
+                assert_eq!(pattern, shadi_mas::PatternKind::Development);
+                assert!(!assembly);
+            }
+            _ => panic!("expected coordinate subcommand"),
+        }
+    }
+
+    #[test]
+    fn parses_coordinate_converge_pattern_and_assembly() {
+        let cli = Cli::try_parse_from([
+            "agentbridge",
+            "coordinate",
+            "--goal",
+            "share a renewable stock",
+            "--agents",
+            "goose,goose",
+            "--pattern",
+            "resource",
+            "--assembly",
+        ])
+        .expect("parse");
+        match cli.command {
+            Cmd::Coordinate {
+                pattern, assembly, ..
+            } => {
+                assert_eq!(pattern, shadi_mas::PatternKind::Resource);
+                assert!(assembly);
             }
             _ => panic!("expected coordinate subcommand"),
         }

--- a/crates/shadi_mas/CHANGELOG.md
+++ b/crates/shadi_mas/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Crate README now matches the tree and points at
+  [SHADI MAS](../../docs/content/shadi-mas.md). Dropped example binaries
+  and adapter names that are not in this crate. Distinguished
+  `shadi_mas` from `slim_mas`.
+
+### Added
+
+- `PreferenceEngine` applies the synchronous Jacobi preference step on
+  epoch-tagged `ScalarProposal` values and rejects stale or replayed
+  announcements. This is not a median vote.
+- ASSEMBLY (`AssemblySession`) and CONVERGE (`ConvergeController`,
+  `CascadeEngine`, `ResourceEngine`). See
+  [ASSEMBLY and CONVERGE](../../docs/content/assembly-converge.md).
+  ASSEMBLY may name classes beyond the implemented examples; `Unmapped`
+  does not run a solver. Paper CONVERGE engines apply the class update
+  after a full epoch and halt on STOP, plateau, or the class horizon.
+  `DevelopmentEngine` is CONVERGE for a code artifact.
+
 ## [0.2.0](https://github.com/agntcy/shadi/compare/agntcy-shadi-mas-v0.1.5...agntcy-shadi-mas-v0.2.0) - 2026-09-09
 
 ### Added

--- a/crates/shadi_mas/README.md
+++ b/crates/shadi_mas/README.md
@@ -1,26 +1,36 @@
 # shadi_mas
 
-`shadi_mas` is the coordination runtime for SHADI multi-agent systems. It owns
-group and coordination semantics: round-tagged events, epoch discipline, duplicate
-and stale-event rejection, finalization rules, and the state machines that drive
-concrete coordination patterns.
+`shadi_mas` (`agntcy-shadi-mas`) is the coordination runtime for SHADI
+multi-agent systems. It owns group semantics: epochs, event discipline,
+finalization, and the engines that apply a class update.
 
-## Role in the SHADI workspace
+The site page is [SHADI MAS](../../docs/content/shadi-mas.md). The two
+group phases are
+[ASSEMBLY and CONVERGE](../../docs/content/assembly-converge.md).
 
+This crate does not own transport, identity, sandboxing, or the
+`agentbridge` CLI. It is also not `slim_mas` (SLIM group membership /
+`shadictl slim-mas`).
+
+## Role
+
+```text
+agentbridge coordinate
+        │
+        ▼
+   MasRuntime<E>
+        │
+        ▼
+ CoordinationEngine     development | preference | cascade | resource
+        │
+        ▼
+ MessagingAdapter / TaskAdapter / ToolAdapter
 ```
-shadi_mas  ←  coordination logic (this crate)
-shadi_a2a  ←  A2A task and agent interaction
-agent_transport_slim  ←  secure MLS-backed messaging transport
-agentbridge ←  CLI coding-agent adapter layer built on top of shadi_mas
-```
 
-Tool integration is modeled as a provider-aware adapter boundary with support
-for both MCP tools and AgentSkills-defined skills, so the same coordination
-runtime works with any LLM backend.
+A `ToolAdapter` may call MCP or an Agent Skill. Engines see
+`SemanticEvent` values only.
 
-## Core abstractions
-
-### `CoordinationEngine` (trait)
+## Event loop
 
 ```rust
 pub trait CoordinationEngine: Send + Sync {
@@ -30,37 +40,46 @@ pub trait CoordinationEngine: Send + Sync {
 }
 ```
 
-Engines consume `SemanticEvent` values and return `EventOutcome`:
-`Applied`, `Deferred`, `Finalized(summary)`, or `Rejected(reason)`.
+`MasRuntime<E>` forwards `apply()` and records every
+`AppliedTransition` on `history()`. Outcomes are `Applied`,
+`Deferred`, `Finalized`, or `Rejected` (duplicate, stale epoch, wrong
+pattern or payload, unknown participant).
 
-### `MasRuntime<E>`
+## ASSEMBLY and CONVERGE
 
-Wraps any engine with history tracking and a single `apply()` entry point.
-History accumulates every `AppliedTransition` for audit and replay.
+- **ASSEMBLY** — `AssemblySession` infers a class from `CLASS <name>`
+  or keywords. An unimplemented token is `PatternKind::Unmapped`.
+- **CONVERGE** — peers announce local state in the form the class
+  requires; the engine applies the update after a full epoch.
 
-### Adapter traits
-
-| Trait | Purpose |
-|-------|---------|
-| `MessagingAdapter` | Publish events to SLIM topics (real or recording) |
-| `TaskAdapter` | Dispatch A2A tasks (real or recording) |
-| `ToolAdapter` | Invoke LLM tools via MCP or AgentSkills |
+The protocol is not limited to numbers. `DevelopmentEngine` is CONVERGE
+for a code artifact. The paper examples use `ConvergeController`.
+`Unmapped` must not start a solver. Do not claim an LLM proved a
+theorem (`proves_llm_mas` is not a runtime flag).
 
 ## Engines
 
-### `PreferenceEngine`
+| Engine | Local state | Finalization |
+|--------|-------------|--------------|
+| `DevelopmentEngine` | `ExternalBytes` artifact | Quorum of `ToolResult` endorsements |
+| `PreferenceEngine` | `ScalarProposal` (`z_i`) | Jacobi step on a full inbox |
+| `CascadeEngine` | last order | Order-up-to + smoothing |
+| `ResourceEngine` | last extraction | Dual step and stock |
 
-Aggregates numeric proposals (votes) per epoch and finalizes with the median
-when a quorum is reached. Used for consensus on scalar decisions.
+`PreferenceEngine` is not a median vote. After a full epoch it sets
 
-### `DevelopmentEngine`
+```text
+z_i ← (c_i + 2β Σ_{j∈N_i} z_j) / (1 + 2β d_i)
+```
 
-Coordinates multiple agents toward a shared code artifact:
+The unique fixed point is `z* = (I + 2β L)⁻¹ c`.
 
-- Each agent submits a code proposal via `SemanticPayload::ExternalBytes`.
-- Agents endorse proposals via `SemanticPayload::ToolResult { accepted: true }`.
-- Finalization selects the artifact with the most endorsements when quorum is met.
-- `max_rounds` provides a safety cutoff to prevent infinite loops.
+`agentbridge coordinate --pattern development` (default) uses
+`DevelopmentEngine`. `--pattern preference|cascade|resource` uses the
+scalar CONVERGE driver. `--assembly` infers the class first.
+
+To add a class: implement `CoordinationEngine` under `src/engines/`,
+export it from `engines/mod.rs`, and add a `PatternKind` variant.
 
 ```rust
 let config = DevelopmentEngineConfig::new(
@@ -70,11 +89,8 @@ let config = DevelopmentEngineConfig::new(
 );
 let mut runtime = MasRuntime::new(DevelopmentEngine::new(Epoch(0), config));
 
-// Each agent submits a proposal.
 runtime.apply(dev_event("claude", b"fn parse(input: &str) -> Ast { ... }"));
 runtime.apply(dev_event("copilot", b"fn parse(s: &str) -> Result<Ast> { ... }"));
-
-// Votes determine the winner; quorum triggers finalization.
 runtime.apply(vote_event("codex", "copilot"));
 runtime.apply(dev_event("codex", b"fn parse(s: &str) -> Option<Ast> { ... }"));
 // → EventOutcome::Finalized(summary)
@@ -82,44 +98,25 @@ runtime.apply(dev_event("codex", b"fn parse(s: &str) -> Option<Ast> { ... }"));
 let winner = runtime.engine().selected_artifact(Epoch(0)).unwrap();
 ```
 
-### Extending with new engines
+## Adapters
 
-Add `crates/shadi_mas/src/engines/<pattern>.rs`, implement `CoordinationEngine`,
-and export from `engines/mod.rs`. The runtime, adapter, and test infrastructure
-work without modification.
+Traits in `adapters.rs`: `MessagingAdapter`, `TaskAdapter`,
+`ToolAdapter`.
 
-## Experiments module
+`shadi_mas::experiments` provides `RecordingMessagingAdapter`,
+`RecordingTaskAdapter`, and `LiveA2ATaskAdapter` (A2A over SLIMRPC or
+official unicast, DID-proof envelopes, `AUTH_REQUIRED` handling).
+AgentBridge supplies `CliToolAdapter`.
 
-`shadi_mas::experiments` contains:
+`LiveA2ATaskAdapter` uses TLS 1.3 and SLIM client certificates from
+`SLIM_TLS_CERT` / `SLIM_TLS_KEY` / `SLIM_TLS_CA` or
+`$SHADI_TMP_DIR/shadi-slim-mtls/`. Verify those files
+(`openssl x509 -text -noout -in <cert>`): not expired; RSA ≥ 2048 or
+P-256+; SHA-2 signatures; self-signed only for lab. Do not hardcode
+certificates or keys.
 
-- **`RecordingMessagingAdapter`** / **`RecordingTaskAdapter`** / **`RecordingToolAdapter`** — in-memory test doubles with full inspection.
-- **`LiveSlimMessagingAdapter`** — real SLIM group or point-to-point transport.
-- **`LiveA2ATaskAdapter`** — real A2A task dispatch over SLIMRPC.
-- **`CommandToolAdapter`** — invokes an external LLM (Ollama, etc.) via subprocess stdin/stdout.
-- `run_preference_experiment_with_adapters`, `run_cascade_experiment_with_adapters`, `run_resource_experiment_with_adapters` — full coordination loops usable in examples and integration tests.
-
-## Examples
-
-```bash
-# Preference consensus over recording adapters (no infrastructure needed)
-cargo run --example preference_experiment -p agntcy-shadi-mas
-
-# Cascade supply-chain coordination
-cargo run --example cascade_experiment -p agntcy-shadi-mas
-
-# Resource extraction governance
-cargo run --example resource_experiment -p agntcy-shadi-mas
-
-# Live protocol spotcheck (needs slimctl + Ollama)
-cargo run --example mas_live_protocol_spotcheck -p agntcy-shadi-mas
-```
-
-## Integration tests
-
-`tests/integration_slim.rs` exercises live adapters against a real SLIM node
-started via `slimctl slim start`. Requires pre-generated mTLS certs
-(`tools/generate_slim_mtls_certs.sh`) and `slimctl` in PATH.
+## Tests
 
 ```bash
-cargo test -p agntcy-shadi-mas --test integration_slim -- --test-threads=1
+cargo test -p agntcy-shadi-mas --lib
 ```

--- a/crates/shadi_mas/src/assembly.rs
+++ b/crates/shadi_mas/src/assembly.rs
@@ -1,0 +1,176 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! ASSEMBLY: joint modeling. Agents debate in natural language and may name a
+//! class. The three paper classes are examples, not a closed set.
+
+use crate::types::PatternKind;
+
+/// Soft ASSEMBLY session. Prose is the debate; the hypothesis is inferred.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AssemblySession {
+    pub transcript: Vec<String>,
+    pub inferred: Option<PatternKind>,
+    pub remap_count: u32,
+}
+
+impl AssemblySession {
+    pub fn ingest(&mut self, text: impl Into<String>) {
+        let text = text.into();
+        self.inferred = infer_pattern(&text).or(self.inferred);
+        self.transcript.push(text);
+    }
+
+    pub fn remap(&mut self, text: impl Into<String>) {
+        self.remap_count += 1;
+        self.inferred = None;
+        self.ingest(text);
+    }
+}
+
+/// Infer a class from ASSEMBLY text. `CLASS <name>` wins; otherwise keywords.
+/// A named class outside the three examples is [`PatternKind::Unmapped`].
+pub fn infer_pattern(text: &str) -> Option<PatternKind> {
+    if let Some(named) = class_line(text) {
+        return Some(named);
+    }
+    keyword_scores(text)
+}
+
+fn class_line(text: &str) -> Option<PatternKind> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let rest = trimmed
+            .strip_prefix("CLASS ")
+            .or_else(|| trimmed.strip_prefix("CLASS="))
+            .or_else(|| trimmed.strip_prefix("class "))?;
+        let token = rest
+            .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+            .find(|t| !t.is_empty())?;
+        if let Some(kind) = PatternKind::parse_name(token) {
+            return Some(kind);
+        }
+        return Some(PatternKind::Unmapped);
+    }
+    None
+}
+
+fn keyword_scores(text: &str) -> Option<PatternKind> {
+    let lower = text.to_ascii_lowercase();
+    let preference = count_hits(
+        &lower,
+        &[
+            "preference",
+            "jacobi",
+            "neighbor",
+            "quadratic",
+            "shared score",
+        ],
+    );
+    let cascade = count_hits(
+        &lower,
+        &[
+            "cascade",
+            "inventory",
+            "pipeline",
+            "supply chain",
+            "retailer",
+            "factory",
+            "order-up-to",
+        ],
+    );
+    let resource = count_hits(
+        &lower,
+        &[
+            "resource",
+            "extraction",
+            "quota",
+            "renewable",
+            "stock",
+            "lambda",
+        ],
+    );
+    let best = [
+        (PatternKind::Preference, preference),
+        (PatternKind::Cascade, cascade),
+        (PatternKind::Resource, resource),
+    ]
+    .into_iter()
+    .max_by_key(|(_, n)| *n)?;
+    if best.1 == 0 {
+        return None;
+    }
+    let ties = [preference, cascade, resource]
+        .into_iter()
+        .filter(|n| *n == best.1)
+        .count();
+    if ties > 1 {
+        return None;
+    }
+    Some(best.0)
+}
+
+fn count_hits(hay: &str, needles: &[&str]) -> usize {
+    needles.iter().filter(|n| hay.contains(*n)).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_line_maps_paper_examples() {
+        assert_eq!(
+            infer_pattern("CLASS preference"),
+            Some(PatternKind::Preference)
+        );
+        assert_eq!(infer_pattern("CLASS cascade\n"), Some(PatternKind::Cascade));
+        assert_eq!(
+            infer_pattern("we agree\nCLASS resource"),
+            Some(PatternKind::Resource)
+        );
+        assert_eq!(
+            infer_pattern("CLASS development"),
+            Some(PatternKind::Development)
+        );
+        assert_eq!(infer_pattern("CLASS=cascade"), Some(PatternKind::Cascade));
+    }
+
+    #[test]
+    fn unknown_class_is_unmapped() {
+        assert_eq!(
+            infer_pattern("CLASS matching-markets"),
+            Some(PatternKind::Unmapped)
+        );
+    }
+
+    #[test]
+    fn keywords_infer_without_class_line() {
+        assert_eq!(
+            infer_pattern("blend neighbor scores on a line"),
+            Some(PatternKind::Preference)
+        );
+        assert_eq!(
+            infer_pattern("factory and retailer inventory pipeline"),
+            Some(PatternKind::Cascade)
+        );
+        assert_eq!(
+            infer_pattern("shared renewable stock and extraction quota"),
+            Some(PatternKind::Resource)
+        );
+    }
+
+    #[test]
+    fn session_keeps_last_stable_hypothesis() {
+        let mut session = AssemblySession::default();
+        session.ingest("talk only");
+        assert_eq!(session.inferred, None);
+        session.ingest("CLASS preference");
+        assert_eq!(session.inferred, Some(PatternKind::Preference));
+        session.ingest("more talk");
+        assert_eq!(session.inferred, Some(PatternKind::Preference));
+        session.remap("CLASS matching-markets");
+        assert_eq!(session.inferred, Some(PatternKind::Unmapped));
+        assert_eq!(session.remap_count, 1);
+    }
+}

--- a/crates/shadi_mas/src/engines/cascade.rs
+++ b/crates/shadi_mas/src/engines/cascade.rs
@@ -1,0 +1,366 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Supply-chain CONVERGE engine. Agents announce last order; the engine
+//! applies the paper order-up-to + smoothing update.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use crate::engines::converge::{scalar_announce, ConvergeSurface};
+use crate::runtime::CoordinationEngine;
+use crate::types::{
+    AgentId, Epoch, EventId, EventOutcome, EventSource, FinalizationSummary, PatternKind,
+    RejectReason, RuntimeCounters, ScalarProposal, SemanticEvent, SemanticPayload,
+};
+
+pub const LEAD: usize = 2;
+pub const TARGET_I: f64 = 8.0;
+pub const I0: f64 = 8.0;
+pub const HOLD_COST: f64 = 1.0;
+pub const BACKLOG_COST: f64 = 2.0;
+pub const SMOOTH: f64 = 0.5;
+pub const RHO: f64 = 1.0;
+pub const PAPER_DEMAND: [f64; 8] = [4.0, 4.0, 4.0, 8.0, 8.0, 8.0, 4.0, 4.0];
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CascadeEngineConfig {
+    pub participants: Vec<AgentId>,
+    pub lead: usize,
+    pub target_i: f64,
+    pub demand: Vec<f64>,
+    pub hold_cost: f64,
+    pub backlog_cost: f64,
+    pub smooth: f64,
+    pub rho: f64,
+}
+
+impl CascadeEngineConfig {
+    pub fn scaled(participants: Vec<AgentId>) -> Result<Self, String> {
+        if participants.len() < 2 {
+            return Err("cascade needs at least two stages".to_string());
+        }
+        Ok(Self {
+            participants,
+            lead: LEAD,
+            target_i: TARGET_I,
+            demand: PAPER_DEMAND.to_vec(),
+            hold_cost: HOLD_COST,
+            backlog_cost: BACKLOG_COST,
+            smooth: SMOOTH,
+            rho: RHO,
+        })
+    }
+
+    pub fn index_of(&self, id: &AgentId) -> Option<usize> {
+        self.participants.iter().position(|p| p == id)
+    }
+
+    pub fn paper_horizon(&self) -> u64 {
+        self.demand.len() as u64
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CascadeEngine {
+    active_epoch: Epoch,
+    config: CascadeEngineConfig,
+    inventory: Vec<f64>,
+    last_q: Vec<f64>,
+    pipeline: Vec<VecDeque<f64>>,
+    last_demand: Vec<f64>,
+    cost: f64,
+    t: usize,
+    announced: BTreeMap<usize, f64>,
+    seen_events: BTreeSet<EventId>,
+    counters: RuntimeCounters,
+}
+
+impl CascadeEngine {
+    pub fn new(active_epoch: Epoch, config: CascadeEngineConfig) -> Self {
+        let n = config.participants.len();
+        let lead = config.lead.max(1);
+        Self {
+            active_epoch,
+            inventory: vec![I0; n],
+            last_q: vec![4.0; n],
+            pipeline: (0..n).map(|_| VecDeque::from(vec![4.0; lead])).collect(),
+            last_demand: vec![4.0; n],
+            cost: 0.0,
+            t: 0,
+            announced: BTreeMap::new(),
+            seen_events: BTreeSet::new(),
+            counters: RuntimeCounters::default(),
+            config,
+        }
+    }
+
+    pub fn active_epoch(&self) -> Epoch {
+        self.active_epoch
+    }
+
+    pub fn config(&self) -> &CascadeEngineConfig {
+        &self.config
+    }
+
+    pub fn cost(&self) -> f64 {
+        self.cost
+    }
+
+    pub fn last_q(&self) -> &[f64] {
+        &self.last_q
+    }
+
+    pub fn inventory(&self) -> &[f64] {
+        &self.inventory
+    }
+
+    fn observed_demand(&self, index: usize) -> f64 {
+        let n = self.config.participants.len();
+        if index + 1 == n {
+            self.config.demand[self.t.min(self.config.demand.len().saturating_sub(1))]
+        } else {
+            self.last_q[index + 1]
+        }
+    }
+
+    fn pipeline_sum(&self, index: usize) -> f64 {
+        self.pipeline[index].iter().sum()
+    }
+
+    fn qbar(&self, index: usize) -> f64 {
+        let n = self.config.participants.len();
+        if index + 1 < n {
+            self.last_q[index + 1]
+        } else {
+            self.last_demand[index]
+        }
+    }
+
+    pub fn formula_value(&self, index: usize) -> f64 {
+        let dhat = self.observed_demand(index);
+        let q_hat = (self.config.target_i + self.config.lead as f64 * dhat
+            - self.inventory[index]
+            - self.pipeline_sum(index))
+        .max(0.0);
+        (q_hat + self.config.rho * self.qbar(index)) / (1.0 + self.config.rho)
+    }
+
+    fn apply_orders(&mut self, orders: Vec<f64>) {
+        let n = self.config.participants.len();
+        let customer = self.config.demand[self.t.min(self.config.demand.len().saturating_sub(1))];
+        for i in 0..n {
+            let arriving = self.pipeline[i].pop_front().unwrap_or(0.0);
+            let demand = if i + 1 == n { customer } else { orders[i + 1] };
+            self.inventory[i] += arriving - demand;
+            let hold = self.config.hold_cost * self.inventory[i].max(0.0);
+            let backlog = self.config.backlog_cost * (-self.inventory[i]).max(0.0);
+            let smooth = self.config.smooth * (orders[i] - self.last_q[i]).powi(2);
+            self.cost += hold + backlog + smooth;
+            self.last_demand[i] = demand;
+            self.pipeline[i].push_back(orders[i]);
+            self.last_q[i] = orders[i];
+        }
+        self.t += 1;
+    }
+
+    fn participant_from_event(
+        &self,
+        event: &SemanticEvent,
+        payload: &ScalarProposal,
+    ) -> Option<usize> {
+        let from_payload = self.config.index_of(&payload.participant)?;
+        match &event.metadata.source {
+            EventSource::Peer(id) => self.config.index_of(id).filter(|&i| i == from_payload),
+            EventSource::Local => Some(from_payload),
+            EventSource::Tool(name) => self
+                .config
+                .index_of(&AgentId::from(name.as_str()))
+                .filter(|&i| i == from_payload),
+            EventSource::Task(_) | EventSource::Recovery => None,
+        }
+    }
+
+    fn try_finalize(&mut self) -> Option<FinalizationSummary> {
+        let n = self.config.participants.len();
+        if self.announced.len() < n {
+            return None;
+        }
+        let orders: Vec<f64> = (0..n).map(|i| self.formula_value(i)).collect();
+        self.apply_orders(orders);
+        self.announced.clear();
+        let summary = FinalizationSummary {
+            epoch: self.active_epoch,
+            participants: n,
+            selected_value: n as i64,
+        };
+        self.active_epoch = Epoch(self.active_epoch.0 + 1);
+        self.counters.finalized += 1;
+        Some(summary)
+    }
+}
+
+impl CoordinationEngine for CascadeEngine {
+    fn pattern(&self) -> PatternKind {
+        PatternKind::Cascade
+    }
+
+    fn apply(&mut self, event: SemanticEvent) -> EventOutcome {
+        if event.pattern != PatternKind::Cascade {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePattern);
+        }
+        if event.metadata.epoch < self.active_epoch {
+            self.counters.rejected += 1;
+            self.counters.stale += 1;
+            return EventOutcome::Rejected(RejectReason::StaleEpoch {
+                current: self.active_epoch,
+            });
+        }
+        if event.metadata.epoch > self.active_epoch {
+            self.counters.deferred += 1;
+            return EventOutcome::Deferred {
+                expected: self.active_epoch,
+                received: event.metadata.epoch,
+            };
+        }
+        if !self.seen_events.insert(event.metadata.event_id.clone()) {
+            self.counters.rejected += 1;
+            self.counters.duplicates += 1;
+            return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+        }
+        let SemanticPayload::ScalarProposal(ref payload) = event.payload else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        };
+        let Some(idx) = self.participant_from_event(&event, payload) else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::UnknownParticipant);
+        };
+        if !payload.value.is_finite() || self.announced.contains_key(&idx) {
+            self.counters.rejected += 1;
+            if self.announced.contains_key(&idx) {
+                self.counters.duplicates += 1;
+                return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+            }
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        }
+        self.announced.insert(idx, payload.value);
+        self.counters.applied += 1;
+        match self.try_finalize() {
+            Some(summary) => EventOutcome::Finalized(summary),
+            None => EventOutcome::Applied,
+        }
+    }
+
+    fn counters(&self) -> RuntimeCounters {
+        self.counters.clone()
+    }
+}
+
+impl ConvergeSurface for CascadeEngine {
+    fn current_value(&self, id: &AgentId) -> Option<f64> {
+        self.config.index_of(id).map(|i| self.last_q[i])
+    }
+
+    fn metric(&self) -> f64 {
+        self.cost
+    }
+
+    fn lower_is_better(&self) -> bool {
+        true
+    }
+
+    fn local_view(&self, id: &AgentId) -> String {
+        let Some(i) = self.config.index_of(id) else {
+            return String::new();
+        };
+        format!(
+            "agent={}\nI_i={:.6}\npipeline_sum={:.6}\nlast_order={:.6}\nobserved_demand={:.6}",
+            id.0,
+            self.inventory[i],
+            self.pipeline_sum(i),
+            self.last_q[i],
+            self.observed_demand(i)
+        )
+    }
+
+    fn announce_event(
+        &self,
+        id: &AgentId,
+        epoch: u64,
+        value: f64,
+        event_id: &str,
+    ) -> SemanticEvent {
+        scalar_announce(PatternKind::Cascade, id, epoch, value, event_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::MasRuntime;
+
+    fn ids(n: usize) -> Vec<AgentId> {
+        (0..n)
+            .map(|i| AgentId::from(format!("goose-{i}").as_str()))
+            .collect()
+    }
+
+    fn announce_all(rt: &mut MasRuntime<CascadeEngine>, epoch: u64) -> EventOutcome {
+        let n = rt.engine().config().participants.len();
+        let mut last = EventOutcome::Applied;
+        for i in 0..n {
+            let id = rt.engine().config().participants[i].clone();
+            let value = rt.engine().last_q()[i];
+            last =
+                rt.apply(
+                    rt.engine()
+                        .announce_event(&id, epoch, value, &format!("c{epoch}-{i}")),
+                );
+        }
+        last
+    }
+
+    #[test]
+    fn paper_instance_accumulates_cost() {
+        let cfg = CascadeEngineConfig::scaled(ids(4)).expect("cfg");
+        let mut rt = MasRuntime::new(CascadeEngine::new(Epoch(0), cfg));
+        for epoch in 0..8 {
+            assert!(matches!(
+                announce_all(&mut rt, epoch),
+                EventOutcome::Finalized(_)
+            ));
+        }
+        assert!(rt.engine().cost() > 0.0);
+        assert_eq!(rt.engine().active_epoch(), Epoch(8));
+    }
+
+    #[test]
+    fn stale_epoch_rejected() {
+        let cfg = CascadeEngineConfig::scaled(ids(2)).expect("cfg");
+        let mut rt = MasRuntime::new(CascadeEngine::new(Epoch(0), cfg));
+        assert!(matches!(
+            announce_all(&mut rt, 0),
+            EventOutcome::Finalized(_)
+        ));
+        let id = rt.engine().config().participants[0].clone();
+        let ev = rt.engine().announce_event(&id, 0, 1.0, "late");
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::StaleEpoch { current: Epoch(1) })
+        );
+    }
+
+    #[test]
+    fn wrong_pattern_is_rejected() {
+        let cfg = CascadeEngineConfig::scaled(ids(2)).expect("cfg");
+        let mut rt = MasRuntime::new(CascadeEngine::new(Epoch(0), cfg));
+        let id = rt.engine().config().participants[0].clone();
+        let mut ev = rt.engine().announce_event(&id, 0, 1.0, "wrong");
+        ev.pattern = PatternKind::Preference;
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::IncompatiblePattern)
+        );
+    }
+}

--- a/crates/shadi_mas/src/engines/cascade.rs
+++ b/crates/shadi_mas/src/engines/cascade.rs
@@ -363,4 +363,117 @@ mod tests {
             EventOutcome::Rejected(RejectReason::IncompatiblePattern)
         );
     }
+
+    #[test]
+    fn scaled_rejects_a_single_stage() {
+        assert!(CascadeEngineConfig::scaled(ids(1)).is_err());
+    }
+
+    #[test]
+    fn reject_paths_and_source_aliases() {
+        use crate::types::{EventMetadata, EventSource, SemanticPayload};
+
+        let cfg = CascadeEngineConfig::scaled(ids(2)).expect("cfg");
+        let mut rt = MasRuntime::new(CascadeEngine::new(Epoch(0), cfg));
+        let id0 = rt.engine().config().participants[0].clone();
+        let id1 = rt.engine().config().participants[1].clone();
+
+        assert_eq!(
+            rt.apply(rt.engine().announce_event(&id0, 3, 1.0, "future")),
+            EventOutcome::Deferred {
+                expected: Epoch(0),
+                received: Epoch(3)
+            }
+        );
+
+        let first = rt.engine().announce_event(&id0, 0, 1.0, "dup");
+        assert_eq!(rt.apply(first.clone()), EventOutcome::Applied);
+        assert_eq!(
+            rt.apply(first),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+        assert_eq!(
+            rt.apply(rt.engine().announce_event(&id0, 0, 2.0, "again")),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+
+        let mut ghost = rt.engine().announce_event(&id0, 0, 1.0, "ghost");
+        ghost.payload = SemanticPayload::ScalarProposal(ScalarProposal {
+            participant: AgentId::from("ghost"),
+            value: 1.0,
+        });
+        ghost.metadata.source = EventSource::Peer(AgentId::from("ghost"));
+        assert_eq!(
+            rt.apply(ghost),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+
+        let bytes = SemanticEvent {
+            pattern: PatternKind::Cascade,
+            metadata: EventMetadata {
+                event_id: EventId::from("bytes"),
+                correlation_id: None,
+                epoch: Epoch(0),
+                source: EventSource::Peer(id1.clone()),
+            },
+            payload: SemanticPayload::ExternalBytes(b"nope".to_vec()),
+        };
+        assert_eq!(
+            rt.apply(bytes),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+
+        let nan = rt.engine().announce_event(&id1, 0, f64::NAN, "nan");
+        assert_eq!(
+            rt.apply(nan),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+
+        let mut local = rt.engine().announce_event(&id1, 0, 4.0, "local");
+        local.metadata.source = EventSource::Local;
+        assert_eq!(
+            rt.apply(local),
+            EventOutcome::Finalized(FinalizationSummary {
+                epoch: Epoch(0),
+                participants: 2,
+                selected_value: 2,
+            })
+        );
+
+        let mut tool = rt.engine().announce_event(&id0, 1, 4.0, "tool");
+        tool.metadata.source = EventSource::Tool(id0.0.clone());
+        assert_eq!(rt.apply(tool), EventOutcome::Applied);
+        let mut task = rt.engine().announce_event(&id1, 1, 4.0, "task");
+        task.metadata.source = EventSource::Task("t".into());
+        assert_eq!(
+            rt.apply(task),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+        let mut recovery = rt.engine().announce_event(&id1, 1, 4.0, "rec");
+        recovery.metadata.source = EventSource::Recovery;
+        assert_eq!(
+            rt.apply(recovery),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+    }
+
+    #[test]
+    fn surface_and_formula_are_defined() {
+        let cfg = CascadeEngineConfig::scaled(ids(3)).expect("cfg");
+        let engine = CascadeEngine::new(Epoch(0), cfg);
+        let id = engine.config().participants[0].clone();
+        let unknown = AgentId::from("ghost");
+        assert_eq!(engine.pattern(), PatternKind::Cascade);
+        assert!(engine.lower_is_better());
+        assert_eq!(engine.current_value(&id), Some(4.0));
+        assert_eq!(engine.current_value(&unknown), None);
+        assert!(engine.local_view(&id).contains("last_order="));
+        assert!(engine.local_view(&unknown).is_empty());
+        assert_eq!(engine.inventory().len(), 3);
+        assert_eq!(engine.last_q().len(), 3);
+        assert!(engine.formula_value(0) >= 0.0);
+        assert!(engine.formula_value(2) >= 0.0);
+        assert_eq!(engine.config().paper_horizon(), 8);
+        assert_eq!(engine.counters().applied, 0);
+    }
 }

--- a/crates/shadi_mas/src/engines/converge.rs
+++ b/crates/shadi_mas/src/engines/converge.rs
@@ -1,0 +1,246 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! CONVERGE halt: improvement signal, STOP/CONTINUE, plateau, paper horizon.
+
+use std::collections::BTreeMap;
+
+use crate::runtime::CoordinationEngine;
+use crate::types::{
+    AgentId, ConvergeBallot, ConvergeDecision, ConvergeHalt, ConvergeSignal, Epoch, PatternKind,
+    ScalarProposal, SemanticEvent,
+};
+
+const IMPROVE_EPS: f64 = 1e-9;
+
+/// Tracks CONVERGE progress after each engine-finalized epoch.
+#[derive(Clone, Debug)]
+pub struct ConvergeController {
+    pub participants: Vec<AgentId>,
+    pub plateau_k: u32,
+    pub paper_horizon: u64,
+    pub lower_is_better: bool,
+    last_metric: Option<f64>,
+    non_improving: u32,
+    epochs_done: u64,
+    votes: BTreeMap<AgentId, ConvergeDecision>,
+    halt: Option<ConvergeHalt>,
+}
+
+impl ConvergeController {
+    pub fn new(
+        participants: Vec<AgentId>,
+        paper_horizon: u64,
+        lower_is_better: bool,
+        plateau_k: u32,
+    ) -> Self {
+        Self {
+            participants,
+            plateau_k: plateau_k.max(1),
+            paper_horizon: paper_horizon.max(1),
+            lower_is_better,
+            last_metric: None,
+            non_improving: 0,
+            epochs_done: 0,
+            votes: BTreeMap::new(),
+            halt: None,
+        }
+    }
+
+    pub fn halt(&self) -> Option<ConvergeHalt> {
+        self.halt
+    }
+
+    pub fn begin_epoch(&mut self) {
+        self.votes.clear();
+    }
+
+    pub fn mark_unmapped(&mut self) {
+        self.halt = Some(ConvergeHalt::Unmapped);
+    }
+
+    pub fn record_metric(&mut self, epoch: Epoch, metric: f64) -> ConvergeSignal {
+        let previous = self.last_metric;
+        let delta = previous.map(|p| metric - p).unwrap_or(0.0);
+        let improved = match previous {
+            None => true,
+            Some(prev) if self.lower_is_better => metric < prev - IMPROVE_EPS,
+            Some(prev) => metric > prev + IMPROVE_EPS,
+        };
+        if improved {
+            self.non_improving = 0;
+        } else if previous.is_some() {
+            self.non_improving += 1;
+        }
+        self.last_metric = Some(metric);
+        self.epochs_done += 1;
+        if self.epochs_done >= self.paper_horizon {
+            self.halt = Some(ConvergeHalt::PaperHorizon);
+        } else if self.non_improving >= self.plateau_k {
+            self.halt = Some(if previous.is_some() && !improved && self.epochs_done > 1 {
+                ConvergeHalt::NoSolution
+            } else {
+                ConvergeHalt::Plateau
+            });
+        }
+        ConvergeSignal {
+            epoch,
+            metric,
+            previous,
+            delta,
+            improved,
+        }
+    }
+
+    pub fn vote(&mut self, ballot: ConvergeBallot) {
+        if self.participants.iter().any(|p| p == &ballot.participant) {
+            self.votes.insert(ballot.participant, ballot.decision);
+        }
+    }
+
+    pub fn conclude_votes(&mut self) -> Option<ConvergeHalt> {
+        if self.halt.is_some() {
+            return self.halt;
+        }
+        let n = self.participants.len().max(1);
+        let stops = self
+            .votes
+            .values()
+            .filter(|d| **d == ConvergeDecision::Stop)
+            .count();
+        if stops * 2 > n {
+            self.halt = Some(ConvergeHalt::MajorityStop);
+        }
+        self.halt
+    }
+}
+
+pub fn parse_announce(text: &str) -> Option<f64> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        let rest = trimmed
+            .strip_prefix("ANNOUNCE value=")
+            .or_else(|| trimmed.strip_prefix("ANNOUNCE "))
+            .or_else(|| trimmed.strip_prefix("COMMIT proposal="))?;
+        let token = rest.split(|c: char| c.is_whitespace() || c == ',').next()?;
+        if let Ok(value) = token.parse::<f64>() {
+            if value.is_finite() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+pub fn parse_converge_vote(text: &str) -> Option<ConvergeDecision> {
+    for line in text.lines() {
+        let upper = line.trim().to_ascii_uppercase();
+        if upper.starts_with("VOTE STOP") || upper == "STOP" {
+            return Some(ConvergeDecision::Stop);
+        }
+        if upper.starts_with("VOTE CONTINUE") || upper == "CONTINUE" {
+            return Some(ConvergeDecision::Continue);
+        }
+    }
+    None
+}
+
+/// Surface a CONVERGE engine exposes to `coordinate` / tests.
+pub trait ConvergeSurface: CoordinationEngine {
+    fn current_value(&self, id: &AgentId) -> Option<f64>;
+    fn metric(&self) -> f64;
+    fn lower_is_better(&self) -> bool;
+    fn local_view(&self, id: &AgentId) -> String;
+    fn announce_event(&self, id: &AgentId, epoch: u64, value: f64, event_id: &str)
+        -> SemanticEvent;
+}
+
+pub fn scalar_announce(
+    pattern: PatternKind,
+    id: &AgentId,
+    epoch: u64,
+    value: f64,
+    event_id: &str,
+) -> SemanticEvent {
+    use crate::types::{EventId, EventMetadata, EventSource, SemanticPayload};
+
+    SemanticEvent {
+        pattern,
+        metadata: EventMetadata {
+            event_id: EventId::from(event_id),
+            correlation_id: None,
+            epoch: Epoch(epoch),
+            source: EventSource::Peer(id.clone()),
+        },
+        payload: SemanticPayload::ScalarProposal(ScalarProposal {
+            participant: id.clone(),
+            value,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids() -> Vec<AgentId> {
+        vec![AgentId::from("a"), AgentId::from("b"), AgentId::from("c")]
+    }
+
+    #[test]
+    fn majority_stop_halts() {
+        let mut ctl = ConvergeController::new(ids(), 8, true, 3);
+        ctl.record_metric(Epoch(0), 1.0);
+        ctl.vote(ConvergeBallot {
+            participant: AgentId::from("a"),
+            decision: ConvergeDecision::Stop,
+        });
+        ctl.vote(ConvergeBallot {
+            participant: AgentId::from("b"),
+            decision: ConvergeDecision::Stop,
+        });
+        ctl.vote(ConvergeBallot {
+            participant: AgentId::from("c"),
+            decision: ConvergeDecision::Continue,
+        });
+        assert_eq!(ctl.conclude_votes(), Some(ConvergeHalt::MajorityStop));
+    }
+
+    #[test]
+    fn paper_horizon_halts() {
+        let mut ctl = ConvergeController::new(ids(), 2, true, 8);
+        ctl.record_metric(Epoch(0), 2.0);
+        assert_eq!(ctl.halt(), None);
+        ctl.record_metric(Epoch(1), 1.0);
+        assert_eq!(ctl.halt(), Some(ConvergeHalt::PaperHorizon));
+    }
+
+    #[test]
+    fn plateau_without_improvement_is_no_solution() {
+        let mut ctl = ConvergeController::new(ids(), 20, true, 2);
+        ctl.record_metric(Epoch(0), 1.0);
+        ctl.record_metric(Epoch(1), 1.0);
+        ctl.record_metric(Epoch(2), 1.0);
+        assert_eq!(ctl.halt(), Some(ConvergeHalt::NoSolution));
+    }
+
+    #[test]
+    fn parse_announce_and_vote_lines() {
+        assert_eq!(
+            parse_announce("ANNOUNCE value=1.5 agent=goose-0"),
+            Some(1.5)
+        );
+        assert_eq!(parse_announce("COMMIT proposal=2.25 agent=a"), Some(2.25));
+        assert_eq!(parse_announce("ANNOUNCE nan"), None);
+        assert_eq!(
+            parse_converge_vote("VOTE CONTINUE\nNEXT goose-1"),
+            Some(ConvergeDecision::Continue)
+        );
+        assert_eq!(
+            parse_converge_vote("VOTE STOP"),
+            Some(ConvergeDecision::Stop)
+        );
+        assert_eq!(parse_converge_vote("STOP"), Some(ConvergeDecision::Stop));
+        assert_eq!(parse_converge_vote("NEXT goose-1"), None);
+    }
+}

--- a/crates/shadi_mas/src/engines/converge.rs
+++ b/crates/shadi_mas/src/engines/converge.rs
@@ -242,5 +242,36 @@ mod tests {
         );
         assert_eq!(parse_converge_vote("STOP"), Some(ConvergeDecision::Stop));
         assert_eq!(parse_converge_vote("NEXT goose-1"), None);
+        assert_eq!(parse_announce("ANNOUNCE 3.25 extra"), Some(3.25));
+        assert_eq!(
+            parse_converge_vote("CONTINUE"),
+            Some(ConvergeDecision::Continue)
+        );
+    }
+
+    #[test]
+    fn unmapped_and_higher_is_better() {
+        let mut ctl = ConvergeController::new(ids(), 8, false, 3);
+        ctl.mark_unmapped();
+        assert_eq!(ctl.halt(), Some(ConvergeHalt::Unmapped));
+        assert_eq!(ctl.conclude_votes(), Some(ConvergeHalt::Unmapped));
+
+        let mut stock = ConvergeController::new(ids(), 8, false, 3);
+        stock.begin_epoch();
+        let first = stock.record_metric(Epoch(0), 10.0);
+        assert!(first.improved);
+        let second = stock.record_metric(Epoch(1), 12.0);
+        assert!(second.improved);
+        stock.vote(ConvergeBallot {
+            participant: AgentId::from("ghost"),
+            decision: ConvergeDecision::Stop,
+        });
+        assert_eq!(stock.conclude_votes(), None);
+        stock.begin_epoch();
+        stock.vote(ConvergeBallot {
+            participant: AgentId::from("a"),
+            decision: ConvergeDecision::Continue,
+        });
+        assert_eq!(stock.conclude_votes(), None);
     }
 }

--- a/crates/shadi_mas/src/engines/mod.rs
+++ b/crates/shadi_mas/src/engines/mod.rs
@@ -1,1 +1,5 @@
+pub mod cascade;
+pub mod converge;
 pub mod development;
+pub mod preference;
+pub mod resource;

--- a/crates/shadi_mas/src/engines/preference.rs
+++ b/crates/shadi_mas/src/engines/preference.rs
@@ -1,0 +1,627 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synchronous Jacobi preference engine (Thm. preference-linear).
+//!
+//! Each epoch, every participant announces its current `z_i` as a
+//! [`ScalarProposal`](crate::types::ScalarProposal). When the full round set
+//! is present, the engine applies
+//!
+//! `z_i ← (c_i + 2β Σ_{j∈N_i} z_j) / (1 + 2β d_i)`
+//!
+//! simultaneously (Jacobi, not Gauss–Seidel) and finalizes the epoch.
+//! Untagged / wrong-epoch / replayed / unknown announcements are rejected.
+//! This is not a median vote.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::engines::converge::{scalar_announce, ConvergeSurface};
+use crate::runtime::CoordinationEngine;
+use crate::types::{
+    AgentId, Epoch, EventId, EventOutcome, EventSource, FinalizationSummary, PatternKind,
+    RejectReason, RuntimeCounters, ScalarProposal, SemanticEvent, SemanticPayload,
+};
+
+const SINGULAR: f64 = 1e-15;
+
+/// Line (or general graph) quadratic-preference instance.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PreferenceEngineConfig {
+    pub participants: Vec<AgentId>,
+    pub neighbors: Vec<Vec<usize>>,
+    pub preferences: Vec<f64>,
+    pub beta: f64,
+    pub z_star: Vec<f64>,
+}
+
+impl PreferenceEngineConfig {
+    /// Build a config. `z*` is `(I + 2β L)^{-1} c`.
+    pub fn new(
+        participants: Vec<AgentId>,
+        neighbors: Vec<Vec<usize>>,
+        preferences: Vec<f64>,
+        beta: f64,
+    ) -> Result<Self, String> {
+        let n = participants.len();
+        if n == 0 {
+            return Err("preference instance needs at least one participant".to_string());
+        }
+        if neighbors.len() != n || preferences.len() != n {
+            return Err(
+                "participants, neighbors, and preferences must have the same length".to_string(),
+            );
+        }
+        if beta <= 0.0 || !beta.is_finite() {
+            return Err("beta must be a positive finite number".to_string());
+        }
+        for (i, nb) in neighbors.iter().enumerate() {
+            for &j in nb {
+                if j >= n || j == i {
+                    return Err(format!("invalid neighbor {j} of node {i}"));
+                }
+            }
+        }
+        let z_star = solve_z_star(&neighbors, &preferences, beta)?;
+        Ok(Self {
+            participants,
+            neighbors,
+            preferences,
+            beta,
+            z_star,
+        })
+    }
+
+    /// Path graph with uniformly spaced preferences, paper β = 0.75.
+    pub fn line(n: usize, c_span: f64, beta: f64) -> Result<Self, String> {
+        let participants = (0..n)
+            .map(|i| AgentId::from(i.to_string().as_str()))
+            .collect();
+        Self::line_with_participants(participants, c_span, beta)
+    }
+
+    /// Path graph with caller-supplied participant ids.
+    pub fn line_with_participants(
+        participants: Vec<AgentId>,
+        c_span: f64,
+        beta: f64,
+    ) -> Result<Self, String> {
+        let n = participants.len();
+        if n < 2 {
+            return Err("line needs n >= 2".to_string());
+        }
+        let preferences = (0..n).map(|i| c_span * i as f64 / (n - 1) as f64).collect();
+        let mut neighbors = vec![Vec::new(); n];
+        for i in 0..n {
+            if i > 0 {
+                neighbors[i].push(i - 1);
+            }
+            if i + 1 < n {
+                neighbors[i].push(i + 1);
+            }
+        }
+        Self::new(participants, neighbors, preferences, beta)
+    }
+
+    pub fn index_of(&self, id: &AgentId) -> Option<usize> {
+        self.participants.iter().position(|p| p == id)
+    }
+
+    pub fn degree(&self, i: usize) -> usize {
+        self.neighbors[i].len()
+    }
+
+    /// Local Jacobi step from a neighbor inbox (values at the *previous* iterate).
+    pub fn jacobi(&self, node: usize, inbox: &BTreeMap<usize, f64>) -> Result<f64, String> {
+        let mut total = 0.0;
+        for &j in &self.neighbors[node] {
+            let Some(value) = inbox.get(&j) else {
+                return Err(format!("missing neighbor {j} for node {node}"));
+            };
+            total += *value;
+        }
+        let d = self.degree(node) as f64;
+        Ok((self.preferences[node] + 2.0 * self.beta * total) / (1.0 + 2.0 * self.beta * d))
+    }
+
+    pub fn corollary_bound(&self, victim: usize, neighbor_delta: f64) -> f64 {
+        let d = self.degree(victim) as f64;
+        (2.0 * self.beta / (1.0 + 2.0 * self.beta * d)) * neighbor_delta.abs()
+    }
+}
+
+/// Epoch-disciplined Jacobi coordinator.
+#[derive(Clone, Debug)]
+pub struct PreferenceEngine {
+    active_epoch: Epoch,
+    config: PreferenceEngineConfig,
+    z: Vec<f64>,
+    announced: BTreeMap<usize, f64>,
+    /// Test helper: replace one announced value before the Jacobi sweep.
+    stale_overrides: BTreeMap<usize, f64>,
+    seen_events: BTreeSet<EventId>,
+    counters: RuntimeCounters,
+}
+
+impl PreferenceEngine {
+    /// Start at the preferred scores `c`.
+    pub fn new(active_epoch: Epoch, config: PreferenceEngineConfig) -> Self {
+        let z = config.preferences.clone();
+        Self::with_state(active_epoch, config, z)
+    }
+
+    pub fn with_state(active_epoch: Epoch, config: PreferenceEngineConfig, z: Vec<f64>) -> Self {
+        assert_eq!(z.len(), config.participants.len());
+        Self {
+            active_epoch,
+            config,
+            z,
+            announced: BTreeMap::new(),
+            stale_overrides: BTreeMap::new(),
+            seen_events: BTreeSet::new(),
+            counters: RuntimeCounters::default(),
+        }
+    }
+
+    pub fn active_epoch(&self) -> Epoch {
+        self.active_epoch
+    }
+
+    pub fn config(&self) -> &PreferenceEngineConfig {
+        &self.config
+    }
+
+    pub fn z(&self) -> &[f64] {
+        &self.z
+    }
+
+    pub fn z_star(&self) -> &[f64] {
+        &self.config.z_star
+    }
+
+    pub fn distance_to_z_star(&self) -> f64 {
+        l2_to(&self.z, &self.config.z_star)
+    }
+
+    /// Force a neighbor's announced value for the current epoch (violate cell).
+    pub fn inject_stale(&mut self, neighbor: usize, value: f64) {
+        self.stale_overrides.insert(neighbor, value);
+    }
+
+    fn participant_from_event(
+        &self,
+        event: &SemanticEvent,
+        payload: &ScalarProposal,
+    ) -> Option<usize> {
+        let from_payload = self.config.index_of(&payload.participant)?;
+        match &event.metadata.source {
+            EventSource::Peer(id) => self.config.index_of(id).filter(|&i| i == from_payload),
+            EventSource::Local => Some(from_payload),
+            EventSource::Tool(name) => self
+                .config
+                .index_of(&AgentId::from(name.as_str()))
+                .filter(|&i| i == from_payload),
+            EventSource::Task(_) | EventSource::Recovery => None,
+        }
+    }
+
+    fn inbox(&self) -> BTreeMap<usize, f64> {
+        let mut inbox = self.announced.clone();
+        for (&j, value) in &self.stale_overrides {
+            inbox.insert(j, *value);
+        }
+        inbox
+    }
+
+    fn try_finalize(&mut self) -> Option<FinalizationSummary> {
+        let n = self.config.participants.len();
+        if self.announced.len() < n {
+            return None;
+        }
+        let inbox = self.inbox();
+        let mut nxt = vec![0.0; n];
+        for i in 0..n {
+            nxt[i] = self
+                .config
+                .jacobi(i, &inbox)
+                .expect("full announcement set implies a complete inbox");
+        }
+        self.z = nxt;
+        self.announced.clear();
+        self.stale_overrides.clear();
+        let summary = FinalizationSummary {
+            epoch: self.active_epoch,
+            participants: n,
+            selected_value: n as i64,
+        };
+        self.active_epoch = Epoch(self.active_epoch.0 + 1);
+        self.counters.finalized += 1;
+        Some(summary)
+    }
+}
+
+impl CoordinationEngine for PreferenceEngine {
+    fn pattern(&self) -> PatternKind {
+        PatternKind::Preference
+    }
+
+    fn apply(&mut self, event: SemanticEvent) -> EventOutcome {
+        if event.pattern != PatternKind::Preference {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePattern);
+        }
+
+        if event.metadata.epoch < self.active_epoch {
+            self.counters.rejected += 1;
+            self.counters.stale += 1;
+            return EventOutcome::Rejected(RejectReason::StaleEpoch {
+                current: self.active_epoch,
+            });
+        }
+
+        if event.metadata.epoch > self.active_epoch {
+            self.counters.deferred += 1;
+            return EventOutcome::Deferred {
+                expected: self.active_epoch,
+                received: event.metadata.epoch,
+            };
+        }
+
+        if !self.seen_events.insert(event.metadata.event_id.clone()) {
+            self.counters.rejected += 1;
+            self.counters.duplicates += 1;
+            return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+        }
+
+        let SemanticPayload::ScalarProposal(ref payload) = event.payload else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        };
+
+        let Some(idx) = self.participant_from_event(&event, payload) else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::UnknownParticipant);
+        };
+
+        if !payload.value.is_finite() {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        }
+
+        if self.announced.contains_key(&idx) {
+            self.counters.rejected += 1;
+            self.counters.duplicates += 1;
+            return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+        }
+
+        self.announced.insert(idx, payload.value);
+        self.counters.applied += 1;
+        match self.try_finalize() {
+            Some(summary) => EventOutcome::Finalized(summary),
+            None => EventOutcome::Applied,
+        }
+    }
+
+    fn counters(&self) -> RuntimeCounters {
+        self.counters.clone()
+    }
+}
+
+impl ConvergeSurface for PreferenceEngine {
+    fn current_value(&self, id: &AgentId) -> Option<f64> {
+        self.config.index_of(id).map(|i| self.z[i])
+    }
+
+    fn metric(&self) -> f64 {
+        self.distance_to_z_star()
+    }
+
+    fn lower_is_better(&self) -> bool {
+        true
+    }
+
+    fn local_view(&self, id: &AgentId) -> String {
+        let Some(i) = self.config.index_of(id) else {
+            return String::new();
+        };
+        let inbound: Vec<String> = self.config.neighbors[i]
+            .iter()
+            .filter_map(|&j| {
+                Some(format!(
+                    "{}={:.6}",
+                    self.config.participants.get(j)?.0,
+                    self.z.get(j)?
+                ))
+            })
+            .collect();
+        format!(
+            "agent={}\nz_i={:.6}\nc_i={:.6}\nbeta={:.6}\nd_i={}\ninbound={}",
+            id.0,
+            self.z[i],
+            self.config.preferences[i],
+            self.config.beta,
+            self.config.degree(i),
+            inbound.join(",")
+        )
+    }
+
+    fn announce_event(
+        &self,
+        id: &AgentId,
+        epoch: u64,
+        value: f64,
+        event_id: &str,
+    ) -> SemanticEvent {
+        scalar_announce(PatternKind::Preference, id, epoch, value, event_id)
+    }
+}
+
+fn l2_to(values: &[f64], target: &[f64]) -> f64 {
+    values
+        .iter()
+        .zip(target)
+        .map(|(v, t)| (v - t).powi(2))
+        .sum::<f64>()
+        .sqrt()
+}
+
+fn solve_z_star(neighbors: &[Vec<usize>], c: &[f64], beta: f64) -> Result<Vec<f64>, String> {
+    let n = c.len();
+    let mut mat = vec![vec![0.0; n]; n];
+    for i in 0..n {
+        let d = neighbors[i].len() as f64;
+        mat[i][i] = 1.0 + 2.0 * beta * d;
+        for &j in &neighbors[i] {
+            mat[i][j] -= 2.0 * beta;
+        }
+    }
+    solve(mat, c.to_vec())
+}
+
+fn solve(mut mat: Vec<Vec<f64>>, rhs: Vec<f64>) -> Result<Vec<f64>, String> {
+    let n = rhs.len();
+    let mut a: Vec<Vec<f64>> = mat
+        .drain(..)
+        .enumerate()
+        .map(|(i, mut row)| {
+            row.push(rhs[i]);
+            row
+        })
+        .collect();
+    for col in 0..n {
+        let pivot = (col..n)
+            .max_by(|r, s| a[*r][col].abs().total_cmp(&a[*s][col].abs()))
+            .ok_or_else(|| "empty preference system".to_string())?;
+        if a[pivot][col].abs() < SINGULAR {
+            return Err("singular preference Laplacian system".to_string());
+        }
+        a.swap(col, pivot);
+        let scale = a[col][col];
+        for j in col..=n {
+            a[col][j] /= scale;
+        }
+        for row in 0..n {
+            if row == col {
+                continue;
+            }
+            let factor = a[row][col];
+            for j in col..=n {
+                a[row][j] -= factor * a[col][j];
+            }
+        }
+    }
+    Ok((0..n).map(|i| a[i][n]).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::MasRuntime;
+    use crate::types::{EventMetadata, EventSource};
+
+    const BETA: f64 = 0.75;
+    const Z_STAR: [f64; 3] = [2.4, 4.0, 5.6];
+
+    fn paper_line() -> PreferenceEngineConfig {
+        PreferenceEngineConfig::line(3, 8.0, BETA).expect("paper line")
+    }
+
+    fn engine_from(z: Vec<f64>) -> MasRuntime<PreferenceEngine> {
+        MasRuntime::new(PreferenceEngine::with_state(Epoch(0), paper_line(), z))
+    }
+
+    fn announce(id: &str, epoch: u64, agent: usize, value: f64) -> SemanticEvent {
+        SemanticEvent {
+            pattern: PatternKind::Preference,
+            metadata: EventMetadata {
+                event_id: EventId::from(id),
+                correlation_id: None,
+                epoch: Epoch(epoch),
+                source: EventSource::Peer(AgentId::from(agent.to_string().as_str())),
+            },
+            payload: SemanticPayload::ScalarProposal(ScalarProposal {
+                participant: AgentId::from(agent.to_string().as_str()),
+                value,
+            }),
+        }
+    }
+
+    fn announce_all(
+        rt: &mut MasRuntime<PreferenceEngine>,
+        epoch: u64,
+        prefix: &str,
+    ) -> EventOutcome {
+        let z = rt.engine().z().to_vec();
+        let mut last = EventOutcome::Applied;
+        for i in 0..z.len() {
+            last = rt.apply(announce(&format!("{prefix}-{i}"), epoch, i, z[i]));
+        }
+        last
+    }
+
+    #[test]
+    fn paper_fixed_point() {
+        let cfg = paper_line();
+        for (got, want) in cfg.z_star.iter().zip(Z_STAR) {
+            assert!((got - want).abs() < 1e-12, "{got} vs {want}");
+        }
+    }
+
+    #[test]
+    fn one_step_from_c_reaches_z_star() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        let outcome = announce_all(&mut rt, 0, "r0");
+        assert!(matches!(outcome, EventOutcome::Finalized(_)));
+        for (got, want) in rt.engine().z().iter().zip(Z_STAR) {
+            assert!((got - want).abs() < 1e-12, "{got} vs {want}");
+        }
+        assert!(rt.engine().distance_to_z_star() < 1e-12);
+        assert_eq!(rt.engine().active_epoch(), Epoch(1));
+    }
+
+    #[test]
+    fn contracts_toward_z_star_from_zero() {
+        let mut rt = engine_from(vec![0.0, 0.0, 0.0]);
+        let mut prev = rt.engine().distance_to_z_star();
+        assert!(prev > 1.0);
+        for epoch in 0..40 {
+            let outcome = announce_all(&mut rt, epoch, &format!("e{epoch}"));
+            assert!(matches!(outcome, EventOutcome::Finalized(_)));
+            let now = rt.engine().distance_to_z_star();
+            assert!(now <= prev + 1e-15, "distance {now} should be <= {prev}");
+            prev = now;
+        }
+        assert!(rt.engine().distance_to_z_star() < 1e-6);
+    }
+
+    #[test]
+    fn stale_epoch_is_rejected_and_hold_inbox_is_used() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        assert!(matches!(
+            announce_all(&mut rt, 0, "r0"),
+            EventOutcome::Finalized(_)
+        ));
+        let hold = rt.engine().z().to_vec();
+        let stale = rt.apply(announce("late", 0, 1, 99.0));
+        assert_eq!(
+            stale,
+            EventOutcome::Rejected(RejectReason::StaleEpoch { current: Epoch(1) })
+        );
+        assert_eq!(rt.engine().z(), hold.as_slice());
+        assert!(matches!(
+            announce_all(&mut rt, 1, "r1"),
+            EventOutcome::Finalized(_)
+        ));
+        for (got, want) in rt.engine().z().iter().zip(Z_STAR) {
+            assert!((got - want).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn replayed_event_id_is_rejected() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        let first = announce("same", 0, 0, 0.0);
+        assert_eq!(rt.apply(first.clone()), EventOutcome::Applied);
+        assert_eq!(
+            rt.apply(first),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+    }
+
+    #[test]
+    fn second_announcement_from_same_agent_is_replay() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        assert_eq!(rt.apply(announce("a", 0, 0, 0.0)), EventOutcome::Applied);
+        assert_eq!(
+            rt.apply(announce("b", 0, 0, 1.0)),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+    }
+
+    #[test]
+    fn unknown_participant_rejected() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        let ev = SemanticEvent {
+            pattern: PatternKind::Preference,
+            metadata: EventMetadata {
+                event_id: EventId::from("x"),
+                correlation_id: None,
+                epoch: Epoch(0),
+                source: EventSource::Peer(AgentId::from("ghost")),
+            },
+            payload: SemanticPayload::ScalarProposal(ScalarProposal {
+                participant: AgentId::from("ghost"),
+                value: 1.0,
+            }),
+        };
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+    }
+
+    #[test]
+    fn stale_inject_obeys_corollary_bound() {
+        let cfg = paper_line();
+        let z = vec![1.0, 3.0, 7.0];
+        let mut hold_inbox = BTreeMap::new();
+        hold_inbox.insert(0, z[0]);
+        hold_inbox.insert(2, z[2]);
+        let hold = cfg.jacobi(1, &hold_inbox).unwrap();
+        let mut stale_inbox = hold_inbox;
+        let stale_neighbor = 0.0;
+        stale_inbox.insert(0, stale_neighbor);
+        let stale = cfg.jacobi(1, &stale_inbox).unwrap();
+        let delta = (stale - hold).abs();
+        let bound = cfg.corollary_bound(1, stale_neighbor - z[0]);
+        assert!(delta <= bound + 1e-12, "{delta} > {bound}");
+        assert!(delta > 0.0);
+
+        let mut engine = PreferenceEngine::with_state(Epoch(0), cfg, z.clone());
+        engine.inject_stale(0, stale_neighbor);
+        let mut rt = MasRuntime::new(engine);
+        assert!(matches!(
+            announce_all(&mut rt, 0, "inj"),
+            EventOutcome::Finalized(_)
+        ));
+        let moved = (rt.engine().z()[1] - hold).abs();
+        assert!((moved - delta).abs() < 1e-12);
+        assert!(moved <= bound + 1e-12);
+    }
+
+    #[test]
+    fn future_epoch_is_deferred() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        assert_eq!(
+            rt.apply(announce("future", 3, 0, 0.0)),
+            EventOutcome::Deferred {
+                expected: Epoch(0),
+                received: Epoch(3)
+            }
+        );
+    }
+
+    #[test]
+    fn wrong_pattern_and_payload_rejected() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        let mut ev = announce("p", 0, 0, 0.0);
+        ev.pattern = PatternKind::Development;
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::IncompatiblePattern)
+        );
+        let ev = SemanticEvent {
+            pattern: PatternKind::Preference,
+            metadata: EventMetadata {
+                event_id: EventId::from("bytes"),
+                correlation_id: None,
+                epoch: Epoch(0),
+                source: EventSource::Peer(AgentId::from("0")),
+            },
+            payload: SemanticPayload::ExternalBytes(b"nope".to_vec()),
+        };
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+    }
+}

--- a/crates/shadi_mas/src/engines/preference.rs
+++ b/crates/shadi_mas/src/engines/preference.rs
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-//! Synchronous Jacobi preference engine (Thm. preference-linear).
+//! Synchronous Jacobi preference engine (theorem preference-linear).
 //!
 //! Each epoch, every participant announces its current `z_i` as a
 //! [`ScalarProposal`](crate::types::ScalarProposal). When the full round set
@@ -623,5 +623,72 @@ mod tests {
             rt.apply(ev),
             EventOutcome::Rejected(RejectReason::IncompatiblePayload)
         );
+    }
+
+    #[test]
+    fn config_rejects_invalid_instances() {
+        assert!(PreferenceEngineConfig::new(vec![], vec![], vec![], BETA).is_err());
+        assert!(PreferenceEngineConfig::line(1, 8.0, BETA).is_err());
+        assert!(PreferenceEngineConfig::line(3, 8.0, 0.0).is_err());
+        let ids = vec![AgentId::from("0"), AgentId::from("1")];
+        assert!(
+            PreferenceEngineConfig::new(ids.clone(), vec![vec![1], vec![0]], vec![0.0], BETA)
+                .is_err()
+        );
+        assert!(
+            PreferenceEngineConfig::new(ids, vec![vec![5], vec![0]], vec![0.0, 1.0], BETA).is_err()
+        );
+        let mut inbox = BTreeMap::new();
+        inbox.insert(0, 1.0);
+        let cfg = paper_line();
+        assert!(cfg.jacobi(1, &inbox).is_err());
+    }
+
+    #[test]
+    fn nan_local_tool_and_recovery_sources() {
+        let mut rt = engine_from(vec![0.0, 4.0, 8.0]);
+        assert_eq!(
+            rt.apply(announce("nan", 0, 0, f64::NAN)),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+
+        let mut local = announce("local", 0, 0, 0.0);
+        local.metadata.source = EventSource::Local;
+        assert_eq!(rt.apply(local), EventOutcome::Applied);
+
+        let mut tool = announce("tool", 0, 1, 4.0);
+        tool.metadata.source = EventSource::Tool("1".into());
+        assert_eq!(rt.apply(tool), EventOutcome::Applied);
+
+        let mut task = announce("task", 0, 2, 8.0);
+        task.metadata.source = EventSource::Task("t".into());
+        assert_eq!(
+            rt.apply(task),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+        let mut recovery = announce("rec", 0, 2, 8.0);
+        recovery.metadata.source = EventSource::Recovery;
+        assert_eq!(
+            rt.apply(recovery),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+    }
+
+    #[test]
+    fn surface_exposes_local_view() {
+        let engine = PreferenceEngine::new(Epoch(0), paper_line());
+        let id = AgentId::from("0");
+        let unknown = AgentId::from("ghost");
+        assert_eq!(engine.pattern(), PatternKind::Preference);
+        assert!(engine.lower_is_better());
+        assert_eq!(engine.current_value(&id), Some(0.0));
+        assert_eq!(engine.current_value(&unknown), None);
+        assert!(engine.local_view(&id).contains("z_i="));
+        assert!(engine.local_view(&unknown).is_empty());
+        assert_eq!(engine.z_star().len(), 3);
+        assert_eq!(engine.config().participants.len(), 3);
+        assert_eq!(engine.counters().applied, 0);
+        let ev = engine.announce_event(&id, 0, 0.0, "s");
+        assert_eq!(ev.pattern, PatternKind::Preference);
     }
 }

--- a/crates/shadi_mas/src/engines/resource.rs
+++ b/crates/shadi_mas/src/engines/resource.rs
@@ -1,0 +1,327 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resource CONVERGE engine. Agents announce last extraction; the engine
+//! applies the paper dual step and plant update.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::engines::converge::{scalar_announce, ConvergeSurface};
+use crate::runtime::CoordinationEngine;
+use crate::types::{
+    AgentId, Epoch, EventId, EventOutcome, EventSource, FinalizationSummary, PatternKind,
+    RejectReason, RuntimeCounters, ScalarProposal, SemanticEvent, SemanticPayload,
+};
+
+pub const R0: f64 = 24.0;
+pub const CAPACITY: f64 = 30.0;
+pub const REGEN: f64 = 0.2;
+pub const QUOTA_FRAC: f64 = 0.25;
+pub const ALPHA: f64 = 0.35;
+pub const ETA: f64 = 0.4;
+pub const R_MIN: f64 = 1.0;
+pub const PAPER_ROUNDS: u64 = 12;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResourceEngineConfig {
+    pub participants: Vec<AgentId>,
+    pub desired: Vec<f64>,
+    pub alpha: f64,
+    pub eta: f64,
+    pub paper_horizon: u64,
+}
+
+impl ResourceEngineConfig {
+    pub fn scaled(participants: Vec<AgentId>) -> Result<Self, String> {
+        let n = participants.len();
+        if n < 2 {
+            return Err("resource needs at least two agents".to_string());
+        }
+        let desired = (0..n).map(|i| if i % 3 == 1 { 2.5 } else { 2.0 }).collect();
+        Ok(Self {
+            participants,
+            desired,
+            alpha: ALPHA,
+            eta: ETA,
+            paper_horizon: PAPER_ROUNDS,
+        })
+    }
+
+    pub fn uncontrolled(participants: Vec<AgentId>) -> Result<Self, String> {
+        let mut cfg = Self::scaled(participants)?;
+        cfg.alpha = 0.0;
+        Ok(cfg)
+    }
+
+    pub fn index_of(&self, id: &AgentId) -> Option<usize> {
+        self.participants.iter().position(|p| p == id)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ResourceEngine {
+    active_epoch: Epoch,
+    config: ResourceEngineConfig,
+    r: f64,
+    lam: f64,
+    e: Vec<f64>,
+    breaches: u32,
+    announced: BTreeMap<usize, f64>,
+    seen_events: BTreeSet<EventId>,
+    counters: RuntimeCounters,
+}
+
+impl ResourceEngine {
+    pub fn new(active_epoch: Epoch, config: ResourceEngineConfig) -> Self {
+        let e = config.desired.clone();
+        Self {
+            active_epoch,
+            r: R0,
+            lam: 0.0,
+            e,
+            breaches: 0,
+            announced: BTreeMap::new(),
+            seen_events: BTreeSet::new(),
+            counters: RuntimeCounters::default(),
+            config,
+        }
+    }
+
+    pub fn active_epoch(&self) -> Epoch {
+        self.active_epoch
+    }
+
+    pub fn config(&self) -> &ResourceEngineConfig {
+        &self.config
+    }
+
+    pub fn stock(&self) -> f64 {
+        self.r
+    }
+
+    pub fn lambda(&self) -> f64 {
+        self.lam
+    }
+
+    pub fn extractions(&self) -> &[f64] {
+        &self.e
+    }
+
+    pub fn breaches(&self) -> u32 {
+        self.breaches
+    }
+
+    fn cap(&self) -> f64 {
+        QUOTA_FRAC * self.r
+    }
+
+    pub fn formula_value(&self, index: usize) -> f64 {
+        let raw = self.e[index]
+            + self.config.eta * ((self.config.desired[index] - self.e[index]) - self.lam);
+        raw.clamp(0.0, self.r.max(0.0))
+    }
+
+    fn apply_extractions(&mut self, extracted: Vec<f64>) {
+        self.e = extracted;
+        let total: f64 = self.e.iter().sum();
+        self.lam = (self.lam + self.config.alpha * (total - self.cap())).max(0.0);
+        let grown = self.r + REGEN * self.r * (1.0 - self.r / CAPACITY);
+        self.r = (grown - total).max(0.0);
+        if self.r < R_MIN {
+            self.breaches += 1;
+        }
+    }
+
+    fn participant_from_event(
+        &self,
+        event: &SemanticEvent,
+        payload: &ScalarProposal,
+    ) -> Option<usize> {
+        let from_payload = self.config.index_of(&payload.participant)?;
+        match &event.metadata.source {
+            EventSource::Peer(id) => self.config.index_of(id).filter(|&i| i == from_payload),
+            EventSource::Local => Some(from_payload),
+            EventSource::Tool(name) => self
+                .config
+                .index_of(&AgentId::from(name.as_str()))
+                .filter(|&i| i == from_payload),
+            EventSource::Task(_) | EventSource::Recovery => None,
+        }
+    }
+
+    fn try_finalize(&mut self) -> Option<FinalizationSummary> {
+        let n = self.config.participants.len();
+        if self.announced.len() < n {
+            return None;
+        }
+        let next: Vec<f64> = (0..n).map(|i| self.formula_value(i)).collect();
+        self.apply_extractions(next);
+        self.announced.clear();
+        let summary = FinalizationSummary {
+            epoch: self.active_epoch,
+            participants: n,
+            selected_value: n as i64,
+        };
+        self.active_epoch = Epoch(self.active_epoch.0 + 1);
+        self.counters.finalized += 1;
+        Some(summary)
+    }
+}
+
+impl CoordinationEngine for ResourceEngine {
+    fn pattern(&self) -> PatternKind {
+        PatternKind::Resource
+    }
+
+    fn apply(&mut self, event: SemanticEvent) -> EventOutcome {
+        if event.pattern != PatternKind::Resource {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePattern);
+        }
+        if event.metadata.epoch < self.active_epoch {
+            self.counters.rejected += 1;
+            self.counters.stale += 1;
+            return EventOutcome::Rejected(RejectReason::StaleEpoch {
+                current: self.active_epoch,
+            });
+        }
+        if event.metadata.epoch > self.active_epoch {
+            self.counters.deferred += 1;
+            return EventOutcome::Deferred {
+                expected: self.active_epoch,
+                received: event.metadata.epoch,
+            };
+        }
+        if !self.seen_events.insert(event.metadata.event_id.clone()) {
+            self.counters.rejected += 1;
+            self.counters.duplicates += 1;
+            return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+        }
+        let SemanticPayload::ScalarProposal(ref payload) = event.payload else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        };
+        let Some(idx) = self.participant_from_event(&event, payload) else {
+            self.counters.rejected += 1;
+            return EventOutcome::Rejected(RejectReason::UnknownParticipant);
+        };
+        if !payload.value.is_finite() || self.announced.contains_key(&idx) {
+            self.counters.rejected += 1;
+            if self.announced.contains_key(&idx) {
+                self.counters.duplicates += 1;
+                return EventOutcome::Rejected(RejectReason::DuplicateEvent);
+            }
+            return EventOutcome::Rejected(RejectReason::IncompatiblePayload);
+        }
+        self.announced.insert(idx, payload.value);
+        self.counters.applied += 1;
+        match self.try_finalize() {
+            Some(summary) => EventOutcome::Finalized(summary),
+            None => EventOutcome::Applied,
+        }
+    }
+
+    fn counters(&self) -> RuntimeCounters {
+        self.counters.clone()
+    }
+}
+
+impl ConvergeSurface for ResourceEngine {
+    fn current_value(&self, id: &AgentId) -> Option<f64> {
+        self.config.index_of(id).map(|i| self.e[i])
+    }
+
+    fn metric(&self) -> f64 {
+        self.r
+    }
+
+    fn lower_is_better(&self) -> bool {
+        false
+    }
+
+    fn local_view(&self, id: &AgentId) -> String {
+        let Some(i) = self.config.index_of(id) else {
+            return String::new();
+        };
+        format!(
+            "agent={}\nlast_e_i={:.6}\nR={:.6}\nlambda={:.6}\nC_R={:.6}",
+            id.0,
+            self.e[i],
+            self.r,
+            self.lam,
+            self.cap()
+        )
+    }
+
+    fn announce_event(
+        &self,
+        id: &AgentId,
+        epoch: u64,
+        value: f64,
+        event_id: &str,
+    ) -> SemanticEvent {
+        scalar_announce(PatternKind::Resource, id, epoch, value, event_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::MasRuntime;
+
+    fn ids(n: usize) -> Vec<AgentId> {
+        (0..n)
+            .map(|i| AgentId::from(format!("goose-{i}").as_str()))
+            .collect()
+    }
+
+    fn announce_all(rt: &mut MasRuntime<ResourceEngine>, epoch: u64) -> EventOutcome {
+        let n = rt.engine().config().participants.len();
+        let mut last = EventOutcome::Applied;
+        for i in 0..n {
+            let id = rt.engine().config().participants[i].clone();
+            let value = rt.engine().extractions()[i];
+            last =
+                rt.apply(
+                    rt.engine()
+                        .announce_event(&id, epoch, value, &format!("r{epoch}-{i}")),
+                );
+        }
+        last
+    }
+
+    #[test]
+    fn coordinated_retains_more_stock_than_greedy() {
+        let coord_cfg = ResourceEngineConfig::scaled(ids(3)).expect("coord");
+        let greedy_cfg = ResourceEngineConfig::uncontrolled(ids(3)).expect("greedy");
+        let mut coord = MasRuntime::new(ResourceEngine::new(Epoch(0), coord_cfg));
+        let mut greedy = MasRuntime::new(ResourceEngine::new(Epoch(0), greedy_cfg));
+        for epoch in 0..12 {
+            assert!(matches!(
+                announce_all(&mut coord, epoch),
+                EventOutcome::Finalized(_)
+            ));
+            assert!(matches!(
+                announce_all(&mut greedy, epoch),
+                EventOutcome::Finalized(_)
+            ));
+        }
+        assert!(coord.engine().stock() > greedy.engine().stock());
+    }
+
+    #[test]
+    fn stale_epoch_rejected() {
+        let cfg = ResourceEngineConfig::scaled(ids(2)).expect("cfg");
+        let mut rt = MasRuntime::new(ResourceEngine::new(Epoch(0), cfg));
+        assert!(matches!(
+            announce_all(&mut rt, 0),
+            EventOutcome::Finalized(_)
+        ));
+        let id = rt.engine().config().participants[0].clone();
+        let ev = rt.engine().announce_event(&id, 0, 1.0, "late");
+        assert_eq!(
+            rt.apply(ev),
+            EventOutcome::Rejected(RejectReason::StaleEpoch { current: Epoch(1) })
+        );
+    }
+}

--- a/crates/shadi_mas/src/engines/resource.rs
+++ b/crates/shadi_mas/src/engines/resource.rs
@@ -324,4 +324,111 @@ mod tests {
             EventOutcome::Rejected(RejectReason::StaleEpoch { current: Epoch(1) })
         );
     }
+
+    #[test]
+    fn scaled_rejects_a_single_agent() {
+        assert!(ResourceEngineConfig::scaled(ids(1)).is_err());
+    }
+
+    #[test]
+    fn reject_paths_and_source_aliases() {
+        use crate::types::{EventMetadata, EventSource, SemanticPayload};
+
+        let cfg = ResourceEngineConfig::scaled(ids(2)).expect("cfg");
+        let mut rt = MasRuntime::new(ResourceEngine::new(Epoch(0), cfg));
+        let id0 = rt.engine().config().participants[0].clone();
+        let id1 = rt.engine().config().participants[1].clone();
+
+        assert_eq!(
+            rt.apply(rt.engine().announce_event(&id0, 4, 1.0, "future")),
+            EventOutcome::Deferred {
+                expected: Epoch(0),
+                received: Epoch(4)
+            }
+        );
+
+        let first = rt.engine().announce_event(&id0, 0, 1.0, "dup");
+        assert_eq!(rt.apply(first.clone()), EventOutcome::Applied);
+        assert_eq!(
+            rt.apply(first),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+        assert_eq!(
+            rt.apply(rt.engine().announce_event(&id0, 0, 2.0, "again")),
+            EventOutcome::Rejected(RejectReason::DuplicateEvent)
+        );
+
+        let mut ghost = rt.engine().announce_event(&id0, 0, 1.0, "ghost");
+        ghost.payload = SemanticPayload::ScalarProposal(ScalarProposal {
+            participant: AgentId::from("ghost"),
+            value: 1.0,
+        });
+        ghost.metadata.source = EventSource::Peer(AgentId::from("ghost"));
+        assert_eq!(
+            rt.apply(ghost),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+
+        let bytes = SemanticEvent {
+            pattern: PatternKind::Resource,
+            metadata: EventMetadata {
+                event_id: EventId::from("bytes"),
+                correlation_id: None,
+                epoch: Epoch(0),
+                source: EventSource::Peer(id1.clone()),
+            },
+            payload: SemanticPayload::ExternalBytes(b"nope".to_vec()),
+        };
+        assert_eq!(
+            rt.apply(bytes),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+
+        let nan = rt.engine().announce_event(&id1, 0, f64::NAN, "nan");
+        assert_eq!(
+            rt.apply(nan),
+            EventOutcome::Rejected(RejectReason::IncompatiblePayload)
+        );
+
+        let mut local = rt.engine().announce_event(&id1, 0, 2.0, "local");
+        local.metadata.source = EventSource::Local;
+        assert!(matches!(rt.apply(local), EventOutcome::Finalized(_)));
+
+        let mut tool = rt.engine().announce_event(&id0, 1, 2.0, "tool");
+        tool.metadata.source = EventSource::Tool(id0.0.clone());
+        assert_eq!(rt.apply(tool), EventOutcome::Applied);
+        let mut task = rt.engine().announce_event(&id1, 1, 2.0, "task");
+        task.metadata.source = EventSource::Task("t".into());
+        assert_eq!(
+            rt.apply(task),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+        let mut recovery = rt.engine().announce_event(&id1, 1, 2.0, "rec");
+        recovery.metadata.source = EventSource::Recovery;
+        assert_eq!(
+            rt.apply(recovery),
+            EventOutcome::Rejected(RejectReason::UnknownParticipant)
+        );
+    }
+
+    #[test]
+    fn surface_and_formula_are_defined() {
+        let cfg = ResourceEngineConfig::uncontrolled(ids(3)).expect("cfg");
+        let engine = ResourceEngine::new(Epoch(0), cfg);
+        let id = engine.config().participants[0].clone();
+        let unknown = AgentId::from("ghost");
+        assert_eq!(engine.pattern(), PatternKind::Resource);
+        assert!(!engine.lower_is_better());
+        assert_eq!(engine.current_value(&id), Some(2.0));
+        assert_eq!(engine.current_value(&unknown), None);
+        assert!(engine.local_view(&id).contains("last_e_i="));
+        assert!(engine.local_view(&unknown).is_empty());
+        assert_eq!(engine.stock(), R0);
+        assert_eq!(engine.lambda(), 0.0);
+        assert_eq!(engine.breaches(), 0);
+        assert_eq!(engine.extractions().len(), 3);
+        assert!(engine.formula_value(0) >= 0.0);
+        assert_eq!(engine.config().paper_horizon, PAPER_ROUNDS);
+        assert_eq!(engine.counters().applied, 0);
+    }
 }

--- a/crates/shadi_mas/src/lib.rs
+++ b/crates/shadi_mas/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod adapters;
+mod assembly;
 pub mod experiments;
 mod runtime;
 mod types;
@@ -9,13 +10,17 @@ mod types;
 pub mod engines;
 
 pub use adapters::{
-    MessagingAdapter, TaskAdapter, TaskEnvelope, ToolAdapter, ToolCall, ToolProvider,
-    ToolResult,
+    MessagingAdapter, TaskAdapter, TaskEnvelope, ToolAdapter, ToolCall, ToolProvider, ToolResult,
+};
+pub use assembly::{infer_pattern, AssemblySession};
+pub use engines::converge::{
+    parse_announce, parse_converge_vote, ConvergeController, ConvergeSurface,
 };
 pub use runtime::{AppliedTransition, CoordinationEngine, MasRuntime};
 pub use types::{
-    AgentId, Epoch, EventId, EventMetadata, EventOutcome, EventSource, FinalizationSummary,
-    PatternKind, RejectReason, RuntimeCounters, SemanticEvent, SemanticPayload,
+    AgentId, ConvergeBallot, ConvergeDecision, ConvergeHalt, ConvergeSignal, Epoch, EventId,
+    EventMetadata, EventOutcome, EventSource, FinalizationSummary, PatternKind, ProtocolPhase,
+    RejectReason, RuntimeCounters, ScalarProposal, SemanticEvent, SemanticPayload,
 };
 
 pub mod integrations {

--- a/crates/shadi_mas/src/types.rs
+++ b/crates/shadi_mas/src/types.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+/// ASSEMBLY / CONVERGE phases. ASSEMBLY is open-ended joint modeling.
+/// CONVERGE is the epoch engine that applies a mapped class update.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProtocolPhase {
+    Assembly,
+    Converge,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AgentId(pub String);
 
@@ -18,7 +26,9 @@ impl From<&str> for EventId {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct Epoch(pub u64);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +37,47 @@ pub enum PatternKind {
     Cascade,
     Resource,
     Development,
+    /// ASSEMBLY named a class SHADI does not implement. CONVERGE must not pretend it solved it.
+    Unmapped,
+}
+
+impl PatternKind {
+    pub fn paper_examples() -> &'static [PatternKind] {
+        &[Self::Preference, Self::Cascade, Self::Resource]
+    }
+
+    /// True when CONVERGE uses the scalar paper driver (`ConvergeController`).
+    /// `Development` is also a CONVERGE class; it uses the artifact driver.
+    pub fn is_converge_class(self) -> bool {
+        matches!(self, Self::Preference | Self::Cascade | Self::Resource)
+    }
+
+    pub fn parse_name(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "preference" | "preference-aggregation" | "jacobi" => Some(Self::Preference),
+            "cascade" | "supply-chain" | "supply_chain" | "beer" => Some(Self::Cascade),
+            "resource" | "allocation" | "fishbanks" => Some(Self::Resource),
+            "development" | "dev" => Some(Self::Development),
+            "unmapped" | "unknown" | "other" => Some(Self::Unmapped),
+            _ => None,
+        }
+    }
+
+    pub fn parse_cli(raw: &str) -> Result<Self, String> {
+        Self::parse_name(raw).ok_or_else(|| {
+            format!("unknown pattern {raw:?} (development|preference|cascade|resource|unmapped)")
+        })
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+            Self::Cascade => "cascade",
+            Self::Resource => "resource",
+            Self::Development => "development",
+            Self::Unmapped => "unmapped",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -64,23 +115,59 @@ pub struct Sensitivity {
     pub delta: i64,
 }
 
+/// Quadratic-preference announcement. `value` is the agent's current `z_i`
+/// (or a neighbor view of it). Distinct from [`Proposal`], which stays `i64`
+/// for vote-style payloads.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ScalarProposal {
+    pub participant: AgentId,
+    pub value: f64,
+}
+
+/// CONVERGE STOP / CONTINUE after an improvement signal.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConvergeDecision {
+    Continue,
+    Stop,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergeBallot {
+    pub participant: AgentId,
+    pub decision: ConvergeDecision,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConvergeHalt {
+    MajorityStop,
+    Plateau,
+    PaperHorizon,
+    Unmapped,
+    NoSolution,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ConvergeSignal {
+    pub epoch: Epoch,
+    pub metric: f64,
+    pub previous: Option<f64>,
+    pub delta: f64,
+    pub improved: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SemanticPayload {
     Proposal(Proposal),
     Vote(Vote),
     Sensitivity(Sensitivity),
-    ToolResult {
-        tool_name: String,
-        accepted: bool,
-    },
-    TaskResult {
-        task_id: String,
-        accepted: bool,
-    },
+    ScalarProposal(ScalarProposal),
+    ConvergeBallot(ConvergeBallot),
+    ToolResult { tool_name: String, accepted: bool },
+    TaskResult { task_id: String, accepted: bool },
     ExternalBytes(Vec<u8>),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SemanticEvent {
     pub pattern: PatternKind,
     pub metadata: EventMetadata,
@@ -120,4 +207,52 @@ pub struct RuntimeCounters {
     pub duplicates: usize,
     pub stale: usize,
     pub finalized: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_maps_aliases_and_unmapped() {
+        assert_eq!(
+            PatternKind::parse_name("jacobi"),
+            Some(PatternKind::Preference)
+        );
+        assert_eq!(
+            PatternKind::parse_name("supply-chain"),
+            Some(PatternKind::Cascade)
+        );
+        assert_eq!(
+            PatternKind::parse_name("fishbanks"),
+            Some(PatternKind::Resource)
+        );
+        assert_eq!(
+            PatternKind::parse_name("dev"),
+            Some(PatternKind::Development)
+        );
+        assert_eq!(
+            PatternKind::parse_name("other"),
+            Some(PatternKind::Unmapped)
+        );
+        assert_eq!(PatternKind::parse_name("not-a-class"), None);
+    }
+
+    #[test]
+    fn parse_cli_rejects_unknown_and_accepts_unmapped() {
+        assert_eq!(
+            PatternKind::parse_cli("unmapped").unwrap(),
+            PatternKind::Unmapped
+        );
+        assert!(PatternKind::parse_cli("nope").is_err());
+    }
+
+    #[test]
+    fn paper_examples_use_scalar_driver_development_does_not() {
+        for kind in PatternKind::paper_examples() {
+            assert!(kind.is_converge_class());
+        }
+        assert!(!PatternKind::Development.is_converge_class());
+        assert!(!PatternKind::Unmapped.is_converge_class());
+    }
 }

--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -109,9 +109,14 @@ as `AUTH_REQUIRED` (re-prove / ask / deny); a forged DID is rejected.
 
 ### Coordination loop
 
-Each epoch has two phases: every agent proposes a code artifact, then every
-agent votes on the best one. Finalization fires as soon as endorsements reach
-the quorum — triggered by applying the last proposal of the epoch.
+`coordinate --pattern development` (default) is CONVERGE for a **code**
+class: every agent proposes a code artifact, then every agent votes on
+the best one. Finalization fires as soon as endorsements reach the
+quorum — triggered by applying the last proposal of the epoch.
+
+The same two group phases cover any class. `--assembly` asks the team to
+model the problem first. `--pattern preference|cascade|resource` runs
+CONVERGE on a paper engine. See [ASSEMBLY and CONVERGE](assembly-converge.md).
 
 ```mermaid
 sequenceDiagram
@@ -191,6 +196,11 @@ The skill only documents existing flags: `list --local`, `delegate`,
 [demo-env.sh](demos/demo-env.sh) so DID auth is set. A fifth CLI on the
 **register** side is a JSON profile under `crates/agentbridge/profiles/`,
 not a new Rust adapter.
+
+ASSEMBLY / CONVERGE hops load [`skills/assembly`](https://github.com/agntcy/shadi/tree/main/skills/assembly)
+and [`skills/converge`](https://github.com/agntcy/shadi/tree/main/skills/converge)
+the same way. Do not paste those files into `--text`. See
+[ASSEMBLY and CONVERGE](assembly-converge.md#agent-skills).
 
 ## Three interaction models
 
@@ -435,39 +445,28 @@ SLIM files.
 
 ## Multi-agent coordination layer (`shadi_mas`)
 
-`shadi_mas` is the coordination runtime that sits above the transport layer,
-consumed by `agentbridge coordinate`. It provides epoch-disciplined state
-machines that can drive any multi-agent pattern to a deterministic
-finalization outcome.
+`agentbridge coordinate` is a driver for [SHADI MAS](shadi-mas.md). That
+crate owns epochs, engines, and ASSEMBLY / CONVERGE. This page only
+covers how AgentBridge feeds it.
 
-```text
-SemanticEvent  ──►  CoordinationEngine  ──►  EventOutcome
-(proposal,          (PreferenceEngine,        (Applied,
- vote, tool          DevelopmentEngine,         Finalized,
- result, …)          …)                         Rejected,
-                                               Deferred)
-```
+`coordinate` builds a roster, optionally runs ASSEMBLY, then constructs
+`MasRuntime<E>` for the class and turns tool replies into
+`SemanticEvent`s. `--pattern development` (default) uses
+`DevelopmentEngine`. `--pattern preference|cascade|resource` uses the
+scalar paper driver. `--assembly` infers the class first. See
+[ASSEMBLY and CONVERGE](assembly-converge.md).
 
-Engines are wrapped in `MasRuntime<E>` which tracks the full history of applied
-transitions and exposes `engine()` / `engine_mut()` for inspection.
-
-| Engine | Pattern | Finalization criterion |
-|--------|---------|----------------------|
-| `PreferenceEngine` | Consensus on a scalar value | Median of proposals when quorum is met |
-| `DevelopmentEngine` | Consensus on a code artifact | Most-endorsed artifact when quorum is met |
-
-Three adapter traits connect the runtime to real infrastructure:
-
-| Trait | Implementation | Purpose |
-|-------|---------------|---------|
-| `MessagingAdapter` | `RecordingMessagingAdapter` / `LiveSlimMessagingAdapter` | Publish events to SLIM |
-| `TaskAdapter` | `RecordingTaskAdapter` / `LiveA2ATaskAdapter` | Dispatch A2A tasks |
-| `ToolAdapter` | `RecordingToolAdapter` / `CommandToolAdapter` / `CliToolAdapter` | Invoke LLMs / CLI tools |
+`LiveA2ATaskAdapter` (in `shadi_mas::experiments`) is the live task
+dispatch used by `delegate`, `handoff --from/--to slim:…`, and
+`coordinate` over SLIM or official A2A unicast. `CliToolAdapter` is
+AgentBridge’s `ToolAdapter` over a local CLI profile.
 
 ### `DevelopmentEngine` — the coordination core
 
-`DevelopmentEngine` is a `CoordinationEngine` that coordinates code artifacts
-rather than scalar numeric values (unlike `PreferenceEngine`).
+`DevelopmentEngine` is the CONVERGE engine for a shared code artifact.
+`agentbridge coordinate --pattern development` (default) stays here.
+ASSEMBLY, other classes, skills, and halt rules are in
+[ASSEMBLY and CONVERGE](assembly-converge.md).
 
 | Event | Payload | Effect |
 |-------|---------|--------|
@@ -555,22 +554,15 @@ corrupting the state machine.
             list.rs
             handoff.rs
             delegate.rs        ← single-shot A2A dispatch
-            coordinate.rs      ← MasRuntime<DevelopmentEngine> loop
-      shadi_mas/               ← coordination runtime
-        src/
-          engines/
-            development.rs     ← DevelopmentEngine
-            preference.rs      ← PreferenceEngine (existing)
-          experiments/
-            mod.rs             ← live adapters + experiment runners
-        tests/
-          integration_slim.rs  ← SLIM node integration tests (run with --include-ignored)
+            coordinate.rs      ← MasRuntime driver (ASSEMBLY / CONVERGE)
+      shadi_mas/               ← coordination runtime (SHADI MAS)
     examples/
       agentbridge_demo/         ← self-contained demo (no infrastructure needed)
     ```
 
 ## Next steps
 
+- Read [SHADI MAS](shadi-mas.md) for the coordination runtime, then [ASSEMBLY and CONVERGE](assembly-converge.md) for the group protocol.
 - Try the [Secure Agent Group Demo](demos/did-agent-group.md) for a full multi-agent, DID-identified walkthrough.
 - Try the [Round-robin Rust Demo](demos/collab-rust.md) for a multi-turn loop where each agent may write at most two lines and chooses the next A2A peer.
 - Try the [Agent Directory Discovery Demo](demos/dir-group-discovery.md) to form and grow a group by discovering members in DIR instead of naming them by hand.

--- a/docs/content/agentbridge.md
+++ b/docs/content/agentbridge.md
@@ -197,8 +197,8 @@ The skill only documents existing flags: `list --local`, `delegate`,
 **register** side is a JSON profile under `crates/agentbridge/profiles/`,
 not a new Rust adapter.
 
-ASSEMBLY / CONVERGE hops load [`skills/assembly`](https://github.com/agntcy/shadi/tree/main/skills/assembly)
-and [`skills/converge`](https://github.com/agntcy/shadi/tree/main/skills/converge)
+ASSEMBLY / CONVERGE hops load [`skills/assembly`](../../skills/assembly/SKILL.md)
+and [`skills/converge`](../../skills/converge/SKILL.md)
 the same way. Do not paste those files into `--text`. See
 [ASSEMBLY and CONVERGE](assembly-converge.md#agent-skills).
 
@@ -461,7 +461,7 @@ dispatch used by `delegate`, `handoff --from/--to slim:…`, and
 `coordinate` over SLIM or official A2A unicast. `CliToolAdapter` is
 AgentBridge’s `ToolAdapter` over a local CLI profile.
 
-### `DevelopmentEngine` — the coordination core
+### DevelopmentEngine
 
 `DevelopmentEngine` is the CONVERGE engine for a shared code artifact.
 `agentbridge coordinate --pattern development` (default) stays here.

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -40,6 +40,7 @@ flowchart TB
     Enforcement[OS sandbox enforcement]
     Memory[Encrypted local memory]
     Transport[Secure agent transport]
+    Coordination[SHADI MAS coordination]
   end
 
   subgraph Workloads[Protected workloads]
@@ -64,6 +65,8 @@ flowchart TB
   Delivery -. scoped secret access .-> Agents
   Memory -. encrypted state .-> Agents
   Transport --> Agents
+  Transport --> Coordination
+  Coordination --> Agents
   Agents --> Repos
   Agents --> Models
   Agents --> Peers
@@ -72,7 +75,7 @@ flowchart TB
 The system can be read as four presentation layers:
 
 - **Experience and control**: operators, policies, profiles, and `shadictl` define the launch contract before a process starts.
-- **Secure runtime**: identity, secret control, trusted delivery, sandboxing, transport, and encrypted memory enforce that contract during execution.
+- **Secure runtime**: identity, secret control, trusted delivery, sandboxing, transport, encrypted memory, and SHADI MAS coordination enforce that contract during execution.
 - **Protected workloads**: agents, tools, and automations run inside the approved runtime boundary.
 - **External systems**: workloads connect to GitHub, model providers, and SLIM/A2A peers only after policy and trust checks are in place.
 
@@ -128,6 +131,32 @@ The system can be read as four presentation layers:
   `invite`/`join`).
 - **Verified sessions**: Messages are only sent/received after DID/VC checks.
 
+### Coordination layer (SHADI MAS)
+
+- **Runtime**: `shadi_mas` is the epoch-disciplined coordination crate.
+  `MasRuntime<E>` applies `SemanticEvent` values to a
+  `CoordinationEngine` and records history.
+- **Group phases**: ASSEMBLY infers a class; CONVERGE applies that
+  class’s update. The protocol is not limited to numbers.
+- **Engines**: `DevelopmentEngine` (code artifact), plus the paper
+  examples `PreferenceEngine`, `CascadeEngine`, and `ResourceEngine`.
+  `Unmapped` has no solver.
+- **Not `slim_mas`**: that crate evaluates SLIM group membership
+  (`shadictl slim-mas`). SHADI MAS decides how an admitted roster
+  advances a shared problem.
+
+See [SHADI MAS](shadi-mas.md) for the event loop, adapters, and file
+map, and [ASSEMBLY and CONVERGE](assembly-converge.md) for the protocol.
+
+??? note "Code map (SHADI MAS)"
+
+    - `crates/shadi_mas/src/runtime.rs`: `CoordinationEngine`, `MasRuntime`.
+    - `crates/shadi_mas/src/types.rs`: `PatternKind`, `SemanticEvent`, outcomes.
+    - `crates/shadi_mas/src/assembly.rs`: `AssemblySession`.
+    - `crates/shadi_mas/src/engines/`: class engines and `ConvergeController`.
+    - `crates/shadi_mas/src/adapters.rs`: Messaging / Task / Tool traits.
+    - `crates/shadi_mas/src/experiments/`: recording adapters, `LiveA2ATaskAdapter`.
+
 ### Secret delivery and policy framework
 
 SHADI has a launch-time secret-delivery framework with exact executable
@@ -175,6 +204,12 @@ delivery, and the prompt-injection boundary, see
     - `crates/agent_transport_slim/src/lib.rs`: transport adapter, verifier gating, and native SLIM session bootstrap.
     - `crates/agent_transport_slim/src/bin/slim-stdio-bridge.rs`: standalone stdio bridge helper; the same bridge engine is now used directly by shadictl for in-sandbox SLIM sessions.
 
+    **Coordination layer (SHADI MAS)**
+
+    - `crates/shadi_mas/src/runtime.rs`: `CoordinationEngine`, `MasRuntime`.
+    - `crates/shadi_mas/src/types.rs`: `PatternKind`, `SemanticEvent`, outcomes.
+    - `crates/shadi_mas/src/engines/`: class engines and `ConvergeController`.
+
     **Secret delivery and policy framework**
 
     - `crates/shadictl/src/trusted_secret_delivery.rs`: secret resolution, exact-program matching, broker lifecycle, and delegated child verification.
@@ -202,4 +237,5 @@ The CLI combines profile defaults, policy file settings, and explicit flags:
 - Review the full threat model, secret-delivery rationale, and residual risks in [Security Notes](security.md).
 - Put this into practice with [Sandbox and Policies](sandbox.md) and the [CLI Reference](cli.md).
 - Integrate into an agent or app via the [API Guide](api_integration.md).
-- See the multi-agent coordination layer and general-purpose A2A agent interconnect in [AgentBridge](agentbridge.md).
+- See the coordination runtime in [SHADI MAS](shadi-mas.md) and the group protocol in [ASSEMBLY and CONVERGE](assembly-converge.md).
+- See the general-purpose A2A agent interconnect in [AgentBridge](agentbridge.md).

--- a/docs/content/assembly-converge.md
+++ b/docs/content/assembly-converge.md
@@ -138,7 +138,7 @@ transcripts do not break. New hops should use `ANNOUNCE`.
 **Development** (code artifacts): each peer proposes `ExternalBytes`
 and endorses via `ToolResult`. Halt is quorum on the winning artifact,
 or `--max-rounds`. See
-[AgentBridge → DevelopmentEngine](agentbridge.md#developmentengine-the-coordination-core).
+[AgentBridge → DevelopmentEngine](agentbridge.md#developmentengine).
 
 A future class uses the same phase and a new announce form. Do not
 force every class through `value=<f64>`.
@@ -216,8 +216,8 @@ into `--text`.
 
 | Skill | Folder | When it applies |
 |-------|--------|-----------------|
-| ASSEMBLY | [`skills/assembly/`](https://github.com/agntcy/shadi/tree/main/skills/assembly) | Hop prints `phase=ASSEMBLY` |
-| CONVERGE | [`skills/converge/`](https://github.com/agntcy/shadi/tree/main/skills/converge) | Hop prints `phase=CONVERGE` and the class uses a printed local view |
+| ASSEMBLY | [`skills/assembly/`](../../skills/assembly/SKILL.md) | Hop prints `phase=ASSEMBLY` |
+| CONVERGE | [`skills/converge/`](../../skills/converge/SKILL.md) | Hop prints `phase=CONVERGE` and the class uses a printed local view |
 
 `skills/converge` as shipped teaches the scalar announce / `VOTE`
 form. A class with a different state type (including development)

--- a/docs/content/assembly-converge.md
+++ b/docs/content/assembly-converge.md
@@ -1,0 +1,308 @@
+# ASSEMBLY and CONVERGE
+
+ASSEMBLY and CONVERGE are the two **group** phases in
+[SHADI MAS](shadi-mas.md) (`shadi_mas`). A team first builds a shared
+model of a problem, then exchanges local state while a class engine
+applies the update and the team decides whether to stop.
+
+The protocol is not limited to numbers. A class may use scores, orders,
+stock, code artifacts, or another local state the engine understands.
+What must stay true is the group: peers model together, then converge
+together. `agentbridge coordinate` drives both phases.
+
+## Why these names
+
+The names must read as group work.
+
+| Name | What the team does | Why not a shorter word |
+|------|--------------------|------------------------|
+| **ASSEMBLY** | Jointly understand the problem and propose a system model | *Model* can be one agent writing a formalization alone |
+| **CONVERGE** | Announce local state together, accept the engine update, and halt together | *Solve* can be one agent producing the next state alone |
+
+A single agent can model or solve. ASSEMBLY and CONVERGE require peers.
+
+## What this is not
+
+- Not hop-local `COMMIT proposal=`. CONVERGE announces current local
+  state in the form the class requires; the **engine** applies the class
+  update after a full epoch.
+- Not a closed taxonomy. Preference, cascade, resource, and development
+  are **implemented examples**. ASSEMBLY may name another class.
+- Not “numeric MAS.” Scalar announce is how some example engines speak.
+  A class whose state is an artifact, a plan, or another object still
+  uses these two phases.
+- Not an LLM theorem. Mapping a prompt to `preference` does not prove
+  Jacobi or the paper’s preference-linear result. `proves_llm_mas` is
+  false.
+- Not the two-line Rust fifo demo. That loop is [round-robin collab](demos/collab-rust.md).
+- Not a skill pasted into `--text`. Peers load Agent Skills; the hop only
+  names the phase.
+
+## Two phases
+
+```mermaid
+flowchart TD
+  start[Goal plus roster] --> assembly["ASSEMBLY\njoint model · CLASS line"]
+  assembly --> mapped{Implemented class?}
+  mapped -->|yes| converge["CONVERGE\nannounce · engine epoch · halt"]
+  mapped -->|Unmapped| stopUnmapped[Halt: no solver]
+  converge --> halt{Halt?}
+  halt -->|continue| converge
+  halt -->|class halt| done[Stop as a team]
+```
+
+| Phase | Who speaks | Who computes the next state | Exit |
+|-------|------------|-----------------------------|------|
+| ASSEMBLY | Every peer | Nobody. `AssemblySession` only infers a class | A `PatternKind`, or `Unmapped` |
+| CONVERGE | Every peer announces local state and may vote | The class engine, after a full epoch | That engine’s halt |
+
+A class is implemented when SHADI has an engine for it. Today that is
+`development` (code artifacts) and the three paper examples
+(`preference`, `cascade`, `resource`). Any other `CLASS` token is
+`Unmapped`. CONVERGE must not start on `Unmapped`.
+
+`--assembly` runs ASSEMBLY first. `--pattern` selects or seeds the
+class. After ASSEMBLY, `coordinate` starts the matching CONVERGE engine
+or refuses if the class is unmapped.
+
+## ASSEMBLY
+
+ASSEMBLY is joint modeling. Peers debate in natural language: who the
+agents are, what they exchange, and what “better” means. They may offer
+a formalization. They **may** name a class that SHADI does not implement.
+
+### Line protocol
+
+Each peer ends with exactly one line:
+
+```text
+CLASS <name>
+```
+
+Then `NEXT <peer>` or `DONE`. No other protocol text.
+
+`<name>` is an implemented token (`development`, `preference`,
+`cascade`, `resource`) or another short token (`matching-markets`, …).
+A token SHADI does not implement becomes `PatternKind::Unmapped`.
+
+### Inference
+
+`AssemblySession` is soft. Prose is the debate; the hypothesis is
+inferred.
+
+1. A `CLASS <name>` or `CLASS=<name>` line wins.
+2. Otherwise keywords may vote among the paper examples (for example
+   “neighbor” / “quadratic” → preference; “inventory” / “pipeline” →
+   cascade; “extraction” / “quota” → resource). A tie or no hits leaves
+   the last stable hypothesis unchanged.
+3. `remap()` clears the hypothesis and re-ingests. Use that when the
+   team changes its mind.
+
+Do not leak a global optimum or a full instance during ASSEMBLY. For the
+paper examples that means no `z*`, full demand path, bullwhip, or
+terminal stock forecast.
+
+## CONVERGE
+
+CONVERGE is a group solve. Each epoch:
+
+1. Every peer sees a **local** view and announces its current state in
+   the form the class requires.
+2. The matching engine applies the class update once the epoch is full.
+3. The team records progress (an improvement signal, a quorum, or
+   another class-specific check).
+4. Peers vote whether to continue, when the class uses ballots.
+5. The team halts together.
+
+The agent does **not** invent the next state. The engine does.
+
+### Class-specific announce
+
+The hop prints `phase=CONVERGE` and the local view. The announce *form*
+belongs to the class.
+
+**Scalar paper examples** (preference, cascade, resource):
+
+```text
+ANNOUNCE value=<f64> agent=<id> epoch=<k>
+VOTE CONTINUE
+```
+
+or `VOTE STOP`. Then `NEXT <peer>` or `DONE`. A missed parse falls back
+to the engine’s current local value. A skill miss is announce versus
+**current** engine state, not versus the formula result.
+
+`COMMIT proposal=` is still parsed as an announce alias so older
+transcripts do not break. New hops should use `ANNOUNCE`.
+
+**Development** (code artifacts): each peer proposes `ExternalBytes`
+and endorses via `ToolResult`. Halt is quorum on the winning artifact,
+or `--max-rounds`. See
+[AgentBridge → DevelopmentEngine](agentbridge.md#developmentengine-the-coordination-core).
+
+A future class uses the same phase and a new announce form. Do not
+force every class through `value=<f64>`.
+
+### Halt on the paper examples
+
+Those three engines share `ConvergeController`. It stops on the first
+of:
+
+| Halt | Meaning |
+|------|---------|
+| `MajorityStop` | Strict majority of the roster voted `STOP` this epoch |
+| `Plateau` | Metric failed to improve for `plateau_k` epochs (default 3 in `coordinate`) |
+| `NoSolution` | Plateau after at least one compared epoch with no improvement |
+| `PaperHorizon` | Epochs reached the class horizon |
+| `Unmapped` | ASSEMBLY named a class with no engine |
+
+Preference treats lower metric as better (`‖z − z*‖₂`). Cascade uses
+accumulated cost (lower is better). Resource uses remaining stock
+(higher is better). Other classes may halt on a different signal.
+
+## Implemented example classes
+
+These are examples, not a closed set. ASSEMBLY may name something else;
+that is a successful modeling outcome and an `Unmapped` CONVERGE
+refusal.
+
+| Class | `PatternKind` | Local state | Engine update | Default horizon in `coordinate` |
+|-------|---------------|-------------|---------------|----------------------------------|
+| Development | `Development` | code artifact | Endorse proposals; most votes wins | `--max-rounds` |
+| Preference aggregation | `Preference` | current `z_i` | Synchronous Jacobi on the neighbor inbox | `--max-rounds` |
+| Supply-chain cascades | `Cascade` | last order | Order-up-to + smoothing on engine-owned plant | `min(--max-rounds, demand length)` (paper demand is 8) |
+| Sustainable resource | `Resource` | last extraction `e_i` | Dual step (`λ`, clip `e_i`) and stock update | `min(--max-rounds, 12)` |
+
+### Development (`DevelopmentEngine`)
+
+`--pattern development` (the `coordinate` default) is CONVERGE for a
+shared code artifact. Peers propose implementations and endorse one.
+Finalization selects the artifact with the most endorsements when
+quorum is met.
+
+### Preference (`PreferenceEngine`)
+
+Line graph, private scores `c`, coupling `β` (default `0.75`). Each
+epoch every node announces `z_i`. When the inbox is complete the engine
+sets, simultaneously (Jacobi, not Gauss–Seidel):
+
+```text
+z_i ← (c_i + 2β Σ_{j∈N_i} z_j) / (1 + 2β d_i)
+```
+
+The unique fixed point is `z* = (I + 2β L)⁻¹ c`. This is **not** a
+median vote (that is a different object in the paper).
+
+### Cascade (`CascadeEngine`)
+
+Stages in a chain. Downstream orders become upstream demand. Paper
+constants: lead `L = 2`, target inventory `I = 8`, demand
+`[4, 4, 4, 8, 8, 8, 4, 4]`, smoothing `0.5`. Agents announce
+`last_order`. The engine owns inventory and pipeline.
+
+### Resource (`ResourceEngine`)
+
+Peers share a renewable stock. Paper constants: `R⁰ = 24`, capacity 30,
+regen `0.2`, quota fraction `0.25`, `α = 0.35`, `η = 0.4`, 12 rounds.
+Agents announce last extraction. Coordinated `α > 0` retains more stock
+than uncontrolled greedy on the paper instance.
+
+## Agent Skills
+
+Peers are instrumented with Agent Skills, using the same install map as
+[`skills/agentbridge`](https://github.com/agntcy/shadi/tree/main/skills/agentbridge).
+Copy the folder. The folder name must match. Do not paste `SKILL.md`
+into `--text`.
+
+| Skill | Folder | When it applies |
+|-------|--------|-----------------|
+| ASSEMBLY | [`skills/assembly/`](https://github.com/agntcy/shadi/tree/main/skills/assembly) | Hop prints `phase=ASSEMBLY` |
+| CONVERGE | [`skills/converge/`](https://github.com/agntcy/shadi/tree/main/skills/converge) | Hop prints `phase=CONVERGE` and the class uses a printed local view |
+
+`skills/converge` as shipped teaches the scalar announce / `VOTE`
+form. A class with a different state type (including development)
+keeps the same phase name and uses that class’s announce form.
+
+| Host | Destination |
+|------|-------------|
+| Claude Code | `~/.claude/skills/<name>/` or `.claude/skills/<name>/` |
+| Cursor | `.cursor/skills/<name>/` |
+| GitHub Copilot | `~/.copilot/skills/<name>/` |
+| Goose | `~/.config/goose/skills/<name>/` |
+| OpenCode | `~/.config/opencode/skills/<name>/` |
+| Codex / others | that host’s skills directory, same folder name |
+
+A mesh job copies both folders into the job-local
+`$XDG_CONFIG_HOME/goose/skills/` tree. The hop names the phase; it does
+not inline the skill body.
+
+Do not invent agentbridge or Goose flags in the skill text.
+
+## CLI
+
+```bash
+# ASSEMBLY, then CONVERGE on whatever class the team names
+agentbridge coordinate \
+  --goal "implement a JSON parser in Rust" \
+  --agents claude-code,copilot,codex \
+  --pattern unmapped \
+  --assembly \
+  --quorum 2 \
+  --max-rounds 5
+
+# Skip ASSEMBLY when the class is already chosen
+agentbridge coordinate \
+  --goal "stages in a chain order from inventory" \
+  --agents slim:goose-0,slim:goose-1,slim:goose-2,slim:goose-3 \
+  --pattern cascade \
+  --max-rounds 8 \
+  --slim-endpoint 127.0.0.1:47357
+```
+
+| Flag | Role |
+|------|------|
+| `--pattern development` | Default. CONVERGE on `DevelopmentEngine` |
+| `--pattern preference\|cascade\|resource` | CONVERGE on that paper engine |
+| `--pattern unmapped` | Force ASSEMBLY; CONVERGE starts only if an implemented class is inferred |
+| `--assembly` | Run ASSEMBLY first even when `--pattern` already names a class |
+| `--max-rounds` | CONVERGE horizon cap |
+| `--quorum` | Endorsement quorum for `DevelopmentEngine` |
+
+`--agents` specs are the same as the rest of agentbridge (`goose`,
+`slim:<id>`, …). Listeners still come from `agentbridge register`.
+Identity is DID-only; see
+[AgentBridge → DID authentication](agentbridge.md#did-authentication).
+
+In the CLI, `PatternKind::is_converge_class()` means “use the scalar
+paper driver (`ConvergeController`)”. Development is still CONVERGE; it
+uses the artifact driver.
+
+## Honest claims
+
+| Claim | Holds when | Does not mean |
+|-------|------------|---------------|
+| Hold equals Ideal | A paper CONVERGE engine applies the published update on the intended class, for that class horizon | The LLM discovered the formula; every class has an Ideal |
+| ASSEMBLY mapped the intended class | `CLASS` / keywords inferred the intended label | The class set is closed, or the map is a proof |
+| Unmapped is success for modeling | The team named a class SHADI does not solve | A solver ran |
+| Mesh is live | Peers admitted, every peer recvs, NEXT/HANDOFF on the ring, hops use `slim://` | Hold vs Ideal |
+
+Do not claim Gemma (or any other model) discovered Jacobi or proved
+preference-linear.
+
+## Types and files
+
+| Item | Location |
+|------|----------|
+| `ProtocolPhase::{Assembly, Converge}` | `crates/shadi_mas/src/types.rs` |
+| `PatternKind`, `ConvergeBallot`, `ConvergeHalt`, `ConvergeSignal` | same |
+| `AssemblySession`, `infer_pattern` | `crates/shadi_mas/src/assembly.rs` |
+| `ConvergeController`, `ConvergeSurface` | `crates/shadi_mas/src/engines/converge.rs` |
+| Class engines | `engines/development.rs`, `preference.rs`, `cascade.rs`, `resource.rs` |
+| CLI driver | `crates/agentbridge_cli/src/commands/coordinate.rs` |
+| Skills | `skills/assembly/`, `skills/converge/` |
+
+## Next steps
+
+- Runtime, engines, and adapters: [SHADI MAS](shadi-mas.md).
+- Install listeners and DID auth from [AgentBridge](agentbridge.md).
+- For transport and group admission see [SLIM and A2A](slim_a2a.md).

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -740,6 +740,8 @@ equivalent of `create`/`invite`.
 ## shadictl slim-mas (`shadictl slim-mas`)
 
 `shadictl slim-mas` evaluates SLIM multi-agent membership rules from a TOML config.
+This is the `slim_mas` crate. It is not [SHADI MAS](shadi-mas.md)
+(`shadi_mas`), which owns coordination engines and ASSEMBLY / CONVERGE.
 
 ### Global flags
 
@@ -781,4 +783,5 @@ Exit codes:
 
 - Walk through a full example in [Sandbox and Policies](sandbox.md) or the [Secure Agent Group Demo](demos/did-agent-group.md).
 - Try the discovery-driven equivalent in the [Agent Directory Discovery Demo](demos/dir-group-discovery.md).
+- Coordination runtime: [SHADI MAS](shadi-mas.md). `agentbridge coordinate --assembly` and `--pattern` are in [ASSEMBLY and CONVERGE](assembly-converge.md#cli).
 - See the underlying security model in [Security Notes](security.md).

--- a/docs/content/design.md
+++ b/docs/content/design.md
@@ -9,9 +9,10 @@ The workspace contains these crates:
 - shadi_py: Python bindings for secrets, SQLCipher memory, and sandbox execution
 - shadi_identity: DID identity derivation and SLIM DID-JWT auth
 - shadi_a2a: A2A-over-SLIM wrapper, including secure group (Collaborate) messaging
-- slim_mas: SLIM multi-agent group config and DID allow-list evaluation (a library, consumed by `shadictl slim-mas`, not itself a CLI)
-- shadi_mas: autonomous multi-round agent coordination runtime (proposal/vote/finalize), consumed by `agentbridge coordinate`
-- agentbridge / agentbridge_cli: general-purpose A2A agent interconnect (register, handoff, delegate, coordinate); ships with CLI coding-tool adapters (Claude Code, Copilot, Codex, Cursor Agent) as its flagship use case- agent_transport_slim: transport adapter for SLIM/A2A and stdio bridge for SHADI-managed sessions
+- slim_mas: SLIM multi-agent group config and DID allow-list evaluation (a library, consumed by `shadictl slim-mas`, not itself a CLI). Not SHADI MAS.
+- shadi_mas: SHADI MAS coordination runtime — epochs, engines, ASSEMBLY / CONVERGE. See [SHADI MAS](shadi-mas.md) and [ASSEMBLY and CONVERGE](assembly-converge.md).
+- agentbridge / agentbridge_cli: general-purpose A2A agent interconnect (register, handoff, delegate, coordinate); ships with CLI coding-tool adapters (Claude Code, Copilot, Codex, Cursor Agent) as its flagship use case
+- agent_transport_slim: transport adapter for SLIM/A2A and stdio bridge for SHADI-managed sessions
 - shadi_telemetry: OpenTelemetry tracing/metrics initialization
 
 Platform-specific backends live under agent_secrets/src/platform.
@@ -24,4 +25,5 @@ locally.
 ## Next steps
 
 - See how these crates fit together in [Architecture](architecture.md).
+- Coordination runtime: [SHADI MAS](shadi-mas.md).
 - Start using the runtime with [Getting Started](getting_started.md).

--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -154,6 +154,7 @@ After the first successful sandboxed command, choose the track that matches your
 - Run the end-to-end local demo: [Operations](operations.md)
 - Integrate SHADI into an agent or app: [API Guide](api_integration.md)
 - Review the system model before deploying: [Architecture](architecture.md)
+- Coordinate a team of agents: [SHADI MAS](shadi-mas.md) and [ASSEMBLY and CONVERGE](assembly-converge.md)
 
 ## Recommended Reading Order
 
@@ -163,4 +164,5 @@ If you want a practical progression through the docs, use this sequence:
 2. [Sandbox and Policies](sandbox.md)
 3. [Operations](operations.md)
 4. [Security Notes](security.md)
-5. [CLI Reference](cli.md)
+5. [SHADI MAS](shadi-mas.md)
+6. [CLI Reference](cli.md)

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -15,6 +15,7 @@ OS-level sandboxing, encrypted local memory, and secure transport.
 - Integrating into an agent or app? Start with the [API Guide](api_integration.md).
 - Looking for flags and commands? See the [CLI Reference](cli.md).
 - Connecting CLI coding tools autonomously? Start with [AgentBridge](agentbridge.md).
+- Coordinating a team of agents? Start with [SHADI MAS](shadi-mas.md), then [ASSEMBLY and CONVERGE](assembly-converge.md).
 
 ## Why SHADI
 
@@ -51,6 +52,8 @@ SHADI presents the runtime as four product layers:
 - Python bindings for secrets, memory, and sandboxed execution.
 - CLI workflows for policy, identity, key management, and sandbox execution.
 - Example agents and demos, including a SecOps workflow against real GitHub signals.
+- **SHADI MAS**: epoch-disciplined coordination runtime (`shadi_mas`) that
+  drives ASSEMBLY / CONVERGE and the class engines AgentBridge consumes.
 - **agentbridge**: interconnect Claude Code, Copilot, Codex, Cursor Agent, and
   other CLI coding tools via A2A, SLIM, and DIR with autonomous coordination
   toward a shared goal.

--- a/docs/content/shadi-mas.md
+++ b/docs/content/shadi-mas.md
@@ -1,0 +1,208 @@
+# SHADI MAS
+
+SHADI MAS is the coordination runtime for a team of agents. The crate is
+`shadi_mas` (`agntcy-shadi-mas`). It owns group semantics: epochs, event
+discipline, finalization, and the engines that apply a class update.
+
+It does not own transport, identity, sandboxing, or a coding-tool CLI.
+Those stay in SLIM / A2A, `shadi_identity`, `shadictl`, and
+[AgentBridge](agentbridge.md). AgentBridge *consumes* this crate
+(`agentbridge coordinate`).
+
+The two group phases — joint model, then joint solve — are
+[ASSEMBLY and CONVERGE](assembly-converge.md). This page is the runtime
+those phases run on.
+
+## What it is not
+
+| Name | Role |
+|------|------|
+| **SHADI MAS** (`shadi_mas`) | Coordination state machines and class engines |
+| **`slim_mas`** | SLIM group membership and DID allow-list evaluation (`shadictl slim-mas`) |
+| **AgentBridge** | Register, list, handoff, delegate, and the `coordinate` driver that feeds this runtime |
+
+`slim_mas` admits *who* may sit on a SLIM channel. SHADI MAS decides
+*how* a roster advances a shared problem once those peers can talk.
+
+## Place in the stack
+
+```text
+agentbridge coordinate / other driver
+        │
+        ▼
+   MasRuntime<E>          ← history + apply()
+        │
+        ▼
+ CoordinationEngine       ← one class (development, preference, …)
+        │
+        ▼
+  adapter traits          ← Messaging / Task / Tool
+        │
+        ▼
+ SLIM · A2A · CLI tools
+```
+
+The runtime is provider-agnostic. A `ToolAdapter` may call MCP or an
+Agent Skill. The engine sees `SemanticEvent` values, not a vendor API.
+
+## Event loop
+
+Every step is one event:
+
+```text
+SemanticEvent  ──►  CoordinationEngine::apply  ──►  EventOutcome
+```
+
+`SemanticEvent` carries `PatternKind`, `EventMetadata` (`event_id`,
+`epoch`, `source`), and a `SemanticPayload`. Outcomes are:
+
+| Outcome | Meaning |
+|---------|---------|
+| `Applied` | Accepted; epoch not finished |
+| `Deferred { expected, received }` | Future epoch; hold until the engine is there |
+| `Finalized(summary)` | Epoch complete; class update applied |
+| `Rejected(reason)` | Duplicate, stale, wrong pattern, wrong payload, or unknown participant |
+
+`MasRuntime<E>` wraps any engine. `apply()` forwards to the engine and
+appends an `AppliedTransition` to `history()` for audit and replay.
+
+### Epoch discipline
+
+Engines reject work that would corrupt the round:
+
+- `DuplicateEvent` — same `event_id` seen again
+- `StaleEpoch` — event epoch behind the engine
+- `FinalizedEpoch` — that epoch already closed
+- `IncompatiblePattern` / `IncompatiblePayload`
+- `UnknownParticipant`
+
+`RuntimeCounters` tally applied, rejected, deferred, duplicates, stale,
+and finalized events.
+
+## Group protocol
+
+`ProtocolPhase` is `Assembly` or `Converge`. ASSEMBLY infers a class
+(`AssemblySession`, `CLASS <name>` or keywords). CONVERGE runs the
+engine for that class. A token SHADI does not implement is
+`PatternKind::Unmapped` and must not start a solver.
+
+The protocol is not limited to numbers. A class may use a code artifact,
+a scalar, or another local state. Announce form is class-specific.
+Details, skills, CLI flags, and honest claims are in
+[ASSEMBLY and CONVERGE](assembly-converge.md).
+
+## Engines
+
+Each implemented class is a `CoordinationEngine`. `coordinate --pattern`
+selects one.
+
+| Engine | `PatternKind` | Local state | When the epoch finalizes |
+|--------|---------------|-------------|--------------------------|
+| `DevelopmentEngine` | `Development` | code artifact (`ExternalBytes`) | Quorum of endorsements (`ToolResult`) |
+| `PreferenceEngine` | `Preference` | `z_i` (`ScalarProposal`) | Full inbox; Jacobi step |
+| `CascadeEngine` | `Cascade` | last order | Full inbox; order-up-to + smoothing |
+| `ResourceEngine` | `Resource` | last extraction | Full inbox; dual step and stock |
+
+`Development` is the `coordinate` default. The three paper engines share
+`ConvergeController` (improvement signal, `VOTE CONTINUE` / `VOTE STOP`,
+plateau, class horizon). In the CLI,
+`PatternKind::is_converge_class()` means “use that scalar driver.”
+Development is still CONVERGE; it uses the artifact driver.
+
+To add a class: implement `CoordinationEngine` in
+`crates/shadi_mas/src/engines/<pattern>.rs`, export it from
+`engines/mod.rs`, and add a `PatternKind` variant. The runtime and
+adapter traits do not change.
+
+## Adapter traits
+
+These are the only I/O seams the crate defines:
+
+| Trait | Job |
+|-------|-----|
+| `MessagingAdapter` | Publish bytes to a topic |
+| `TaskAdapter` | Dispatch a `TaskEnvelope` (pattern, epoch, body) |
+| `ToolAdapter` | Invoke a tool (`ToolProvider::Mcp` or `AgentSkills`) |
+
+`shadi_mas::experiments` ships the implementations that exist today:
+
+| Type | Role |
+|------|------|
+| `RecordingMessagingAdapter` | In-memory publish log |
+| `RecordingTaskAdapter` | In-memory dispatch log |
+| `LiveA2ATaskAdapter` | Live A2A `SendMessage` over SLIMRPC or official unicast |
+
+[AgentBridge](agentbridge.md) supplies `CliToolAdapter` (`ToolAdapter`
+over a local CLI profile). Unsigned inbound A2A parks as
+`AUTH_REQUIRED` (`experiments::auth_required`); a forged DID is
+rejected.
+
+!!! note "SLIM client certificates"
+
+    `LiveA2ATaskAdapter` authenticates to the SLIM node with TLS 1.3 and
+    the same client material as AgentBridge: `SLIM_TLS_CERT` /
+    `SLIM_TLS_KEY` / `SLIM_TLS_CA`, or
+    `$SHADI_TMP_DIR/shadi-slim-mtls/client[-<agent>].crt|.key` and
+    `ca.crt`. Verify those files before use:
+
+    ```bash
+    openssl x509 -text -noout -in <certificate_file>
+    ```
+
+    Required checks: not expired and already valid; RSA ≥ 2048 bits or
+    ECDSA on P-256 or stronger; SHA-2 signature (not MD5 or SHA-1).
+    Self-signed material is for lab and CI only. Generate the bundle
+    with `tools/generate_slim_mtls_certs.sh`. Do not hardcode
+    certificates or keys.
+
+## How AgentBridge drives it
+
+`agentbridge coordinate` builds a roster, optionally runs ASSEMBLY, then
+constructs `MasRuntime<E>` for the inferred class and feeds events from
+tool replies.
+
+- `--pattern development` — propose / endorse until quorum or
+  `--max-rounds`
+- `--pattern preference\|cascade\|resource` — scalar CONVERGE driver
+- `--assembly` — ASSEMBLY first; CONVERGE starts only if the class is
+  implemented
+
+Listeners, DID proof, and `delegate` / `handoff` stay on the AgentBridge
+page. This crate does not parse clap flags.
+
+## Tests
+
+```bash
+cargo test -p agntcy-shadi-mas --lib
+```
+
+Unit tests cover ASSEMBLY inference, each engine’s epoch rules, and
+`AUTH_REQUIRED` policy. There is no live-SLIM integration test in this
+crate today.
+
+## File map
+
+```text
+crates/shadi_mas/src/
+  lib.rs
+  types.rs          PatternKind, SemanticEvent, outcomes, CONVERGE ballots
+  runtime.rs        CoordinationEngine, MasRuntime
+  adapters.rs       Messaging / Task / Tool traits
+  assembly.rs       AssemblySession, infer_pattern
+  engines/
+    development.rs
+    preference.rs
+    cascade.rs
+    resource.rs
+    converge.rs     ConvergeController, ConvergeSurface, announce/vote parse
+  experiments/
+    mod.rs          recording adapters, LiveA2ATaskAdapter
+    auth_required.rs
+```
+
+## Next steps
+
+- Group phases, skills, and claims: [ASSEMBLY and CONVERGE](assembly-converge.md)
+- Driver CLI and listeners: [AgentBridge](agentbridge.md)
+- Transport and admission: [SLIM and A2A](slim_a2a.md)
+- Crate README: [`crates/shadi_mas/README.md`](https://github.com/agntcy/shadi/blob/main/crates/shadi_mas/README.md)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - Introduction:
       - Overview: overview.md
       - Architecture: architecture.md
+      - SHADI MAS: shadi-mas.md
       - Security Notes: security.md
       - Design Overview: design.md
   - Guides:
@@ -94,6 +95,7 @@ nav:
       - A2A unicast demo: demos/a2a-grpc.md
       - A2A unicast sample run: demos/a2a-grpc-sample.md
       - AgentBridge: agentbridge.md
+      - ASSEMBLY and CONVERGE: assembly-converge.md
       - Mobile: mobile_integration.md
   - Reference:
       - CLI Reference: cli.md

--- a/skills/assembly/SKILL.md
+++ b/skills/assembly/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: assembly
+description: >-
+  ASSEMBLY phase: jointly understand a problem, propose a system model, and
+  optionally name a class. Use when the hop says phase=ASSEMBLY or the team
+  must model a problem before solving it.
+---
+
+# ASSEMBLY — model the problem together
+
+You are one peer on a SHADI mesh. MCP is off. This phase is **group
+modeling**, not a single agent solving.
+
+Understand the problem with your peers. Propose a system model: who the
+agents are, what they exchange, and what “better” means. Offer a
+formalization if you can.
+
+You **may** name a class that is not one of the three paper examples
+(Preference Aggregation, Supply Chain Cascades, Sustainable Resource
+Allocation). Those three are examples, not a closed set.
+
+## Line protocol
+
+End with exactly one line:
+
+`CLASS <name>`
+
+`<name>` is `preference`, `cascade`, `resource`, or another short token
+if you believe the problem is a different class. Then `NEXT goose-<n>`
+or `DONE`. No other text.
+
+## Forbidden
+
+- Do not compute or mention a global target vector, `z*`, a full demand
+  path, bullwhip, or a terminal stock forecast.
+- Do not start MCP, desktop, or Summon.
+- Do not invent agentbridge or Goose flags.
+
+## Install this skill
+
+Copy the `skills/assembly/` folder to the host skills directory. The folder
+name must be `assembly`.
+
+| Host | Destination |
+|---|---|
+| Claude Code | `~/.claude/skills/assembly/` or `.claude/skills/assembly/` |
+| Cursor | `.cursor/skills/assembly/` |
+| GitHub Copilot | `~/.copilot/skills/assembly/` |
+| Goose | `~/.config/goose/skills/assembly/` |
+| OpenCode | `~/.config/opencode/skills/assembly/` |
+| Codex / others | that host’s skills directory, same folder name |

--- a/skills/assembly/references/classes.md
+++ b/skills/assembly/references/classes.md
@@ -1,0 +1,20 @@
+# Example classes (not a closed set)
+
+ASSEMBLY may propose any system model. This paper scores only these three
+when the experiment sets an intended label.
+
+## preference
+
+Peers on a graph. Each has a private preferred score. Neighbors exchange
+current scores. Better means the shared scores move together.
+
+## cascade
+
+Stages in a chain. Downstream orders become upstream demand. Each stage
+has inventory and a pipeline. Better means lower holding, backlog, and
+order-churn cost.
+
+## resource
+
+Peers share a renewable stock. Each wants to extract. A shared limit or
+price may restrain take. Better means the stock is not exhausted.

--- a/skills/converge/SKILL.md
+++ b/skills/converge/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: converge
+description: >-
+  CONVERGE phase: announce local state and vote CONTINUE or STOP. The class
+  engine applies the update. Use when the hop says phase=CONVERGE.
+---
+
+# CONVERGE — solve together
+
+You are one peer on a SHADI mesh. MCP is off. CONVERGE is the group
+phase: the team exchanges local state and stops together. The **engine**
+applies the mapped class update after every peer has announced this
+epoch. You do **not** invent the next state.
+
+This skill’s announce line is for classes whose local view is a printed
+scalar. A class with another state type keeps `phase=CONVERGE` and uses
+that class’s form.
+
+## Announce
+
+Reply with the printed local value:
+
+`ANNOUNCE value=<f64> agent=<id> epoch=<k>`
+
+Then either `NEXT goose-<n>` or `DONE`.
+
+## Vote
+
+After you have the improvement signal (or if the hop printed one), add:
+
+`VOTE CONTINUE` or `VOTE STOP`
+
+STOP if the signal is good enough or not improving. CONTINUE otherwise.
+The team halts on majority STOP, a plateau, or the paper horizon.
+
+## Forbidden
+
+- Do not invent a Jacobi step, order-up-to formula, or dual update.
+- Do not mention `z*`, bullwhip, or a target stock path.
+- Do not start MCP, desktop, or Summon.
+- Do not invent agentbridge or Goose flags.
+
+## Install this skill
+
+Copy the `skills/converge/` folder (this file plus `references/`) to the
+host skills directory. The folder name must be `converge`.
+
+| Host | Destination |
+|---|---|
+| Claude Code | `~/.claude/skills/converge/` or `.claude/skills/converge/` |
+| Cursor | `.cursor/skills/converge/` |
+| GitHub Copilot | `~/.copilot/skills/converge/` |
+| Goose | `~/.config/goose/skills/converge/` |
+| OpenCode | `~/.config/opencode/skills/converge/` |
+| Codex / others | that host’s skills directory, same folder name |

--- a/skills/converge/references/inbox.md
+++ b/skills/converge/references/inbox.md
@@ -1,0 +1,15 @@
+# Example inboxes
+
+The hop prints the local view. Announce that printed value.
+
+## preference
+
+`z_i`, `c_i`, `beta`, `d_i`, inbound neighbor scores. Announce `z_i`.
+
+## cascade
+
+`I_i`, `pipeline_sum`, `last_order`, `observed_demand`. Announce `last_order`.
+
+## resource
+
+`last_e_i`, `R`, `lambda`, `C_R`. Announce `last_e_i`.


### PR DESCRIPTION
## Summary
- Group phases: ASSEMBLY maps a shared problem class; CONVERGE applies the class update and votes CONTINUE/STOP.
- Adds Preference, Cascade, and Resource engines plus `coordinate --assembly` / `--pattern`.
- Docs and Agent Skills for both phases.

## Test plan
- [ ] `cargo test -p agntcy-shadi-mas --lib`
- [ ] `cargo test -p agntcy-agentbridge-cli`

