### PR TITLE
test(sandbox): fuzz policy-patch apply and cap control lines

### DIFF
--- a/crates/shadi_sandbox/fuzz/Cargo.toml
+++ b/crates/shadi_sandbox/fuzz/Cargo.toml
@@ -28,4 +28,11 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "policy-patch"
+path = "fuzz_targets/policy-patch.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]

--- a/crates/shadi_sandbox/fuzz/README.md
+++ b/crates/shadi_sandbox/fuzz/README.md
@@ -18,6 +18,12 @@ fuzzing for its own sake:
   standing between an arbitrary name and a path-traversal escape out of
   `socket_dir()` is that sanitizer.
 
+- **`policy-patch`** — applies a deserialized `ControlMessage::Patch` to
+  `apply_policy_patch` (the same path `handle_patch` uses after parse).
+  Asserts `extract_host` never leaks a `://` scheme and that filesystem
+  staging lengths match the patch. The control socket also rejects any
+  line larger than `CONTROL_LINE_MAX_BYTES` (64 KiB).
+
 ## Running
 
 ```sh
@@ -25,6 +31,7 @@ cargo install cargo-fuzz
 rustup toolchain install nightly
 cargo +nightly fuzz run control-message
 cargo +nightly fuzz run session-name
+cargo +nightly fuzz run policy-patch
 ```
 
 Both ran clean for 30 seconds (~7.3-7.8M executions each) with no crash

--- a/crates/shadi_sandbox/fuzz/fuzz_targets/policy-patch.rs
+++ b/crates/shadi_sandbox/fuzz/fuzz_targets/policy-patch.rs
@@ -1,0 +1,63 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shadi_sandbox::{
+    apply_policy_patch, extract_host, ControlMessage, PatchAxisStatus, PatchState,
+    CONTROL_LINE_MAX_BYTES,
+};
+
+// Mirrors handle_patch after the control socket has already accepted a line.
+// Same-UID peers can write that socket, so apply_policy_patch must not panic
+// and must not leak a URL scheme into the live allowlist.
+fuzz_target!(|data: &[u8]| {
+    if data.len() > CONTROL_LINE_MAX_BYTES {
+        return;
+    }
+    let Ok(line) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    for dest in line.split(|c: char| c.is_ascii_whitespace() || c == ',') {
+        if dest.is_empty() {
+            continue;
+        }
+        let host = extract_host(dest);
+        assert!(
+            !host.contains("://"),
+            "extract_host({dest:?}) = {host:?} still contains a scheme"
+        );
+    }
+
+    let Ok(msg) = serde_json::from_str::<ControlMessage>(line) else {
+        return;
+    };
+    let ControlMessage::Patch(patch) = msg else {
+        return;
+    };
+
+    let mut without_proxy = PatchState::default();
+    let result = apply_policy_patch(&mut without_proxy, &patch);
+    if !patch.add_read.is_empty() || !patch.add_write.is_empty() || !patch.add_allow.is_empty() {
+        assert_eq!(without_proxy.staged_read.len(), patch.add_read.len());
+        assert_eq!(without_proxy.staged_write.len(), patch.add_write.len());
+        assert_eq!(without_proxy.staged_allow.len(), patch.add_allow.len());
+        assert_eq!(result.filesystem, PatchAxisStatus::PendingRestart);
+    }
+    if !patch.add_net_allow.is_empty() || !patch.remove_net_allow.is_empty() {
+        assert_eq!(result.network, PatchAxisStatus::Rejected);
+        assert!(without_proxy.net_allow.is_empty());
+    }
+    for host in &without_proxy.net_allow {
+        assert!(!host.contains("://"), "net_allow leaked scheme: {host}");
+    }
+
+    let mut with_proxy = PatchState {
+        has_live_proxy: true,
+        ..Default::default()
+    };
+    let _ = apply_policy_patch(&mut with_proxy, &patch);
+    for host in &with_proxy.net_allow {
+        assert!(!host.contains("://"), "proxy net_allow leaked scheme: {host}");
+    }
+    assert_eq!(with_proxy.staged_read.len(), without_proxy.staged_read.len());
+});

