### PR TITLE
test(identity): fuzz DID-proof envelope unwrap

### DIFF
--- a/crates/shadi_identity/fuzz/Cargo.toml
+++ b/crates/shadi_identity/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "agntcy-shadi-identity-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.agntcy-shadi-identity]
+path = ".."
+
+[[bin]]
+name = "did-proof"
+path = "fuzz_targets/did-proof.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]

--- a/crates/shadi_identity/fuzz/README.md
+++ b/crates/shadi_identity/fuzz/README.md
@@ -1,0 +1,14 @@
+# Fuzz targets
+
+- **`did-proof`** — feeds arbitrary bytes to `looks_like_did_proof` and
+  `unwrap_signed_message`. Malformed envelopes must return an error.
+  Payloads above `DID_PROOF_PAYLOAD_MAX_BYTES` (1 MiB) and header lines
+  above `DID_PROOF_HEADER_MAX_BYTES` (1 KiB) are rejected.
+
+## Running
+
+```sh
+cargo install cargo-fuzz
+rustup toolchain install nightly
+cargo +nightly fuzz run did-proof
+```

--- a/crates/shadi_identity/fuzz/fuzz_targets/did-proof.rs
+++ b/crates/shadi_identity/fuzz/fuzz_targets/did-proof.rs
@@ -1,0 +1,39 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shadi_identity::{
+    looks_like_did_proof, unwrap_signed_message, DID_PROOF_HEADER_MAX_BYTES,
+    DID_PROOF_PAYLOAD_MAX_BYTES,
+};
+
+// A2A / SLIM peers can send arbitrary bytes. unwrap_signed_message must
+// reject malformed envelopes without panicking, and must refuse payloads
+// or headers above the documented caps.
+fuzz_target!(|data: &[u8]| {
+    let looks = looks_like_did_proof(data);
+    match unwrap_signed_message(data) {
+        Ok(verified) => {
+            assert!(looks, "verified envelope must start with DID-proof magic");
+            assert!(
+                verified.did.starts_with("did:key:"),
+                "verified DID leaked a non-did:key claim: {}",
+                verified.did
+            );
+            assert!(
+                verified.did.len() <= DID_PROOF_HEADER_MAX_BYTES,
+                "verified DID exceeded header cap"
+            );
+            assert!(
+                verified.payload.len() <= DID_PROOF_PAYLOAD_MAX_BYTES,
+                "verified payload exceeded cap: {}",
+                verified.payload.len()
+            );
+        }
+        Err(_) => {
+            let header_budget = 17 + 1 + DID_PROOF_HEADER_MAX_BYTES + 1 + DID_PROOF_HEADER_MAX_BYTES + 1;
+            if data.len() > header_budget + DID_PROOF_PAYLOAD_MAX_BYTES {
+                // Oversize input must not verify.
+            }
+        }
+    }
+});

--- a/crates/shadi_identity/src/did_proof.rs
+++ b/crates/shadi_identity/src/did_proof.rs
@@ -15,6 +15,12 @@ use ed25519_dalek::Signature;
 const MAGIC: &[u8] = b"SHADI-DID-PROOF/1";
 const DOMAIN: &[u8] = b"SHADI-DID-PROOF/1";
 
+/// Maximum inner payload accepted by [`wrap_signed_message`] / [`unwrap_signed_message`].
+pub const DID_PROOF_PAYLOAD_MAX_BYTES: usize = 1024 * 1024;
+
+/// Maximum DID or signature header line in a DID-proof envelope.
+pub const DID_PROOF_HEADER_MAX_BYTES: usize = 1024;
+
 /// Payload plus the `did:key` that signed it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedPayload {
@@ -32,6 +38,11 @@ pub fn wrap_signed_message(
     identity: &AgentIdentity,
     payload: &[u8],
 ) -> Result<Vec<u8>, IdentityError> {
+    if payload.len() > DID_PROOF_PAYLOAD_MAX_BYTES {
+        return Err(IdentityError::Proof(format!(
+            "DID-proof payload exceeds {DID_PROOF_PAYLOAD_MAX_BYTES} bytes"
+        )));
+    }
     let did = identity.did();
     let sig = identity.sign_bytes(&canonical(&did, payload));
     let sig_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sig);
@@ -134,6 +145,12 @@ fn split_envelope(bytes: &[u8]) -> Result<(String, String, &[u8]), IdentityError
     if magic != MAGIC {
         return Err(IdentityError::Proof("bad DID-proof magic".to_string()));
     }
+    if headers[1].len() > DID_PROOF_HEADER_MAX_BYTES || headers[2].len() > DID_PROOF_HEADER_MAX_BYTES
+    {
+        return Err(IdentityError::Proof(
+            "DID-proof header exceeds size limit".to_string(),
+        ));
+    }
     let did = std::str::from_utf8(headers[1])
         .map_err(|_| IdentityError::Proof("DID is not UTF-8".to_string()))?
         .to_string();
@@ -145,7 +162,13 @@ fn split_envelope(bytes: &[u8]) -> Result<(String, String, &[u8]), IdentityError
             "DID-proof envelope missing DID or signature".to_string(),
         ));
     }
-    Ok((did, sig, &bytes[start..]))
+    let payload = &bytes[start..];
+    if payload.len() > DID_PROOF_PAYLOAD_MAX_BYTES {
+        return Err(IdentityError::Proof(format!(
+            "DID-proof payload exceeds {DID_PROOF_PAYLOAD_MAX_BYTES} bytes"
+        )));
+    }
+    Ok((did, sig, payload))
 }
 
 #[cfg(test)]
@@ -226,6 +249,12 @@ mod tests {
         assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"", b"x")).is_err());
         assert!(unwrap_signed_message(&raw_envelope(b"did:key:\xff", b"c2ln", b"x")).is_err());
         assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"sig\xff", b"x")).is_err());
+        let huge_did = vec![b'a'; DID_PROOF_HEADER_MAX_BYTES + 1];
+        assert!(unwrap_signed_message(&raw_envelope(&huge_did, b"c2ln", b"x")).is_err());
+        let huge_payload = vec![b'x'; DID_PROOF_PAYLOAD_MAX_BYTES + 1];
+        assert!(unwrap_signed_message(&raw_envelope(b"did:key:zabc", b"c2ln", &huge_payload)).is_err());
+        let id = AgentIdentity::generate().unwrap();
+        assert!(wrap_signed_message(&id, &huge_payload).is_err());
     }
 
     #[test]

--- a/crates/shadi_identity/src/lib.rs
+++ b/crates/shadi_identity/src/lib.rs
@@ -25,7 +25,7 @@ pub mod ssh;
 pub use auth::{build_did_auth, create_app, did_auth_from_env, require_did_auth_from_env, SlimAuth};
 pub use did_proof::{
     looks_like_did_proof, sign_message_from_env, unwrap_signed_message, wrap_signed_message,
-    VerifiedPayload,
+    VerifiedPayload, DID_PROOF_HEADER_MAX_BYTES, DID_PROOF_PAYLOAD_MAX_BYTES,
 };
 
 /// Multicodec prefix for an Ed25519 public key (`0xed` varint-encoded).


### PR DESCRIPTION
## Summary
- Add a `did-proof` cargo-fuzz target over `looks_like_did_proof` and `unwrap_signed_message`.
- Reject payloads above 1 MiB and DID/signature header lines above 1 KiB so a peer cannot force unbounded allocation.
- Malformed envelopes return `IdentityError` rather than panic.

Closes #248.

## Test plan
- [x] `cargo test -p agntcy-shadi-identity --lib`
- [ ] `cargo +nightly fuzz run did-proof` in `crates/shadi_identity/fuzz`
- [ ] Existing admission / transport DID-proof tests still pass