--- a/crates/shadi_sandbox/src/control.rs
+++ b/crates/shadi_sandbox/src/control.rs
@@ -14,7 +14,7 @@
 //! [`socket_dir`]. A caller connects, writes one JSON [`ControlMessage`] line,
 //! and reads one JSON [`ControlResponse`] line back.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
 use crate::policy_patch::{
@@ -25,6 +25,35 @@ use crate::policy_patch::{
 use crate::policy_patch::PatchAxisStatus;
 #[cfg(test)]
 use std::io::Read;
+
+/// Maximum bytes accepted for one control-socket JSON line, including the newline.
+pub const CONTROL_LINE_MAX_BYTES: usize = 64 * 1024;
+
+/// Outcome of [`read_control_line`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlLine {
+    /// Peer closed the write side.
+    Eof,
+    /// A line of at most [`CONTROL_LINE_MAX_BYTES`] was read into the buffer.
+    Line,
+    /// The line exceeded [`CONTROL_LINE_MAX_BYTES`]. Remaining bytes on the
+    /// stream are unsynchronized; the caller should close the connection.
+    TooLong,
+}
+
+/// Read one newline-terminated control line, rejecting anything larger than
+/// [`CONTROL_LINE_MAX_BYTES`].
+pub fn read_control_line<R: BufRead>(reader: &mut R, buf: &mut String) -> io::Result<ControlLine> {
+    buf.clear();
+    let n = io::Read::take(&mut *reader, CONTROL_LINE_MAX_BYTES as u64 + 1).read_line(buf)?;
+    if n == 0 {
+        return Ok(ControlLine::Eof);
+    }
+    if n > CONTROL_LINE_MAX_BYTES {
+        return Ok(ControlLine::TooLong);
+    }
+    Ok(ControlLine::Line)
+}
 
 /// Directory holding control sockets.
 ///
@@ -220,9 +249,17 @@ fn send_message(socket_path: &Path, msg: &ControlMessage) -> Result<ControlRespo
 
     let mut reader = BufReader::new(&stream);
     let mut line = String::new();
-    reader
-        .read_line(&mut line)
-        .map_err(|e| format!("failed to read response: {}", e))?;
+    match read_control_line(&mut reader, &mut line)
+        .map_err(|e| format!("failed to read response: {}", e))?
+    {
+        ControlLine::Line => {}
+        ControlLine::Eof => return Err("empty response".to_string()),
+        ControlLine::TooLong => {
+            return Err(format!(
+                "control line exceeds {CONTROL_LINE_MAX_BYTES} bytes"
+            ));
+        }
+    }
 
     serde_json::from_str(&line).map_err(|e| format!("invalid response: {}", e))
 }
@@ -435,5 +472,28 @@ mod tests {
         assert!(send_terminate(missing).is_err());
         assert!(send_patch(missing, &PolicyPatch::default()).is_err());
         assert!(!is_reachable(missing));
+    }
+
+    #[test]
+    fn read_control_line_accepts_a_short_line() {
+        let mut reader = std::io::Cursor::new(b"{\"type\":\"query_policy\"}\n");
+        let mut buf = String::new();
+        assert_eq!(
+            read_control_line(&mut reader, &mut buf).expect("read"),
+            ControlLine::Line
+        );
+        assert!(buf.starts_with("{\"type\":\"query_policy\"}"));
+    }
+
+    #[test]
+    fn read_control_line_rejects_an_oversize_line() {
+        let mut payload = vec![b'a'; CONTROL_LINE_MAX_BYTES + 2];
+        payload.push(b'\n');
+        let mut reader = std::io::Cursor::new(payload);
+        let mut buf = String::new();
+        assert_eq!(
+            read_control_line(&mut reader, &mut buf).expect("read"),
+            ControlLine::TooLong
+        );
     }
 }

--- a/crates/shadi_sandbox/src/lib.rs
+++ b/crates/shadi_sandbox/src/lib.rs
@@ -8,6 +8,7 @@ pub mod policy_patch;
 pub mod resolve;
 mod platform;
 
+pub use control::{read_control_line, ControlLine, CONTROL_LINE_MAX_BYTES};
 pub use net_proxy::{NetAllowlist, NetProxy};
 pub use policy::{PlatformSandboxProfile, ProfileDefaults, SandboxPolicy, SandboxProfile};
 pub use resolve::{
@@ -15,8 +16,8 @@ pub use resolve::{
     resolve_policy, PolicyDescription, PolicyFileValues, PolicyOverrides, ResolvedPolicy,
 };
 pub use policy_patch::{
-    ControlMessage, ControlResponse, PatchAxisStatus, PolicyPatch, PolicyPatchResponse,
-    ProcessResources,
+    apply_policy_patch, extract_host, ControlMessage, ControlResponse, PatchAxisStatus,
+    PatchState, PolicyPatch, PolicyPatchResponse, ProcessResources,
 };
 use std::process::{Command, ExitStatus};
 use std::io;

--- a/crates/shadi_sandbox/src/policy_patch.rs
+++ b/crates/shadi_sandbox/src/policy_patch.rs
@@ -8,6 +8,8 @@
 //! allow/block lists) can be applied instantly. Filesystem and network patches
 //! are staged and reported as `PendingRestart` in the response.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 /// An incremental patch to the effective sandbox policy.
@@ -134,6 +136,129 @@ pub enum ControlResponse {
     Error { message: String },
 }
 
+/// Mutable axes a [`PolicyPatch`] can change. The control-socket listener
+/// maps live session state onto this so the apply path can be fuzzed
+/// without a Unix socket or a `Mutex`.
+#[derive(Debug, Clone, Default)]
+pub struct PatchState {
+    pub allow: HashSet<String>,
+    pub blocked: HashSet<String>,
+    pub staged_read: Vec<String>,
+    pub staged_write: Vec<String>,
+    pub staged_allow: Vec<String>,
+    pub net_allow: Vec<String>,
+    /// When false, network changes are rejected (kernel sandbox cannot
+    /// update in place and a restart would kill the workload).
+    pub has_live_proxy: bool,
+}
+
+/// Strip a URL scheme and path from a net-allow entry, returning just the host.
+///
+/// Users may write `http://httping.org/` but the proxy allowlist matches
+/// hostnames only.
+pub fn extract_host(dest: &str) -> String {
+    let after_scheme = if let Some(pos) = dest.find("://") {
+        &dest[pos + 3..]
+    } else {
+        dest
+    };
+    let host_port = after_scheme.split('/').next().unwrap_or(after_scheme);
+    let host = if host_port.starts_with('[') {
+        host_port
+            .trim_start_matches('[')
+            .split(']')
+            .next()
+            .unwrap_or(host_port)
+    } else {
+        host_port.split(':').next().unwrap_or(host_port)
+    };
+    host.to_ascii_lowercase()
+}
+
+/// Apply a patch to [`PatchState`]. Command changes take effect immediately;
+/// filesystem paths are staged; network changes apply only when a live
+/// proxy allowlist is present.
+pub fn apply_policy_patch(state: &mut PatchState, patch: &PolicyPatch) -> PolicyPatchResponse {
+    let mut commands_status = PatchAxisStatus::Unchanged;
+    let mut fs_status = PatchAxisStatus::Unchanged;
+    let mut net_status = PatchAxisStatus::Unchanged;
+    let mut pending_restart = Vec::new();
+
+    let has_cmd_changes = !patch.add_allow_command.is_empty()
+        || !patch.remove_allow_command.is_empty()
+        || !patch.add_block_command.is_empty()
+        || !patch.remove_block_command.is_empty();
+
+    if has_cmd_changes {
+        for cmd in &patch.add_allow_command {
+            state.allow.insert(cmd.clone());
+        }
+        for cmd in &patch.remove_allow_command {
+            state.allow.remove(cmd);
+        }
+        for cmd in &patch.add_block_command {
+            state.blocked.insert(cmd.clone());
+        }
+        for cmd in &patch.remove_block_command {
+            state.blocked.remove(cmd);
+        }
+        commands_status = PatchAxisStatus::Applied;
+    }
+
+    let has_fs_changes =
+        !patch.add_read.is_empty() || !patch.add_write.is_empty() || !patch.add_allow.is_empty();
+
+    if has_fs_changes {
+        state.staged_read.extend(patch.add_read.iter().cloned());
+        state.staged_write.extend(patch.add_write.iter().cloned());
+        state.staged_allow.extend(patch.add_allow.iter().cloned());
+        fs_status = PatchAxisStatus::PendingRestart;
+        pending_restart.push("filesystem".to_string());
+    }
+
+    let has_net_changes = !patch.add_net_allow.is_empty() || !patch.remove_net_allow.is_empty();
+
+    if has_net_changes {
+        if state.has_live_proxy {
+            for dest in &patch.add_net_allow {
+                let host = extract_host(dest);
+                if !state.net_allow.contains(&host) {
+                    state.net_allow.push(host);
+                }
+            }
+            for dest in &patch.remove_net_allow {
+                let host = extract_host(dest);
+                state.net_allow.retain(|d| d != &host);
+            }
+            net_status = PatchAxisStatus::Applied;
+        } else {
+            net_status = PatchAxisStatus::Rejected;
+        }
+    }
+
+    let accepted = commands_status != PatchAxisStatus::Rejected
+        && fs_status != PatchAxisStatus::Rejected
+        && net_status != PatchAxisStatus::Rejected;
+
+    let message = if pending_restart.is_empty() {
+        "patch applied".to_string()
+    } else {
+        format!(
+            "patch accepted; staged axes ({}) require manual process restart",
+            pending_restart.join(", ")
+        )
+    };
+
+    PolicyPatchResponse {
+        accepted,
+        filesystem: fs_status,
+        commands: commands_status,
+        network: net_status,
+        message,
+        pending_restart,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,6 +357,49 @@ mod tests {
         let json = serde_json::to_string(&msg).expect("serialize");
         let back: ControlMessage = serde_json::from_str(&json).expect("deserialize");
         assert!(matches!(back, ControlMessage::QueryResources));
+    }
+
+    #[test]
+    fn extract_host_strips_scheme_port_and_path() {
+        assert_eq!(extract_host("httping.org"), "httping.org");
+        assert_eq!(extract_host("http://httping.org/"), "httping.org");
+        assert_eq!(extract_host("https://httping.org/ping?v=1"), "httping.org");
+        assert_eq!(extract_host("httping.org:80"), "httping.org");
+        assert_eq!(extract_host("192.0.2.1"), "192.0.2.1");
+        assert_eq!(extract_host("HTTPing.ORG"), "httping.org");
+        assert_eq!(extract_host("[::1]:443"), "::1");
+    }
+
+    #[test]
+    fn apply_policy_patch_stages_fs_and_rejects_net_without_proxy() {
+        let mut state = PatchState::default();
+        let patch = PolicyPatch {
+            add_allow_command: vec!["npm".to_string()],
+            add_read: vec!["/opt/tool".to_string()],
+            add_net_allow: vec!["https://example.com/".to_string()],
+            ..Default::default()
+        };
+        let result = apply_policy_patch(&mut state, &patch);
+        assert!(state.allow.contains("npm"));
+        assert_eq!(state.staged_read, vec!["/opt/tool".to_string()]);
+        assert!(result.pending_restart.contains(&"filesystem".to_string()));
+        assert_eq!(result.network, PatchAxisStatus::Rejected);
+        assert!(state.net_allow.is_empty());
+    }
+
+    #[test]
+    fn apply_policy_patch_normalizes_net_allow_with_proxy() {
+        let mut state = PatchState {
+            has_live_proxy: true,
+            ..Default::default()
+        };
+        let patch = PolicyPatch {
+            add_net_allow: vec!["https://Example.com:443/path".to_string()],
+            ..Default::default()
+        };
+        let result = apply_policy_patch(&mut state, &patch);
+        assert_eq!(result.network, PatchAxisStatus::Applied);
+        assert_eq!(state.net_allow, vec!["example.com".to_string()]);
     }
 
     #[test]

--- a/crates/shadictl/src/policy_watch.rs
+++ b/crates/shadictl/src/policy_watch.rs
@@ -16,7 +16,7 @@
 //! [`PatchAxisStatus::PendingRestart`].
 
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};

--- a/crates/shadictl/src/policy_watch.rs
+++ b/crates/shadictl/src/policy_watch.rs
@@ -35,8 +35,9 @@ use std::os::unix::net::UnixStream;
 use uds_windows::UnixListener;
 
 use shadi_sandbox::{
-    ControlMessage, ControlResponse, NetAllowlist, PatchAxisStatus, PolicyPatch,
-    PolicyPatchResponse, SandboxPolicy,
+    apply_policy_patch, read_control_line, ControlLine, ControlMessage, ControlResponse,
+    NetAllowlist, PatchAxisStatus, PatchState, PolicyPatch, PolicyPatchResponse, SandboxPolicy,
+    CONTROL_LINE_MAX_BYTES,
 };
 
 // The caller's half of this protocol lives in the library, so `shadictl`, the
@@ -83,39 +84,6 @@ impl Drop for ControlSocketHandle {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
     }
-}
-
-/// Strip a URL scheme and path from a net-allow entry, returning just the host.
-///
-/// Users may naturally write `http://httping.org/` but the proxy allowlist
-/// works on hostnames only.  This normalisation makes both equivalent:
-///
-/// ```
-/// // assert_eq!(extract_host("http://httping.org/ping"), "httping.org");
-/// // assert_eq!(extract_host("httping.org"),             "httping.org");
-/// // assert_eq!(extract_host("192.0.2.1"),               "192.0.2.1");  // RFC 5737 TEST-NET
-/// ```
-fn extract_host(dest: &str) -> String {
-    // Strip scheme (e.g. "http://", "https://").
-    let after_scheme = if let Some(pos) = dest.find("://") {
-        &dest[pos + 3..]
-    } else {
-        dest
-    };
-    // Strip trailing path / query / fragment — take up to the first '/'.
-    let host_port = after_scheme.split('/').next().unwrap_or(after_scheme);
-    // Strip port suffix (host:port) — only for non-IPv6 addresses.
-    let host = if host_port.starts_with('[') {
-        // IPv6 literal [::1]:port or [::1]
-        host_port
-            .trim_start_matches('[')
-            .split(']')
-            .next()
-            .unwrap_or(host_port)
-    } else {
-        host_port.split(':').next().unwrap_or(host_port)
-    };
-    host.to_ascii_lowercase()
 }
 
 // ---------------------------------------------------------------------------
@@ -251,9 +219,16 @@ fn handle_stream(stream: impl std::io::Read + std::io::Write, live: &Arc<Mutex<L
 
     loop {
         line_buf.clear();
-        match reader.read_line(&mut line_buf) {
-            Ok(0) => break, // EOF
-            Ok(_) => {}
+        match read_control_line(&mut reader, &mut line_buf) {
+            Ok(ControlLine::Eof) => break,
+            Ok(ControlLine::Line) => {}
+            Ok(ControlLine::TooLong) => {
+                let resp = ControlResponse::Error {
+                    message: format!("control line exceeds {CONTROL_LINE_MAX_BYTES} bytes"),
+                };
+                let _ = write_response(reader.get_mut(), &resp);
+                break;
+            }
             Err(_) => break,
         }
 
@@ -386,109 +361,41 @@ fn handle_patch(live: &Arc<Mutex<LivePolicy>>, patch: PolicyPatch) -> ControlRes
         }
     };
 
-    let mut commands_status = PatchAxisStatus::Unchanged;
-    let mut fs_status = PatchAxisStatus::Unchanged;
-    let mut net_status = PatchAxisStatus::Unchanged;
-    let mut pending_restart = Vec::new();
-
-    // --- Command allow/block (user-space, immediate) ---
-    let has_cmd_changes = !patch.add_allow_command.is_empty()
-        || !patch.remove_allow_command.is_empty()
-        || !patch.add_block_command.is_empty()
-        || !patch.remove_block_command.is_empty();
-
-    if has_cmd_changes {
-        for cmd in &patch.add_allow_command {
-            guard.allow.insert(cmd.clone());
-        }
-        for cmd in &patch.remove_allow_command {
-            guard.allow.remove(cmd);
-        }
-        for cmd in &patch.add_block_command {
-            guard.blocked.insert(cmd.clone());
-        }
-        for cmd in &patch.remove_block_command {
-            guard.blocked.remove(cmd);
-        }
-        commands_status = PatchAxisStatus::Applied;
-    }
-
-    // --- Filesystem paths (kernel, staged) ---
-    let has_fs_changes =
-        !patch.add_read.is_empty() || !patch.add_write.is_empty() || !patch.add_allow.is_empty();
-
-    if has_fs_changes {
-        guard.staged_read.extend(patch.add_read);
-        guard.staged_write.extend(patch.add_write);
-        guard.staged_allow.extend(patch.add_allow);
-        fs_status = PatchAxisStatus::PendingRestart;
-        pending_restart.push("filesystem".to_string());
-    }
-
-    // --- Network allow ---
-    // When a live proxy allowlist is present the change takes effect immediately
-    // (no restart needed).  Without the proxy the change is staged and requires a
-    // manual restart because the kernel sandbox cannot be updated in place.
-    let has_net_changes = !patch.add_net_allow.is_empty() || !patch.remove_net_allow.is_empty();
-
-    if has_net_changes {
-        let current = guard
+    let has_live_proxy = guard.live_net_allowlist.is_some();
+    let mut state = PatchState {
+        allow: std::mem::take(&mut guard.allow),
+        blocked: std::mem::take(&mut guard.blocked),
+        staged_read: std::mem::take(&mut guard.staged_read),
+        staged_write: std::mem::take(&mut guard.staged_write),
+        staged_allow: std::mem::take(&mut guard.staged_allow),
+        net_allow: guard
             .live_net_allowlist
             .as_ref()
             .map(|al| al.snapshot())
-            .unwrap_or_else(|| guard.policy.net_allow().to_vec());
+            .unwrap_or_else(|| guard.policy.net_allow().to_vec()),
+        has_live_proxy,
+    };
 
-        let mut next_allow = current;
-        for dest in &patch.add_net_allow {
-            let host = extract_host(dest);
-            if !next_allow.contains(&host) {
-                next_allow.push(host);
-            }
-        }
-        for dest in &patch.remove_net_allow {
-            let host = extract_host(dest);
-            next_allow.retain(|d| d != &host);
-        }
+    let result = apply_policy_patch(&mut state, &patch);
 
+    guard.allow = state.allow;
+    guard.blocked = state.blocked;
+    guard.staged_read = state.staged_read;
+    guard.staged_write = state.staged_write;
+    guard.staged_allow = state.staged_allow;
+
+    if result.network == PatchAxisStatus::Applied {
         if let Some(ref al) = guard.live_net_allowlist {
-            // Proxy is running: update the allowlist live — no restart needed.
-            al.update(next_allow.clone());
-            // Also keep the policy in sync so QueryPolicy reflects reality.
-            guard.policy = guard.policy.clone().with_network_destinations(next_allow);
-            net_status = PatchAxisStatus::Applied;
-        } else {
-            // No proxy: network patches cannot be applied live and MUST NOT
-            // trigger a child restart (that would break the running application).
-            // Reject the change so the caller knows it cannot take effect.
-            net_status = PatchAxisStatus::Rejected;
+            al.update(state.net_allow.clone());
+            guard.policy = guard.policy.clone().with_network_destinations(state.net_allow);
         }
     }
 
-    if !pending_restart.is_empty() {
+    if !result.pending_restart.is_empty() {
         guard.restart_requested.store(true, Ordering::SeqCst);
     }
 
-    let accepted = commands_status != PatchAxisStatus::Rejected
-        && fs_status != PatchAxisStatus::Rejected
-        && net_status != PatchAxisStatus::Rejected;
-
-    let message = if pending_restart.is_empty() {
-        "patch applied".to_string()
-    } else {
-        format!(
-            "patch accepted; staged axes ({}) require manual process restart",
-            pending_restart.join(", ")
-        )
-    };
-
-    ControlResponse::PatchResult(PolicyPatchResponse {
-        accepted,
-        filesystem: fs_status,
-        commands: commands_status,
-        network: net_status,
-        message,
-        pending_restart,
-    })
+    ControlResponse::PatchResult(result)
 }
 
 pub(crate) fn snapshot_live_policy(live: &Arc<Mutex<LivePolicy>>) -> Result<SandboxPolicy, String> {
@@ -539,38 +446,38 @@ mod tests {
 
     #[test]
     fn extract_host_handles_bare_hostname() {
-        assert_eq!(extract_host("httping.org"), "httping.org");
+        assert_eq!(shadi_sandbox::extract_host("httping.org"), "httping.org");
     }
 
     #[test]
     fn extract_host_strips_http_scheme() {
-        assert_eq!(extract_host("http://httping.org/"), "httping.org");
+        assert_eq!(shadi_sandbox::extract_host("http://httping.org/"), "httping.org");
     }
 
     #[test]
     fn extract_host_strips_https_scheme_and_path() {
-        assert_eq!(extract_host("https://httping.org/ping?v=1"), "httping.org");
+        assert_eq!(shadi_sandbox::extract_host("https://httping.org/ping?v=1"), "httping.org");
     }
 
     #[test]
     fn extract_host_strips_port() {
-        assert_eq!(extract_host("httping.org:80"), "httping.org");
+        assert_eq!(shadi_sandbox::extract_host("httping.org:80"), "httping.org");
     }
 
     #[test]
     fn extract_host_bare_ip() {
         // 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — reserved for documentation.
-        assert_eq!(extract_host("192.0.2.1"), "192.0.2.1");
+        assert_eq!(shadi_sandbox::extract_host("192.0.2.1"), "192.0.2.1");
     }
 
     #[test]
     fn extract_host_ip_with_scheme_and_path() {
-        assert_eq!(extract_host("http://192.0.2.1/"), "192.0.2.1");
+        assert_eq!(shadi_sandbox::extract_host("http://192.0.2.1/"), "192.0.2.1");
     }
 
     #[test]
     fn extract_host_lowercases() {
-        assert_eq!(extract_host("HTTPing.ORG"), "httping.org");
+        assert_eq!(shadi_sandbox::extract_host("HTTPing.ORG"), "httping.org");
     }
 
     fn wait_for_socket_ready_with_timeout(sock_path: &Path, timeout: std::time::Duration) {
@@ -1368,6 +1275,35 @@ mod tests {
         let mut line = String::new();
         BufReader::new(&stream).read_line(&mut line).expect("read response");
         assert!(!line.trim().is_empty(), "expected a response, got nothing");
+
+        drop(stream);
+        drop(handle);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn control_socket_rejects_an_oversize_line() {
+        use std::io::{BufRead, BufReader, Write};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock_path = dir.path().join("oversize.sock");
+        let handle = start_control_socket(&sock_path, test_live_policy()).expect("start socket");
+        wait_for_socket_ready(&sock_path);
+
+        let mut stream = std::os::unix::net::UnixStream::connect(&sock_path).expect("connect");
+        let mut line = vec![b'x'; CONTROL_LINE_MAX_BYTES + 8];
+        line.push(b'\n');
+        stream.write_all(&line).expect("write oversize");
+        stream.flush().expect("flush");
+
+        let mut response = String::new();
+        BufReader::new(&stream)
+            .read_line(&mut response)
+            .expect("read error");
+        assert!(
+            response.contains("exceeds"),
+            "expected an oversize error, got {response:?}"
+        );
 
         drop(stream);
         drop(handle);


### PR DESCRIPTION
Closes #244. First PR in the #243 stack.

## Summary
- Move `extract_host` and `apply_policy_patch` into `shadi_sandbox` so the control-socket apply path can be fuzzed without a Unix socket.
- Add the `policy-patch` cargo-fuzz target. It asserts `extract_host` never leaks a `://` scheme and that staged path lengths match the patch.
- Reject control-socket lines larger than 64 KiB (`CONTROL_LINE_MAX_BYTES`) on both the listener and the client.

## Test plan
- [x] `cargo test -p agntcy-shadi-sandbox`
- [x] `cargo test -p agntcy-shadi-cli --bin shadictl policy_watch`
- [ ] `cargo +nightly fuzz run policy-patch`